### PR TITLE
v1.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ## [v1.14.2] - 2019-06-xx
 ### Added 
 - Offset and Limit X headers added to collections.
+- If X-Source exists in request header it is saved with the request so we can start tracking sources.
 
 ## [v1.14.1] - 2019-05-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ### Added 
 - Offset and Limit X headers added to collections.
 - If X-Source exists in request header it is saved with the request so we can start tracking sources.
+- Capture the id of the user that created an item.
 
 ## [v1.14.1] - 2019-05-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.14.2] - 2019-06-xx
+### Added 
+- Offset and Limit X headers added to collections.
+
 ## [v1.14.1] - 2019-05-01
 ### Fixed
 - Item subcategory collection and single item returning incorrect results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
-## [v1.14.2] - 2019-06-xx
+## [v1.14.2] - 2019-05-31
 ### Added 
 - Offset and Limit X headers added to collections.
 - If X-Source exists in request header it is saved with the request so we can start tracking sources.
 - Capture the id of the user that created an item.
 - `source` filter added to /request/access-log.
+- `source` filter added to /summary/request/access-log/monthly.
 
 ## Changed
 - Upgraded `RequestLog` Transformer, switching to a new system.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - Offset and Limit X headers added to collections.
 - If X-Source exists in request header it is saved with the request so we can start tracking sources.
 - Capture the id of the user that created an item.
+- `source` filter added to /request/access-log.
+
+## Changed
+- Upgraded `RequestLog` Transformer, switching to a new system.
 
 ## [v1.14.1] - 2019-05-01
 ### Fixed

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -15,6 +15,7 @@ use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * Manage items
@@ -223,6 +224,7 @@ class ItemController extends Controller
                 'effective_date' => $request->input('effective_date'),
                 'total' => $request->input('total'),
                 'percentage' => $request->input('percentage', 100),
