### PR TITLE
v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ## [v1.14.0] - 2019-05-xx
 ### Added
 - New route /summary/resource-types.
+- New route /summary/resource-types/[resource-type]/resources
 
 ### Changed
 - Content updates, README, CHANGELOG and the landing page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.14.0] - 2019-05-xx
+### Changed
+- Content updates, README, CHANGELOG and the landing page.
+
 ## [v1.13.1] - 2019-04-23
 ### Changed
 - Content update, there are now multiple children.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,19 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
-## [v1.14.0] - 2019-05-xx
+## [v1.14.0] - 2019-04-30
 ### Added
 - New route /summary/resource-types.
-- New route /summary/resource-types/[resource-type]/resources
-- Sorting options added to /resource_types/[resource-type]/resources/[resource]/items collection.
+- New route /summary/resource-types/[resource-type]/resources.
+- Sorting options added to /resource-types/[resource-type]/resources/[resource]/items collection.
 
 ### Changed
-- Content updates, README, CHANGELOG and the landing page.
-- GET parameter changed to include-resources for resource-types route.
-- GET parameter changed to include-subcategories for categories routes
+- Content updates to the README, CHANGELOG and the landing page.
+- GET parameter changed to include-resources for the resource-types route.
+- GET parameter changed to include-subcategories for the categories routes.
+
+### Fixed
+- Item category and Item subcategory collections were not returning a collection.
 
 ## [v1.13.1] - 2019-04-23
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ## [v1.14.0] - 2019-05-xx
 ### Changed
 - Content updates, README, CHANGELOG and the landing page.
+- GET parameter changed to include-resources for resource-types route.
 
 ## [v1.13.1] - 2019-04-23
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ### Changed
 - Content updates, README, CHANGELOG and the landing page.
 - GET parameter changed to include-resources for resource-types route.
+- GET parameter changed to include-subcategories for categories routes
 
 ## [v1.13.1] - 2019-04-23
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ### Added
 - New route /summary/resource-types.
 - New route /summary/resource-types/[resource-type]/resources
+- Sorting options added to /resource_types/[resource-type]/resources/[resource]/items collection.
 
 ### Changed
 - Content updates, README, CHANGELOG and the landing page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
 ## [v1.14.0] - 2019-05-xx
+### Added
+- New route /summary/resource-types.
+
 ### Changed
 - Content updates, README, CHANGELOG and the landing page.
 - GET parameter changed to include-resources for resource-types route.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ which allows you to provide year, month, category and subcategory.
 | OPTIONS  | v1/summary/resource-types |
 | GET/HEAD | v1/summary/resource-types/{resource_type_id}/items |
 | OPTIONS  | v1/summary/resource-types/{resource_type_id}/items |
+| GET/HEAD | v1/summary/resource-types/{resource_type_id}/resources |
+| OPTIONS  | v1/summary/resource-types/{resource_type_id}/resources |
 | GET/HEAD | v1/summary/resource-types/{resource_type_id}/resources/{resource_id}/items |
 | OPTIONS  | v1/summary/resource-types/{resource_type_id}/resources/{resource_id}/items |
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ which allows you to provide year, month, category and subcategory.
 | :--- | :--- |
 | GET/HEAD | v1/summary/request/access-log/monthly |
 | OPTIONS  | v1/summary/request/access-log/monthly |
+| GET/HEAD | v1/summary/resource-types |
+| OPTIONS  | v1/summary/resource-types |
 | GET/HEAD | v1/summary/resource-types/{resource_type_id}/items |
 | OPTIONS  | v1/summary/resource-types/{resource_type_id}/items |
 | GET/HEAD | v1/summary/resource-types/{resource_type_id}/resources/{resource_id}/items |

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 What does it cost to raise a child in the UK?
 