+                'user_id' => Auth::user()->id
             ]);
             $item->setActualisedTotal($item->total, $item->percentage);
             $item->save();

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -65,6 +65,8 @@ class ItemController extends Controller
         $headers = [
             'X-Count' => count($items),
             'X-Total-Count' => $total,
+            'X-Offset' => $pagination['offset'],
+            'X-Limit' => $pagination['limit'],
             'X-Link-Previous' => $pagination['links']['previous'],
             'X-Link-Next' => $pagination['links']['next']
         ];

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -110,7 +110,7 @@ class RequestController extends Controller
         return $this->generateOptionsForIndex(
             [
                 'description_localisation' => 'route-descriptions.request_GET_access-log',
-                'parameters_config' => [],
+                'parameters_config' => 'api.request.parameters.collection',
                 'conditionals' => [],
                 'sortable_config' => null,
                 'pagination' => true,
@@ -129,7 +129,7 @@ class RequestController extends Controller
         return $this->generateOptionsForIndex(
             [
                 'description_localisation' => 'route-descriptions.request_GET_error_log',
-                'parameters_config' => 'api.request.parameters.collection',
+                'parameters_config' => [],
                 'conditionals' => [],
                 'sortable_config' => null,
                 'pagination' => false,

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -77,14 +77,13 @@ class RequestController extends Controller
 
         $this->collection_parameters = Get::parameters(['source']);
 
-        print_r($this->collection_parameters);
-
         $pagination = UtilityPagination::init($request->path(), $total, 50)
             ->paging();
 
         $log = (new RequestLog())->paginatedCollection(
             $pagination['offset'],
-            $pagination['limit']
+            $pagination['limit'],
+            $this->collection_parameters
         );
 
         $headers = [
@@ -96,11 +95,11 @@ class RequestController extends Controller
         ];
 
         return response()->json(
-            $log->map(
-                function ($log_item)
-                {
-                    return (new RequestLogTransformer($log_item))->toArray();
-                }
+            array_map(
+                function ($access_log_entry) {
+                    return (new RequestLogTransformer($access_log_entry))->toArray();
+                },
+                $log
             ),
             200,
             $headers

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -43,6 +43,8 @@ class RequestController extends Controller
 
         $headers = [
             'X-Total-Count' => $total,
+            'X-Offset' => $pagination['offset'],
+            'X-Limit' => $pagination['limit'],
             'X-Link-Previous' => $pagination['links']['previous'],
             'X-Link-Next' => $pagination['links']['next'],
         ];
@@ -80,6 +82,8 @@ class RequestController extends Controller
 
         $headers = [
             'X-Total-Count' => $total,
+            'X-Offset' => $pagination['offset'],
+            'X-Limit' => $pagination['limit'],
             'X-Link-Previous' => $pagination['links']['previous'],
             'X-Link-Next' => $pagination['links']['next'],
         ];

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Parameters\Get;
 use App\Models\RequestErrorLog;
 use App\Models\RequestLog;
 use App\Models\Transformers\RequestErrorLog as RequestErrorLogTransformer;
@@ -22,6 +23,8 @@ use Illuminate\Http\Request;
  */
 class RequestController extends Controller
 {
+    protected $collection_parameters = [];
+
     /**
      * Return the paginated request log
      *
@@ -71,6 +74,10 @@ class RequestController extends Controller
     public function accessLog(Request $request): JsonResponse
     {
         $total = (new RequestLog())->totalCount();
+
+        $this->collection_parameters = Get::parameters(['source']);
+
+        print_r($this->collection_parameters);
 
         $pagination = UtilityPagination::init($request->path(), $total, 50)
             ->paging();

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -63,6 +63,8 @@ class ResourceTypeItemController extends Controller
         $headers = [
             'X-Count' => count($items),
             'X-Total-Count' => $total,
+            'X-Offset' => $pagination['offset'],
+            'X-Limit' => $pagination['limit'],
             'X-Link-Previous' => $pagination['links']['previous'],
             'X-Link-Next' => $pagination['links']['next']
         ];

--- a/app/Http/Controllers/SummaryRequestController.php
+++ b/app/Http/Controllers/SummaryRequestController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Parameters\Get;
 use App\Models\RequestLog;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -15,6 +16,8 @@ use Illuminate\Http\Request;
  */
 class SummaryRequestController extends Controller
 {
+    private $collection_parameters;
+
     /**
      * Return a summary of the access log, monthly
      *
@@ -24,7 +27,9 @@ class SummaryRequestController extends Controller
      */
     public function monthlyAccessLog(Request $request): JsonResponse
     {
-        $monthly_summary = (new RequestLog())->monthlyRequests();
+        $this->collection_parameters = Get::parameters(['source']);
+
+        $monthly_summary = (new RequestLog())->monthlyRequests($this->collection_parameters);
 
         $summary = [];
         foreach ($monthly_summary as $month) {

--- a/app/Http/Controllers/SummaryRequestController.php
+++ b/app/Http/Controllers/SummaryRequestController.php
@@ -47,7 +47,7 @@ class SummaryRequestController extends Controller
         return $this->generateOptionsForIndex(
             [
                 'description_localisation' => 'route-descriptions.summary_GET_request_access-log_monthly',
-                'parameters_config' => [],
+                'parameters_config' => 'api.request.parameters.collection',
                 'conditionals' => [],
                 'sortable_config' => null,
                 'pagination' => false,

--- a/app/Http/Middleware/LogRequests.php
+++ b/app/Http/Middleware/LogRequests.php
@@ -37,7 +37,8 @@ class LogRequests
         try {
             $log = new RequestLog([
                 'method' => $request->method(),
-                'request' => $request->fullUrl()
+                'request' => $request->fullUrl(),
+                'source' => $request->header('X-Source', 'api')
             ]);
             $log->save();
         } catch (Exception $e) {

--- a/app/Http/Parameters/Get.php
+++ b/app/Http/Parameters/Get.php
@@ -172,6 +172,17 @@ class Get
                     }
                     break;
 
+                case 'source':
+                    if (array_key_exists($key, self::$parameters) === true) {
+                        if (
+                            is_string(self::$parameters[$key]) === false ||
+                            in_array(self::$parameters[$key], ['api', 'legacy', 'website']) === false
+                        ) {
+                            unset(self::$parameters[$key]);
+                        }
+                    }
+                    break;
+
                 default:
                     // Do nothing
                     break;

--- a/app/Models/RequestLog.php
+++ b/app/Models/RequestLog.php
@@ -49,17 +49,27 @@ class RequestLog extends Model
             toArray();
     }
 
-    public function monthlyRequests()
+    /**
+     * @param array $collection_parameters
+     *
+     * @return array
+     */
+    public function monthlyRequests(array $collection_parameters = [])
     {
         $collection = $this->orderBy(DB::raw("DATE_FORMAT(`request_log`.`created_at`, '%Y-%m')"))
-            ->groupBy(DB::raw("DATE_FORMAT(`request_log`.`created_at`, '%Y-%m')"))
-            ->select(
-                DB::raw("DATE_FORMAT(`request_log`.`created_at`, '%Y-%m')"),
-                DB::raw("COUNT(`request_log`.`id`) AS `requests`"),
-                DB::raw("ANY_VALUE(DATE_FORMAT(`request_log`.`created_at`, '%Y')) AS `year`"),
-                DB::raw("ANY_VALUE(DATE_FORMAT(`request_log`.`created_at`, '%M')) AS `month`")
-            );
+            ->groupBy(DB::raw("DATE_FORMAT(`request_log`.`created_at`, '%Y-%m')"));
 
-        return $collection->get();
+        if (array_key_exists('source', $collection_parameters) === true) {
+            $collection->where("source", '=', $collection_parameters['source']);
+        }
+
+        $collection->select(
+            DB::raw("DATE_FORMAT(`request_log`.`created_at`, '%Y-%m')"),
+            DB::raw("COUNT(`request_log`.`id`) AS `requests`"),
+            DB::raw("ANY_VALUE(DATE_FORMAT(`request_log`.`created_at`, '%Y')) AS `year`"),
+            DB::raw("ANY_VALUE(DATE_FORMAT(`request_log`.`created_at`, '%M')) AS `month`")
+        );
+
+        return $collection->get()->toArray();
     }
 }

--- a/app/Models/RequestLog.php
+++ b/app/Models/RequestLog.php
@@ -24,9 +24,29 @@ class RequestLog extends Model
         return count($this->select('id')->get());
     }
 
-    public function paginatedCollection(int $offset = 0, int $limit = 10)
+    /**
+     * @param int $offset
+     * @param int $limit
+     * @param array $collection_parameters
+     *
+     * @return array
+     */
+    public function paginatedCollection(
+        int $offset = 0,
+        int $limit = 10,
+        array $collection_parameters = []
+    )
     {
-        return $this->orderByDesc('created_at')->offset($offset)->limit($limit)->get();
+        $collection = $this->orderByDesc('created_at');
+
+        if (array_key_exists('source', $collection_parameters) === true) {
+            $collection->where('source', '=', $collection_parameters['source']);
+        }
+
+        return $collection->offset($offset)->
+            limit($limit)->
+            get()->
+            toArray();
     }
 
     public function monthlyRequests()

--- a/app/Models/Transformers/RequestLog.php
+++ b/app/Models/Transformers/RequestLog.php
@@ -6,28 +6,31 @@ namespace App\Models\Transformers;
 /**
  * Transform the data returns from Eloquent into the format we want for the API
  *
+ * This is an updated version of the transformers, the other transformers need to
+ * be updated to operate on an array rather than collections
+ *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
 class RequestLog extends Transformer
 {
-    protected $log;
+    protected $data_to_transform;
 
-    public function __construct(\App\Models\RequestLog $log)
+    public function __construct(array $data_to_transform)
     {
         parent::__construct();
 
-        $this->log = $log;
+        $this->data_to_transform = $data_to_transform;
     }
 
     public function toArray(): array
     {
         return [
-            'method' => $this->log->method,
-            'source' => $this->log->source,
-            'request_uri' => $this->log->request,
-            'created' => $this->log->created_at->toDateTimeString()
+            'method' => $this->data_to_transform['method'],
+            'source' => $this->data_to_transform['source'],
+            'request_uri' => $this->data_to_transform['request'],
+            'created' => $this->data_to_transform['created_at']
         ];
     }
 }

--- a/app/Models/Transformers/RequestLog.php
+++ b/app/Models/Transformers/RequestLog.php
@@ -25,6 +25,7 @@ class RequestLog extends Transformer
     {
         return [
             'method' => $this->log->method,
+            'source' => $this->log->source,
             'request_uri' => $this->log->request,
             'created' => $this->log->created_at->toDateTimeString()
         ];

--- a/config/api/request/parameters.php
+++ b/config/api/request/parameters.php
@@ -3,6 +3,15 @@
 declare(strict_types=1);
 
 return [
-    'collection' => [],
+    'collection' => [
+        'source' => [
+            "parameter" => "source",
+            "title" => 'request/parameters.title-source',
+            "description" => 'request/parameters.description-source',
+            "default" => null,
+            "type" => "string",
+            "required" => false
+        ],
+    ],
     'item' => []
 ];

--- a/config/api/request/summary-parameters.php
+++ b/config/api/request/summary-parameters.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'collection' => [
+        'source' => [
+            "parameter" => "source",
+            "title" => 'request/parameters.title-source',
+            "description" => 'request/parameters.description-source',
+            "default" => null,
+            "type" => "string",
+            "required" => false
+        ],
+    ],
+    'item' => []
+];

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '1.14.1',
+    'version'=> '1.14.2',
     'prefix' => 'v1',
-    'release_date' => '2019-05-01',
+    'release_date' => '2019-05-31',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/database/migrations/2019_05_30_112441_source_field_for_requests_log.php
+++ b/database/migrations/2019_05_30_112441_source_field_for_requests_log.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class SourceFieldForRequestsLog extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('request_log', function (Blueprint $table) {
+            $table->string('source', 25)
+                ->after('method')
+                ->default('api');
+            $table->index('source');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('request_log', function (Blueprint $table) {
+            $table->dropIndex('request_log_source_index');
+            $table->dropColumn('source');
+        });
+    }
+}

--- a/database/migrations/2019_05_30_144849_capture_who_entered_expense.php
+++ b/database/migrations/2019_05_30_144849_capture_who_entered_expense.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CaptureWhoEnteredExpense extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('item', function (Blueprint $table) {
+            $table->unsignedInteger('user_id')
+                ->after('actualised_total')
+                ->default(1);
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('item', function (Blueprint $table) {
+            $table->dropForeign('item_user_id_foreign');
+            $table->dropColumn('user_id');
+        });
+    }
+}

--- a/resources/lang/en/request/parameters.php
+++ b/resources/lang/en/request/parameters.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title-source' => 'Source',
+    'description-source' => 'Show results for thr request source, api, legacy or website'
+];

--- a/resources/lang/en/request/parameters.php
+++ b/resources/lang/en/request/parameters.php
@@ -4,5 +4,5 @@ declare(strict_types=1);
 
 return [
     'title-source' => 'Source',
-    'description-source' => 'Show results for thr request source, api, legacy or website'
+    'description-source' => 'Show results for the requested source, api, legacy or website'
 ];

--- a/resources/lang/en/request/summary-parameters.php
+++ b/resources/lang/en/request/summary-parameters.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title-source' => 'Source',
+    'description-source' => 'Return the access log summary for the requested source, api, legacy or website'
+];


### PR DESCRIPTION
## [v1.14.2] - 2019-05-31 
### Added  
- Offset and Limit X headers added to collections. 
- If X-Source exists in request header it is saved with the request so we can start tracking sources. 
- Capture the id of the user that created an item. 
- `source` filter added to /request/access-log. 
- `source` filter added to /summary/request/access-log/monthly. 

## Changed 
- Upgraded `RequestLog` Transformer, switching to a new system.