-[Costs to Expect](https://www.costs-to-expect.com) is a long-term project, my wife and I are tracking the expenses to 
-raise our children to, adulthood, 18.
+[Costs to Expect](https://www.costs-to-expect.com) is a long-term personal project, my wife and I are tracking 
+the expenses to raise our children to, adulthood, 18.
 
 ### Why?
 

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -35,7 +35,7 @@ class CategoryController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        $this->collection_parameters = Get::parameters(['include_sub_categories']);
+        $this->collection_parameters = Get::parameters(['include-subcategories']);
 
         $categories = (new Category())->paginatedCollection($this->include_private, $this->collection_parameters);
 
@@ -67,7 +67,7 @@ class CategoryController extends Controller
     {
         Validate::categoryRoute($category_id);
 
-        $this->show_parameters = Get::parameters(['include_sub_categories']);
+        $this->show_parameters = Get::parameters(['include-subcategories']);
 
         $category = (new Category)->single($category_id);
 
@@ -93,7 +93,7 @@ class CategoryController extends Controller
      */
     public function optionsIndex(Request $request): JsonResponse
     {
-        $this->collection_parameters = Get::parameters(['include_sub_categories']);
+        $this->collection_parameters = Get::parameters(['include-subcategories']);
 
         return $this->generateOptionsForIndex(
             [

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -100,6 +100,7 @@ class CategoryController extends Controller
                 'description_localisation' => 'route-descriptions.category_GET_index',
                 'parameters_config' => 'api.category.parameters.collection',
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ],

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -113,6 +113,7 @@ class Controller extends BaseController
         ]
     ) {
         $get_parameters = [];
+        $get_parameters_sortable = [];
         $post_fields = [];
 
         if ($get['parameters_config'] !== null) {
@@ -128,10 +129,15 @@ class Controller extends BaseController
             }
         }
 
+        if ($get['sortable_config'] !== null) {
+            $get_parameters_sortable = Config::get($get['sortable_config']);
+        }
+
         $routes = [
             'GET' => [
                 'description' => trans($get['description_localisation']),
                 'authenticated' => $get['authenticated'],
+                'sortable' => $get_parameters_sortable,
                 'parameters' => $get_parameters
             ]
         ];

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -99,8 +99,9 @@ class Controller extends BaseController
     protected function generateOptionsForIndex(
         array $get = [
             'description_localisation' => '',
-            'parameters_config' => '',
+            'parameters_config' => null,
             'conditionals' => [],
+            'sortable_config' => null,
             'pagination' => true,
             'authenticated' => false
         ],
@@ -114,15 +115,17 @@ class Controller extends BaseController
         $get_parameters = [];
         $post_fields = [];
 
-        foreach (
-            array_merge_recursive(
-                ($get['pagination'] === true ? Config::get('api.pagination.parameters') : []),
-                Config::get($get['parameters_config']),
-                $get['conditionals']
-            ) as $parameter => $detail) {
-            $detail['title'] = trans($detail['title']);
-            $detail['description'] = trans($detail['description']);
-            $get_parameters[$parameter] = $detail;
+        if ($get['parameters_config'] !== null) {
+            foreach (
+                array_merge_recursive(
+                    ($get['pagination'] === true ? Config::get('api.pagination.parameters') : []),
+                    Config::get($get['parameters_config']),
+                    $get['conditionals']
+                ) as $parameter => $detail) {
+                $detail['title'] = trans($detail['title']);
+                $detail['description'] = trans($detail['description']);
+                $get_parameters[$parameter] = $detail;
+            }
         }
 
         $routes = [

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -51,7 +51,7 @@ class ItemCategoryController extends Controller
         ];
 
         return response()->json(
-            (new ItemCategoryTransformer($item_category))->toArray(),
+            [(new ItemCategoryTransformer($item_category))->toArray()],
             200,
             $headers
         );

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -123,6 +123,7 @@ class ItemCategoryController extends Controller
                 'description_localisation' => 'route-descriptions.item_category_GET_index',
                 'parameters_config' => 'api.item-category.parameters.collection',
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ],

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -137,7 +137,7 @@ class ItemController extends Controller
                 'description_localisation' => 'route-descriptions.item_GET_index',
                 'parameters_config' => 'api.item.parameters.collection',
                 'conditionals' => $this->get_parameters,
-                'sortable_config' => null,
+                'sortable_config' => 'api.item.sortable',
                 'pagination' => true,
                 'authenticated' => false
             ],

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -137,6 +137,7 @@ class ItemController extends Controller
                 'description_localisation' => 'route-descriptions.item_GET_index',
                 'parameters_config' => 'api.item.parameters.collection',
                 'conditionals' => $this->get_parameters,
+                'sortable_config' => null,
                 'pagination' => true,
                 'authenticated' => false
             ],

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -42,7 +42,7 @@ class ItemController extends Controller
     {
         Validate::resourceRoute($resource_type_id, $resource_id);
 
-        $this->collection_parameters = Get::parameters(['year', 'month', 'category', 'subcategory']);
+        $this->collection_parameters = Get::parameters(['year', 'month', 'category', 'subcategory', 'sort']);
 
         $total = (new Item())->totalCount(
             $resource_type_id,

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -114,7 +114,7 @@ class ItemSubCategoryController extends Controller
         ];
 
         return response()->json(
-            (new ItemSubCategoryTransformer($item_sub_category))->toArray(),
+            [(new ItemSubCategoryTransformer($item_sub_category))->toArray()],
             200,
             $headers
         );

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -155,6 +155,7 @@ class ItemSubCategoryController extends Controller
                 'description_localisation' => 'route-descriptions.item_sub_category_GET_index',
                 'parameters_config' => 'api.item-subcategory.parameters.collection',
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ],

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -108,6 +108,7 @@ class RequestController extends Controller
                 'description_localisation' => 'route-descriptions.request_GET_access-log',
                 'parameters_config' => [],
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => true,
                 'authenticated' => false
             ]
@@ -126,6 +127,7 @@ class RequestController extends Controller
                 'description_localisation' => 'route-descriptions.request_GET_error_log',
                 'parameters_config' => 'api.request.parameters.collection',
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ],

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -100,6 +100,7 @@ class ResourceController extends Controller
                 'description_localisation' => 'route-descriptions.resource_GET_index',
                 'parameters_config' => 'api.resource.parameters.collection',
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ],

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -97,6 +97,7 @@ class ResourceTypeController extends Controller
                 'description_localisation' => 'route-descriptions.resource_type_GET_index',
                 'parameters_config' => 'api.resource-type.parameters.collection',
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ],

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -36,7 +36,7 @@ class ResourceTypeController extends Controller
     {
         $resource_types = (new ResourceType())->paginatedCollection($this->include_private);
 
-        $this->collection_parameters = Get::parameters(['include_resources']);
+        $this->collection_parameters = Get::parameters(['include-resources']);
 
         $headers = [
             'X-Total-Count' => count($resource_types)
@@ -66,7 +66,7 @@ class ResourceTypeController extends Controller
     {
         Validate::resourceTypeRoute($resource_type_id);
 
-        $this->show_parameters = Get::parameters(['include_resources']);
+        $this->show_parameters = Get::parameters(['include-resources']);
 
         $resource_type = (new ResourceType())->single($resource_type_id, $this->include_private);
 

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -103,6 +103,7 @@ class ResourceTypeItemController extends Controller
                 'description_localisation' => 'route-descriptions.resource_type_item_GET_index',
                 'parameters_config' => 'api.resource-type-item.parameters.collection',
                 'conditionals' => $this->conditional_get_parameters,
+                'sortable_config' => null,
                 'pagination' => true,
                 'authenticated' => false
             ]

--- a/app/Http/Controllers/SubCategoryController.php
+++ b/app/Http/Controllers/SubCategoryController.php
@@ -103,6 +103,7 @@ class SubCategoryController extends Controller
                 'description_localisation' => 'route-descriptions.sub_category_GET_index',
                 'parameters_config' => 'api.subcategory.parameters.collection',
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ],

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -331,6 +331,7 @@ class SummaryItemController extends Controller
                 'description_localisation' => 'route-descriptions.summary_GET_resource-type_resource_items',
                 'parameters_config' => 'api.item.summary-parameters.collection',
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ]

--- a/app/Http/Controllers/SummaryRequestController.php
+++ b/app/Http/Controllers/SummaryRequestController.php
@@ -49,6 +49,7 @@ class SummaryRequestController extends Controller
                 'description_localisation' => 'route-descriptions.summary_GET_request_access-log_monthly',
                 'parameters_config' => [],
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ]

--- a/app/Http/Controllers/SummaryResourceController.php
+++ b/app/Http/Controllers/SummaryResourceController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Parameters\Route\Validate;
-use App\Models\ResourceType;
+use App\Models\Resource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -28,7 +28,7 @@ class SummaryResourceController extends Controller
     {
         Validate::resourceTypeRoute($resource_type_id);
 
-        $summary = (new ResourceType())->totalCount($this->include_private);
+        $summary = (new Resource())->totalCount($resource_type_id, $this->include_private);
 
         return response()->json(
             [

--- a/app/Http/Controllers/SummaryResourceController.php
+++ b/app/Http/Controllers/SummaryResourceController.php
@@ -57,6 +57,7 @@ class SummaryResourceController extends Controller
                 'description_localisation' => 'route-descriptions.summary-resource-GET-index',
                 'parameters_config' => 'api.resource.summary-parameters.collection',
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ]

--- a/app/Http/Controllers/SummaryResourceController.php
+++ b/app/Http/Controllers/SummaryResourceController.php
@@ -32,7 +32,7 @@ class SummaryResourceController extends Controller
 
         return response()->json(
             [
-                'resource-types' => $summary
+                'resources' => $summary
             ],
             200,
             ['X-Total-Count' => $summary]

--- a/app/Http/Controllers/SummaryResourceController.php
+++ b/app/Http/Controllers/SummaryResourceController.php
@@ -2,28 +2,32 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Parameters\Route\Validate;
 use App\Models\ResourceType;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 /**
- * Summary controller for the resource-type routes
+ * Summary controller for the resource routes
  *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class SummaryResourceTypeController extends Controller
+class SummaryResourceController extends Controller
 {
     /**
-     * Return a summary of the resource types
+     * Return a summary of the resources
      *
      * @param Request $request
+     * @param string $resource_type_id
      *
      * @return JsonResponse
      */
-    public function index(Request $request): JsonResponse
+    public function index(Request $request, string $resource_type_id): JsonResponse
     {
+        Validate::resourceTypeRoute($resource_type_id);
+
         $summary = (new ResourceType())->totalCount($this->include_private);
 
         return response()->json(
@@ -37,18 +41,21 @@ class SummaryResourceTypeController extends Controller
 
 
     /**
-     * Generate the OPTIONS request for the resource type summarys
+     * Generate the OPTIONS request for the resource summary
      *
      * @param Request $request
+     * @param string $resource_type_id
      *
      * @return JsonResponse
      */
-    public function optionsIndex(Request $request): JsonResponse
+    public function optionsIndex(Request $request, string $resource_type_id): JsonResponse
     {
+        Validate::resourceTypeRoute($resource_type_id);
+
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.summary-resource-type-GET-index',
-                'parameters_config' => 'api.resource-type.summary-parameters.collection',
+                'description_localisation' => 'route-descriptions.summary-resource-GET-index',
+                'parameters_config' => 'api.resource.summary-parameters.collection',
                 'conditionals' => [],
                 'pagination' => false,
                 'authenticated' => false

--- a/app/Http/Controllers/SummaryResourceTypeController.php
+++ b/app/Http/Controllers/SummaryResourceTypeController.php
@@ -50,6 +50,7 @@ class SummaryResourceTypeController extends Controller
                 'description_localisation' => 'route-descriptions.summary-resource-type-GET-index',
                 'parameters_config' => 'api.resource-type.summary-parameters.collection',
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ]

--- a/app/Http/Controllers/SummaryResourceTypeController.php
+++ b/app/Http/Controllers/SummaryResourceTypeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ResourceType;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -23,7 +24,15 @@ class SummaryResourceTypeController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
+        $summary = (new ResourceType())->totalCount($this->include_private);
 
+        return response()->json(
+            [
+                'resource-types' => $summary
+            ],
+            200,
+            ['X-Total-Count' => $summary]
+        );
     }
 
 

--- a/app/Http/Controllers/SummaryResourceTypeController.php
+++ b/app/Http/Controllers/SummaryResourceTypeController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Summary controller for the resource-type routes
+ *
+ * @author Dean Blackborough <dean@g3d-development.com>
+ * @copyright Dean Blackborough 2018-2019
+ * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
+ */
+class SummaryResourceTypeController extends Controller
+{
+    /**
+     * Return a summary of the resource types
+     *
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function index(Request $request): JsonResponse
+    {
+
+    }
+
+
+    /**
+     * Generate the OPTIONS request for summary of the access log
+     *
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function optionsIndex(Request $request): JsonResponse
+    {
+        return $this->generateOptionsForIndex(
+            [
+                'description_localisation' => 'route-descriptions.summary-resource-type-GET-index',
+                'parameters_config' => 'api.resource-type.summary-parameters.collection',
+                'conditionals' => [],
+                'pagination' => false,
+                'authenticated' => false
+            ]
+        );
+    }
+}

--- a/app/Http/Controllers/SummaryResourceTypeController.php
+++ b/app/Http/Controllers/SummaryResourceTypeController.php
@@ -28,7 +28,7 @@ class SummaryResourceTypeController extends Controller
 
         return response()->json(
             [
-                'resource-types' => $summary
+                'resource_types' => $summary
             ],
             200,
             ['X-Total-Count' => $summary]

--- a/app/Http/Controllers/SummaryResourceTypeItemController.php
+++ b/app/Http/Controllers/SummaryResourceTypeItemController.php
@@ -358,6 +358,7 @@ class SummaryResourceTypeItemController extends Controller
                 'description_localisation' => 'route-descriptions.summary-resource-type-item-GET-index',
                 'parameters_config' => 'api.resource-type-item.summary-parameters.collection',
                 'conditionals' => [],
+                'sortable_config' => null,
                 'pagination' => false,
                 'authenticated' => false
             ]

--- a/app/Http/Parameters/Get.php
+++ b/app/Http/Parameters/Get.php
@@ -37,7 +37,7 @@ class Get
 
                 switch ($parameter) {
                     case 'include-resources';
-                    case 'include_sub_categories';
+                    case 'include-subcategories';
                         self::$parameters[$parameter] = General::booleanValue($request_parameters[$parameter]);
                         break;
 
@@ -67,8 +67,7 @@ class Get
                     break;
 
                 case 'include-categories':
-                case 'include_subcategories':
-                case 'include_sub_categories':
+                case 'include-subcategories':
                 case 'include-resources':
                     if (array_key_exists($key, self::$parameters) === true) {
                         if (General::booleanValue(self::$parameters[$key]) === false) {

--- a/app/Http/Parameters/Get.php
+++ b/app/Http/Parameters/Get.php
@@ -36,7 +36,7 @@ class Get
                 $request_parameters[$parameter] !== 'nill') {
 
                 switch ($parameter) {
-                    case 'include_resources';
+                    case 'include-resources';
                     case 'include_sub_categories';
                         self::$parameters[$parameter] = General::booleanValue($request_parameters[$parameter]);
                         break;
@@ -69,7 +69,7 @@ class Get
                 case 'include-categories':
                 case 'include_subcategories':
                 case 'include_sub_categories':
-                case 'include_resources':
+                case 'include-resources':
                     if (array_key_exists($key, self::$parameters) === true) {
                         if (General::booleanValue(self::$parameters[$key]) === false) {
                             unset(self::$parameters[$key]);

--- a/app/Http/Parameters/Get.php
+++ b/app/Http/Parameters/Get.php
@@ -147,6 +147,14 @@ class Get
                     }
                     break;
 
+                case 'sort':
+                    if (array_key_exists($key, self::$parameters) === true) {
+                        if (strlen(self::$parameters[$key]) < 1) {
+                            unset(self::$parameters[$key]);
+                        }
+                    }
+                    break;
+
                 case 'year':
                     if (array_key_exists($key, self::$parameters) === true) {
                         if (intval(self::$parameters[$key]) < 2013 ||

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -18,6 +18,27 @@ class Resource extends Model
 
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
+    /**
+     * Return the total number of resources
+     *
+     * @param integer $resource_type_id
+     * @param boolean $include_private Include resources attached to private resource types
+     *
+     * @return integer
+     */
+    public function totalCount(int $resource_type_id, bool $include_private = false): int
+    {
+        $collection = $this->select("resource.id")->
+            join('resource_type', 'resource.resource_type_id', 'resource_type.id')->
+            where('resource_type.id', '=', $resource_type_id);
+
+        if ($include_private === false) {
+            $collection->where('resource_type.private', '=', 0);
+        }
+
+        return count($collection->get());
+    }
+
     public function items()
     {
         return $this->hasMany(Item::class, 'resource_id', 'id');

--- a/app/Models/ResourceType.php
+++ b/app/Models/ResourceType.php
@@ -21,6 +21,23 @@ class ResourceType extends Model
 
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
+    /**
+     * Return the total number of resource types
+     *
+     * @param boolean $include_private Include private resource types
+     *
+     * @return integer
+     */
+    public function totalCount(bool $include_private = false): int
+    {
+        $collection = $this->select("resource_type.id");
+        if ($include_private === false) {
+            $collection->where('resource_type.private', '=', 0);
+        }
+
+        return count($collection->get());
+    }
+
     public function resources()
     {
         return $this->hasMany(Resource::class, 'resource_type_id', 'id');

--- a/app/Models/Transformers/Category.php
+++ b/app/Models/Transformers/Category.php
@@ -45,12 +45,12 @@ class Category extends Transformer
                 'id' => $this->hash->resourceType()->encode($this->category->resource_type_id),
                 'name' => $this->category->resource_type_name,
             ],
-            'sub_categories_count' => $this->category->category_sub_categories
+            'subcategories_count' => $this->category->category_sub_categories
         ];
 
         if (
-            isset($this->parameters['include_sub_categories']) &&
-            $this->parameters['include_sub_categories'] === true
+            isset($this->parameters['include-subcategories']) &&
+            $this->parameters['include-subcategories'] === true
         ) {
             $subCategoriesCollection = (new SubCategoryModel())->paginatedCollection(
                 $this->category->category_id
@@ -62,7 +62,7 @@ class Category extends Transformer
                 }
             );
 
-            $result['sub_categories'] = $this->sub_categories;
+            $result['subcategories'] = $this->sub_categories;
         }
 
         return $result;

--- a/app/Models/Transformers/ResourceType.php
+++ b/app/Models/Transformers/ResourceType.php
@@ -47,10 +47,10 @@ class ResourceType extends Transformer
             'description' => $this->resource_type->description,
             'created' => $this->resource_type->created_at->toDateTimeString(),
             'public' => !boolval($this->resource_type->private),
-            'resources_count' => $this->resource_type->resources_count()
+            'resources-count' => $this->resource_type->resources_count()
         ];
 
-        if (isset($this->parameters['include_resources']) && $this->parameters['include_resources'] === true) {
+        if (isset($this->parameters['include-resources']) && $this->parameters['include-resources'] === true) {
             $resourcesCollection = $this->resource_type->resources;
 
             $resourcesCollection->map(

--- a/config/api/category/parameters.php
+++ b/config/api/category/parameters.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 return [
     'collection' => [
-        'include_sub_categories' => [
-            'field' => 'include_sub_categories',
-            'title' => 'category/parameters.title-include_sub_categories',
-            'description' => 'category/parameters.description-include_sub_categories',
+        'include-subcategories' => [
+            'field' => 'include-subcategories',
+            'title' => 'category/parameters.title-include-subcategories',
+            'description' => 'category/parameters.description-include-subcategories',
             'type' => 'boolean',
             'required' => false
         ]
     ],
     'item' => [
-        'include_sub_categories' => [
-            'field' => 'include_sub_categories',
-            'title' => 'category/parameters.title-include_sub_categories',
-            'description' => 'category/parameters.description-include_sub_categories',
+        'include-subcategories' => [
+            'field' => 'include-subcategories',
+            'title' => 'category/parameters.title-include-subcategories',
+            'description' => 'category/parameters.description-include-subcategories',
             'type' => 'boolean',
             'required' => false
         ]

--- a/config/api/item/parameters.php
+++ b/config/api/item/parameters.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 return [
     'collection' => [
+        'sort' => [
+            "parameter" => "sort",
+            "title" => 'sortable.title',
+            "description" => 'sortable.description',
+            "default" => null,
+            "type" => "string",
+            "required" => false
+        ],
         'year' => [
             "parameter" => "year",
             "title" => 'item/parameters.title-year',

--- a/config/api/item/sortable.php
+++ b/config/api/item/sortable.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'description' => [
+        'field' => 'description',
+        'description' => 'sortable.asc-desc'
+    ],
+    'total' => [
+        'field' => 'total',
+        'description' => 'sortable.asc-desc'
+    ],
+    'actualised_total' => [
+        'field' => 'actualised_total',
+        'description' => 'sortable.asc-desc'
+    ],
+    'effective_date' => [
+        'field' => 'effective_date',
+        'description' => 'sortable.asc-desc'
+    ],
+    'created' => [
+        'field' => 'created',
+        'description' => 'sortable.asc-desc'
+    ]
+];

--- a/config/api/item/sortable.php
+++ b/config/api/item/sortable.php
@@ -3,24 +3,9 @@
 declare(strict_types=1);
 
 return [
-    'description' => [
-        'field' => 'description',
-        'description' => 'sortable.asc-desc'
-    ],
-    'total' => [
-        'field' => 'total',
-        'description' => 'sortable.asc-desc'
-    ],
-    'actualised_total' => [
-        'field' => 'actualised_total',
-        'description' => 'sortable.asc-desc'
-    ],
-    'effective_date' => [
-        'field' => 'effective_date',
-        'description' => 'sortable.asc-desc'
-    ],
-    'created' => [
-        'field' => 'created',
-        'description' => 'sortable.asc-desc'
-    ]
+    'description',
+    'total',
+    'actualised_total',
+    'effective_date',
+    'created'
 ];

--- a/config/api/resource-type/parameters.php
+++ b/config/api/resource-type/parameters.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return [
     'collection' => [
-        'include_resources' => [
+        'include-resources' => [
             'field' => 'include-resources',
             'title' => 'resource-type/parameters.title-include-resources',
             'description' => 'resource-type/parameters.description-include-resources',
@@ -13,7 +13,7 @@ return [
         ]
     ],
     'item' => [
-        'include_resources' => [
+        'include-resources' => [
             'field' => 'include-resources',
             'title' => 'resource-type/parameters.title-include-resources',
             'description' => 'resource-type/parameters.description-include-resources',

--- a/config/api/resource-type/parameters.php
+++ b/config/api/resource-type/parameters.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 return [
     'collection' => [
         'include_resources' => [
-            'field' => 'include_resources',
-            'title' => 'resource-type/parameters.title-include_resources',
-            'description' => 'resource-type/parameters.description-include_resources',
+            'field' => 'include-resources',
+            'title' => 'resource-type/parameters.title-include-resources',
+            'description' => 'resource-type/parameters.description-include-resources',
             'type' => 'boolean',
             'required' => false
         ]
     ],
     'item' => [
         'include_resources' => [
-            'field' => 'include_resources',
-            'title' => 'resource-type/parameters.title-include_resources',
-            'description' => 'resource-type/parameters.description-include_resources',
+            'field' => 'include-resources',
+            'title' => 'resource-type/parameters.title-include-resources',
+            'description' => 'resource-type/parameters.description-include-resources',
             'type' => 'boolean',
             'required' => false
         ]

--- a/config/api/resource-type/summary-parameters.php
+++ b/config/api/resource-type/summary-parameters.php
@@ -3,14 +3,6 @@
 declare(strict_types=1);
 
 return [
-    'collection' => [
-        'include_resources' => [
-            'field' => 'include-resources',
-            'title' => 'resource-type/parameters.title-include-resources',
-            'description' => 'resource-type/parameters.description-include-resources',
-            'type' => 'boolean',
-            'required' => false
-        ]
-    ],
+    'collection' => [],
     'item' => []
 ];

--- a/config/api/resource-type/summary-parameters.php
+++ b/config/api/resource-type/summary-parameters.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'collection' => [
+        'include_resources' => [
+            'field' => 'include-resources',
+            'title' => 'resource-type/parameters.title-include-resources',
+            'description' => 'resource-type/parameters.description-include-resources',
+            'type' => 'boolean',
+            'required' => false
+        ]
+    ],
+    'item' => []
+];

--- a/config/api/resource/summary-parameters.php
+++ b/config/api/resource/summary-parameters.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'collection' => [],
+    'item' => []
+];

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'version'=> '1.13.1',
+    'version'=> '1.14.0',
     'prefix' => 'v1',
     'release_date' => '2019-04-23',
     'changelog' => [

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -3,7 +3,7 @@
 return [
     'version'=> '1.14.0',
     'prefix' => 'v1',
-    'release_date' => '2019-04-23',
+    'release_date' => '2019-04-30',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/resources/lang/en/category/parameters.php
+++ b/resources/lang/en/category/parameters.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 return [
-    'title-include_sub_categories' => 'Include subcategories?',
-    'description-include_sub_categories' => 'Optionally include the subcategories for each category'
+    'title-include-subcategories' => 'Include subcategories?',
+    'description-include-subcategories' => 'Optionally include the subcategories for each category'
 ];

--- a/resources/lang/en/resource-type/parameters.php
+++ b/resources/lang/en/resource-type/parameters.php
@@ -3,6 +3,6 @@
 declare(strict_types=1);
 
 return [
-    'title-include_resources' => 'Include resources?',
-    'description-include_resources' => 'Optionally include the resources for each resource type'
+    'title-include-resources' => 'Include resources?',
+    'description-include-resources' => 'Optionally include the resources for each resource type'
 ];

--- a/resources/lang/en/route-descriptions.php
+++ b/resources/lang/en/route-descriptions.php
@@ -56,6 +56,8 @@ return [
 
     'summary_GET_request_access-log_monthly' => 'Return a summary of the access log, read requests, grouped by month',
 
+    'summary-resource-type-GET-index' => 'Return a summary of the resource types',
+
     'summary_GET_resource-type_resource_items' => 'Return the TCO (Total cost of ownership, sum of items) for the selected resource',
 
     'summary-resource-type-item-GET-index' => 'Return a summary of the items for all the resources matching this resource type',

--- a/resources/lang/en/route-descriptions.php
+++ b/resources/lang/en/route-descriptions.php
@@ -57,6 +57,7 @@ return [
     'summary_GET_request_access-log_monthly' => 'Return a summary of the access log, read requests, grouped by month',
 
     'summary-resource-type-GET-index' => 'Return a summary of the resource types',
+    'summary-resource-GET-index' => 'Return a summary of the resources',
 
     'summary_GET_resource-type_resource_items' => 'Return the TCO (Total cost of ownership, sum of items) for the selected resource',
 

--- a/resources/lang/en/sortable.php
+++ b/resources/lang/en/sortable.php
@@ -3,5 +3,6 @@
 declare(strict_types=1);
 
 return [
-    'asc-desc' => 'Field is sortable in ascending and descending order'
+    'title' => 'Sorting options',
+    'description' => 'Sortable fields are all sortable in ascending and descending order, example sort=field1:asc|field2:desc'
 ];

--- a/resources/lang/en/sortable.php
+++ b/resources/lang/en/sortable.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'asc-desc' => 'Field is sortable in ascending and descending order'
+];

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -33,8 +33,8 @@
             <div class="inner">
                 <h3 class="masthead-brand">Costs to Expect</h3>
                 <nav class="nav nav-masthead justify-content-center">
-                    <a class="nav-link" href="https://www.costs-to-expect.com">Website</a>
-                    <a class="nav-link" href="/v1">API</a>
+                    <a class="nav-link" href="https://www.costs-to-expect.com">The Website</a>
+                    <a class="nav-link" href="/v1">The API</a>
                     <a class="nav-link" href="/v1/changelog">API changelog</a>
                 </nav>
             </div>
@@ -44,7 +44,7 @@
 
         <footer class="mastfoot mt-auto">
             <div class="inner">
-                <p>Copyright &copy; <a href="https://www.deanblackborough.com">Dean Blackborough</a> {{ date('Y') }}</p>
+                <p>Copyright &copy; <a href="https://www.deanblackborough.com">Dean Blackborough</a> 2018-{{ date('Y') }}</p>
                 <p>All code maintained by <a href="https://www.deanblackborough.com">Dean Blackborough</a> and licensed under MIT.</p>
             </div>
         </footer>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -4,23 +4,24 @@
 
     <main role="main" class="inner cover">
         <h1 class="cover-heading">Costs to Expect API</h1>
-        <p class="lead"><a href="https://www.costs-to-expect.com">Costs to Expect</a>
-            is a long-term project, my wife and I
-            are tracking the expenses to raise our child to adulthood, 18.</p>
+        <p class="lead">This <a href="https://github.com/costs-to-expect/api/blob/master/LICENSE">Open Source</a>
+            API is the <a href="https://github.com/costs-to-expect/api">API</a> for the for the
+            <a href="https://www.costs-to-expect.com">Costs to Expect</a> service,
+            a small part of the service is a long-term personal project, my wife
+            and I are tracking the expenses to raise our two children to
+            adulthood, 18.</p>
         <p class="lead">
-            <a href="/v1" class="btn btn-lg btn-primary mb-1">The API</a>
-            <a href="https://www.costs-to-expect.com" class="btn btn-lg btn-primary mb-1">Website</a>
+            <a href="/v1" class="btn btn-lg btn-primary mb-1">The API</a>&nbsp;
+            <a href="https://www.costs-to-expect.com" class="btn btn-lg btn-primary mb-1">The Website</a>
         </p>
         <p class="lead">
-            <a href="https://github.com/costs-to-expect" class="btn btn-lg btn-primary">View on GitHub</a>
+            <a href="https://github.com/costs-to-expect" class="btn btn-lg btn-primary">GitHub</a>
         </p>
 
         <p><small>Latest release: {{ $version }} ({{ $date }})</small></p>
 
-        <p class="mt-4">This Laravel app is the RESTful API for the
-            <a href="https://www.costs-to-expect.com">Costs to Expect</a> service,
-            the API will be used by the <a href="https://www.costs-to-expect.com">Costs to Expect</a> website
-            and companion iOS app which I'm creating to assist my wife with data input.
+        <p class="mt-4">This Laravel app is a RESTful API and is part of the
+            <a href="https://www.costs-to-expect.com">Costs to Expect</a> service.
         </p>
     </main>
 

--- a/routes/api/public-summary-routes.php
+++ b/routes/api/public-summary-routes.php
@@ -13,6 +13,11 @@ Route::group(
         ]
     ],
     function () {
+        Route::get(
+            'summary/resource-types',
+            'SummaryResourceTypeController@index'
+        );
+
         Route::options(
             'summary/resource-types',
             'SummaryResourceTypeController@optionsIndex'

--- a/routes/api/public-summary-routes.php
+++ b/routes/api/public-summary-routes.php
@@ -24,6 +24,16 @@ Route::group(
         );
 
         Route::get(
+            'summary/resource-types/{resource_type_id}/resources',
+            'SummaryResourceController@index'
+        );
+
+        Route::options(
+            'summary/resource-types/{resource_type_id}/resources',
+            'SummaryResourceController@optionsIndex'
+        );
+
+        Route::get(
             'summary/resource-types/{resource_type_id}/items',
             'SummaryResourceTypeItemController@index'
         );

--- a/routes/api/public-summary-routes.php
+++ b/routes/api/public-summary-routes.php
@@ -13,6 +13,11 @@ Route::group(
         ]
     ],
     function () {
+        Route::options(
+            'summary/resource-types',
+            'SummaryResourceTypeController@optionsIndex'
+        );
+
         Route::get(
             'summary/resource-types/{resource_type_id}/items',
             'SummaryResourceTypeItemController@index'
@@ -22,7 +27,6 @@ Route::group(
             'summary/resource-types/{resource_type_id}/items',
             'SummaryResourceTypeItemController@optionsIndex'
         );
-
 
         Route::get(
             'summary/resource-types/{resource_type_id}/resources/{resource_id}/items',


### PR DESCRIPTION
### Added
- New route /summary/resource-types.
- New route /summary/resource-types/[resource-type]/resources
- Sorting options added to /resource-types/[resource-type]/resources/[resource]/items collection.

### Changed
- Content updates to the README, CHANGELOG and the landing page.
- GET parameter changed to include-resources for the resource-types route.
- GET parameter changed to include-subcategories for the categories routes.

### Fixed
- Item category and Item subcategory collections were not returning a collection.