### PR TITLE
v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ### Added
 - `publish_after` field added to item, POST and PATCH updated.
 - Tests for POSTMAN, now up to 277 tests.
+- /resource-types/[resource-type]/resources/[resource]/items collection updated to not display unpublished items.
+- /resource-types/[resource-type]/items collection update to not display unpublished items.
 
 ### Changed
 - `description` added to /summary/resource-types/[resource-type]/resources/[resource]/items?categories=true summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
 ## [v1.15.0] - 2019-06-xx
+### Added
+- Tests for POSTMAN, now up to 193 tests.
+
 ### Changed
-- Category transformer updated to new setup.
 - `description` added to /summary/resource-types/[resource-type]/resources/[resource]/items?categories=true summary
+- `description` added to /summary/resource-types/[resource-type]/resources/[resource]/items?category=[category]&subcategories=true
+- Category, ItemCategorySummary and ItemSubCategorySummary transformers updated to new setup.
 
 ### Fixed
 - Collection parameters not passed through to category transformer. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - Moved request fields validators.
 - Moved request route validators.
 - Moved class used to fetch GET parameters.
+- Refactored the sort parameters code, added validation and code now resides in its own class, now reusable.
 
 ### Fixed
 - Collection parameters not passed through to category transformer. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,11 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - Moved request route validators.
 - Moved class used to fetch GET parameters.
 - Refactored the sort parameters code, added validation and code now resides in its own class, now reusable.
+- General refactoring, never happy with the design.
 
 ### Fixed
 - Collection parameters not passed through to category transformer. 
-- Header indent incorrect for v1.14.3 subheadings.
+- Header indent incorrect for the v1.14.3 changelog subheadings.
 - Description missing from /categories collection.
 
 ## [v1.14.3] - 2019-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 
 ## [v1.15.0] - 2019-06-xx
 ### Added
+- `publish_after` field added to item, POST and PATCH updated.
 - Tests for POSTMAN, now up to 277 tests.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - /resource-types/[resource-type]/resources/[resource]/items collection updated to not include unpublished items.
 - /resource-types/[resource-type]/items collection updated to not include unpublished items.
 - /summary/resource-types/d185Q15grY/resources/kw8gLq31VB/items updated to not include unpublished items.
+- /summary/resource-types/d185Q15grY/items updated to not include unpublished items.
 
 ### Changed
 - `description` added to /summary/resource-types/[resource-type]/resources/[resource]/items?categories=true summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ### Added
 - `publish_after` field added to item, POST and PATCH updated.
 - Tests for POSTMAN, now up to 277 tests.
-- /resource-types/[resource-type]/resources/[resource]/items collection updated to not display unpublished items.
-- /resource-types/[resource-type]/items collection update to not display unpublished items.
+- /resource-types/[resource-type]/resources/[resource]/items collection updated to not include unpublished items.
+- /resource-types/[resource-type]/items collection updated to not include unpublished items.
+- /summary/resource-types/d185Q15grY/resources/kw8gLq31VB/items updated to not include unpublished items.
 
 ### Changed
 - `description` added to /summary/resource-types/[resource-type]/resources/[resource]/items?categories=true summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - Category, ItemCategorySummary and ItemSubCategorySummary transformers updated to new setup.
 - Up the throttle limit.
 - Don't format numbers in output, leave that to the apps.
+- Moved request fields validators.
+- Moved request route validators.
 
 ### Fixed
 - Collection parameters not passed through to category transformer. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - Description missing from /categories collection.
 - Pagination helper not hashing subcategory value before adding to URI.
 - Sort and search conditions added to pagination URIs.
+- Section value cleared in changelog parser when new release found.
 
 ## [v1.14.3] - 2019-06-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ## [v1.15.0] - 2019-06-xx
 ### Added
 - `publish_after` field added to item, POST and PATCH updated.
-- Tests for POSTMAN, now up to 277 tests.
+- Tests for POSTMAN, now up to 280 tests.
 - /resource-types/[resource-type]/resources/[resource]/items collection updated to not include unpublished items.
 - /resource-types/[resource-type]/items collection updated to not include unpublished items.
 - /summary/resource-types/d185Q15grY/resources/kw8gLq31VB/items updated to not include unpublished items.
@@ -21,6 +21,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - Don't format numbers in output, leave that to the apps.
 - Moved request fields validators.
 - Moved request route validators.
+- Moved class used to fetch GET parameters.
 
 ### Fixed
 - Collection parameters not passed through to category transformer. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ## [v1.15.0] - 2019-06-xx
 ### Changed
 - Category transformer updated to new setup.
+- `description` added to /summary/resource-types/[resource-type]/resources/[resource]/items?categories=true summary
 
 ### Fixed
 - Collection parameters not passed through to category transformer. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,21 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.15.0] - 2019-06-xx
+### Changed
+- Category transformer updated to new setup.
+
+### Fixed
+- Collection parameters not passed through to category transformer. 
+- Header indent incorrect for v1.14.3 subheadings.
+- Description missing from /categories collection.
+
 ## [v1.14.3] - 2019-06-02
-## Added
+### Added
 - Added Twitter social card summary to the landing page.
 - Added `include-categories` and `include-subcategories` parameters to /resource-types/[resource-type]/resources/[resource]/items collection.
 
-## Changed
+### Changed
 - `postman` is now a supported value for the `source` parameter.
 
 ## [v1.14.2] - 2019-05-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - Collection parameters not passed through to category transformer. 
 - Header indent incorrect for the v1.14.3 changelog subheadings.
 - Description missing from /categories collection.
+- Pagination helper not hashing subcategory.
+- Sort and search conditions added to pagination URIs.
 
 ## [v1.14.3] - 2019-06-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
-## [v1.15.0] - 2019-06-xx
+## [v1.15.0] - 2019-06-09
 ### Added
 - `publish_after` field added to item, POST and PATCH updated.
 - Tests for POSTMAN, now up to 280 tests.
@@ -20,17 +20,17 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - Category, ItemCategorySummary and ItemSubCategorySummary transformers updated to new setup.
 - Up the throttle limit.
 - Don't format numbers in output, leave that to the apps.
-- Moved request fields validators.
-- Moved request route validators.
-- Moved class used to fetch GET parameters.
-- Refactored the sort parameters code, added validation and code now resides in its own class, now reusable.
+- Moved fields validators.
+- Moved route validators.
+- Moved the class used to fetch GET parameters.
+- Refactored the sort parameters code, added validation and the code now resides in its own class, now reusable.
 - General refactoring, never happy with the design.
 
 ### Fixed
-- Collection parameters not passed through to category transformer. 
-- Header indent incorrect for the v1.14.3 changelog subheadings.
+- Collection parameters not being passed through to the category transformer. 
+- Header indents incorrect for the v1.14.3 changelog entry.
 - Description missing from /categories collection.
-- Pagination helper not hashing subcategory.
+- Pagination helper not hashing subcategory value before adding to URI.
 - Sort and search conditions added to pagination URIs.
 
 ## [v1.14.3] - 2019-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 
 ## [v1.15.0] - 2019-06-xx
 ### Added
-- Tests for POSTMAN, now up to 193 tests.
+- Tests for POSTMAN, now up to 277 tests.
 
 ### Changed
 - `description` added to /summary/resource-types/[resource-type]/resources/[resource]/items?categories=true summary
+- `description` added to /summary/resource-types/[resource-type]/items?categories=true summary
 - `description` added to /summary/resource-types/[resource-type]/resources/[resource]/items?category=[category]&subcategories=true
+- `description` added to /summary/resource-types/[resource-type]/items?category=[category]&subcategories=true
 - Category, ItemCategorySummary and ItemSubCategorySummary transformers updated to new setup.
+- Up the throttle limit.
+- Don't format numbers in output, leave that to the apps.
 
 ### Fixed
 - Collection parameters not passed through to category transformer. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - Tests for POSTMAN, now up to 280 tests.
 - /resource-types/[resource-type]/resources/[resource]/items collection updated to not include unpublished items.
 - /resource-types/[resource-type]/items collection updated to not include unpublished items.
-- /summary/resource-types/d185Q15grY/resources/kw8gLq31VB/items updated to not include unpublished items.
-- /summary/resource-types/d185Q15grY/items updated to not include unpublished items.
+- /summary/resource-types/[resource-type]/resources/[resource]/items updated to not include unpublished items.
+- /summary/resource-types/[resource-type]/items updated to not include unpublished items.
+- search support added to /summary/resource-types/[resource-type]/resources/[resource]/items
 
 ### Changed
 - `description` added to /summary/resource-types/[resource-type]/resources/[resource]/items?categories=true summary
@@ -203,7 +204,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ### Added
 - Added resource_type GET parameter to /categories route to filter results.
 - Two options for changelog, markdown on GitHub and via API.
-- Added Google Analytics to then landing page.
+- Added Google Analytics to the landing page.
 
 ### Changed
  - Corrected CHANGELOG dates, I'm not from the future.

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -100,18 +100,18 @@ class CategoryController extends Controller
 
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.category_GET_index',
-                'parameters_config' => 'api.category.parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.category_GET_index',
+                'parameters_config_string' => 'api.category.parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.category_POST',
+                'description_localisation_string' => 'route-descriptions.category_POST',
                 'fields_config' => 'api.category.fields',
-                'conditionals' => $this->conditionalPostParameters(),
-                'authenticated' => true
+                'conditionals_config' => $this->conditionalPostParameters(),
+                'authentication_required' => true
             ]
         );
     }
@@ -130,14 +130,14 @@ class CategoryController extends Controller
 
         return $this->generateOptionsForShow(
             [
-                'description_localisation' => 'route-descriptions.category_GET_show',
-                'parameters_config' => 'api.category.parameters.item',
-                'conditionals' => [],
-                'authenticated' => false
+                'description_localisation_string' => 'route-descriptions.category_GET_show',
+                'parameters_config_string' => 'api.category.parameters.item',
+                'conditionals_config' => [],
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.category_DELETE',
-                'authenticated' => true
+                'description_localisation_string' => 'route-descriptions.category_DELETE',
+                'authentication_required' => true
             ]
         );
     }

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -104,6 +104,7 @@ class CategoryController extends Controller
                 'parameters_config_string' => 'api.category.parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ],

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -37,18 +37,21 @@ class CategoryController extends Controller
     {
         $this->collection_parameters = Get::parameters(['include-subcategories']);
 
-        $categories = (new Category())->paginatedCollection($this->include_private, $this->collection_parameters);
+        $categories = (new Category())->paginatedCollection(
+            $this->include_private,
+            $this->collection_parameters
+        );
 
         $headers = [
             'X-Total-Count' => count($categories)
         ];
 
         return response()->json(
-            $categories->map(
-                function ($category)
-                {
+            array_map(
+                function($category) {
                     return (new CategoryTransformer($category, $this->collection_parameters))->toArray();
-                }
+                },
+                $categories
             ),
             200,
             $headers

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -8,7 +8,7 @@ use App\Models\Category;
 use App\Models\ResourceType;
 use App\Models\Transformers\Category as CategoryTransformer;
 use App\Utilities\Response as UtilityResponse;
-use App\Http\Parameters\Request\Validators\Category as CategoryValidator;
+use App\Validators\Request\Fields\Category as CategoryValidator;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Get;
+use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\Category;
 use App\Models\ResourceType;
@@ -35,7 +35,7 @@ class CategoryController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        $this->collection_parameters = Get::parameters(['include-subcategories']);
+        $this->collection_parameters = Parameters::fetch(['include-subcategories']);
 
         $categories = (new Category())->paginatedCollection(
             $this->include_private,
@@ -70,7 +70,7 @@ class CategoryController extends Controller
     {
         Route::categoryRoute($category_id);
 
-        $this->show_parameters = Get::parameters(['include-subcategories']);
+        $this->show_parameters = Parameters::fetch(['include-subcategories']);
 
         $category = (new Category)->single($category_id);
 
@@ -96,7 +96,7 @@ class CategoryController extends Controller
      */
     public function optionsIndex(Request $request): JsonResponse
     {
-        $this->collection_parameters = Get::parameters(['include-subcategories']);
+        $this->collection_parameters = Parameters::fetch(['include-subcategories']);
 
         return $this->generateOptionsForIndex(
             [

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Parameters\Get;
-use App\Http\Parameters\Route\Validate;
+use App\Validators\Request\Route;
 use App\Models\Category;
 use App\Models\ResourceType;
 use App\Models\Transformers\Category as CategoryTransformer;
@@ -68,7 +68,7 @@ class CategoryController extends Controller
      */
     public function show(Request $request, $category_id): JsonResponse
     {
-        Validate::categoryRoute($category_id);
+        Route::categoryRoute($category_id);
 
         $this->show_parameters = Get::parameters(['include-subcategories']);
 
@@ -126,7 +126,7 @@ class CategoryController extends Controller
      */
     public function optionsShow(Request $request, string $category_id): JsonResponse
     {
-        Validate::categoryRoute($category_id);
+        Route::categoryRoute($category_id);
 
         return $this->generateOptionsForShow(
             [
@@ -193,7 +193,7 @@ class CategoryController extends Controller
         string $category_id
     ): JsonResponse
     {
-        Validate::categoryRoute($category_id);
+        Route::categoryRoute($category_id);
 
         try {
             (new Category())->find($category_id)->delete();

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -98,30 +98,30 @@ class Controller extends BaseController
      */
     protected function generateOptionsForIndex(
         array $get = [
-            'description_localisation' => '',
-            'parameters_config' => null,
-            'conditionals' => [],
+            'description_localisation_string' => '',
+            'parameters_config_string' => null,
+            'conditionals_config' => [],
             'sortable_config' => null,
-            'pagination' => true,
-            'authenticated' => false
+            'enable_pagination' => true,
+            'authentication_required' => false
         ],
         array $post = [
-            'description_localisation' => '',
+            'description_localisation_string' => '',
             'fields_config' => '',
-            'conditionals' => [],
-            'authenticated' => true
+            'conditionals_config' => [],
+            'authentication_required' => true
         ]
     ) {
         $get_parameters = [];
         $get_parameters_sortable = [];
         $post_fields = [];
 
-        if ($get['parameters_config'] !== null) {
+        if ($get['parameters_config_string'] !== null) {
             foreach (
                 array_merge_recursive(
-                    ($get['pagination'] === true ? Config::get('api.pagination.parameters') : []),
-                    Config::get($get['parameters_config']),
-                    $get['conditionals']
+                    ($get['enable_pagination'] === true ? Config::get('api.pagination.parameters') : []),
+                    Config::get($get['parameters_config_string']),
+                    $get['conditionals_config']
                 ) as $parameter => $detail) {
                 $detail['title'] = trans($detail['title']);
                 $detail['description'] = trans($detail['description']);
@@ -135,23 +135,23 @@ class Controller extends BaseController
 
         $routes = [
             'GET' => [
-                'description' => trans($get['description_localisation']),
-                'authenticated' => $get['authenticated'],
+                'description' => trans($get['description_localisation_string']),
+                'authentication_required' => $get['authentication_required'],
                 'sortable' => $get_parameters_sortable,
                 'parameters' => $get_parameters
             ]
         ];
 
-        if (strlen($post['description_localisation']) > 0) {
-            foreach (array_merge_recursive(Config::get($post['fields_config']), $post['conditionals']) as $field => $detail) {
+        if (strlen($post['description_localisation_string']) > 0) {
+            foreach (array_merge_recursive(Config::get($post['fields_config']), $post['conditionals_config']) as $field => $detail) {
                 $detail['title'] = trans($detail['title']);
                 $detail['description'] = trans($detail['description']);
                 $post_fields[$field] = $detail;
             }
 
             $routes['POST'] = [
-                'description' => trans($post['description_localisation']),
-                'authenticated' => $post['authenticated'],
+                'description' => trans($post['description_localisation_string']),
+                'authentication_required' => $post['authentication_required'],
                 'fields' => $post_fields
             ];
         }
@@ -168,26 +168,26 @@ class Controller extends BaseController
      */
     protected function generateOptionsForShow(
         array $get = [
-            'description_localisation' => '',
-            'parameters_config' => '',
-            'conditionals' => [],
-            'authenticated' => false
+            'description_localisation_string' => '',
+            'parameters_config_string' => '',
+            'conditionals_config' => [],
+            'authentication_required' => false
         ],
         array $delete = [
-            'description_localisation' => '',
-            'authenticated' => false
+            'description_localisation_string' => '',
+            'authentication_required' => false
         ],
         array $patch = [
-            'description_localisation' => '',
+            'description_localisation_string' => '',
             'fields_config' => '',
-            'conditionals' => [],
-            'authenticated' => false
+            'conditionals_config' => [],
+            'authentication_required' => false
         ]
     ) {
         $get_parameters = [];
         $patch_fields = [];
 
-        foreach (array_merge_recursive(Config::get($get['parameters_config']), $get['conditionals']) as $parameter => $detail) {
+        foreach (array_merge_recursive(Config::get($get['parameters_config_string']), $get['conditionals_config']) as $parameter => $detail) {
             $detail['title'] = trans($detail['title']);
             $detail['description'] = trans($detail['description']);
             $get_parameters[$parameter] = $detail;
@@ -195,29 +195,29 @@ class Controller extends BaseController
 
         $routes = [
             'GET' => [
-                'description' => trans($get['description_localisation']),
-                'authenticated' => $get['authenticated'],
+                'description' => trans($get['description_localisation_string']),
+                'authentication_required' => $get['authentication_required'],
                 'parameters' => $get_parameters
             ]
         ];
 
-        if (strlen($delete['description_localisation']) > 0) {
+        if (strlen($delete['description_localisation_string']) > 0) {
             $routes['DELETE'] = [
-                'description' => trans($delete['description_localisation']),
-                'authenticated' => $delete['authenticated']
+                'description' => trans($delete['description_localisation_string']),
+                'authentication_required' => $delete['authentication_required']
             ];
         }
 
-        if (strlen($patch['description_localisation']) > 0) {
-            foreach (array_merge_recursive(Config::get($patch['fields_config']), $patch['conditionals']) as $field => $detail) {
+        if (strlen($patch['description_localisation_string']) > 0) {
+            foreach (array_merge_recursive(Config::get($patch['fields_config']), $patch['conditionals_config']) as $field => $detail) {
                 $detail['title'] = trans($detail['title']);
                 $detail['description'] = trans($detail['description']);
                 $patch_fields[$field] = $detail;
             }
 
             $routes['PATCH'] = [
-                'description' => trans($patch['description_localisation']),
-                'authenticated' => $patch['authenticated'],
+                'description' => trans($patch['description_localisation_string']),
+                'authentication_required' => $patch['authentication_required'],
                 'fields' => $patch_fields
             ];
         }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -102,6 +102,7 @@ class Controller extends BaseController
             'parameters_config_string' => null,
             'conditionals_config' => [],
             'sortable_config' => null,
+            'searchable_config' => null,
             'enable_pagination' => true,
             'authentication_required' => false
         ],
@@ -114,6 +115,7 @@ class Controller extends BaseController
     ) {
         $get_parameters = [];
         $get_parameters_sortable = [];
+        $get_parameters_searchable = [];
         $post_fields = [];
 
         if ($get['parameters_config_string'] !== null) {
@@ -133,11 +135,16 @@ class Controller extends BaseController
             $get_parameters_sortable = Config::get($get['sortable_config']);
         }
 
+        if ($get['searchable_config'] !== null) {
+            $get_parameters_searchable = Config::get($get['searchable_config']);
+        }
+
         $routes = [
             'GET' => [
                 'description' => trans($get['description_localisation_string']),
                 'authentication_required' => $get['authentication_required'],
                 'sortable' => $get_parameters_sortable,
+                'searchable' => $get_parameters_searchable,
                 'parameters' => $get_parameters
             ]
         ];

--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -102,6 +102,7 @@ class IndexController extends Controller
 
                     ++$i;
                     $changes[$i]['release'] = trim(str_replace('##', '', $line));
+                    $section = null;
                 }
 
                 if (strpos($line, '###') !== false) {

--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -70,7 +70,7 @@ class IndexController extends Controller
             [
                 'GET' => [
                     'description' => trans('route-descriptions.api_GET_index'),
-                    'authenticated' => false,
+                    'authentication_required' => false,
                     'parameters' => []
                 ]
             ]
@@ -136,7 +136,7 @@ class IndexController extends Controller
             [
                 'GET' => [
                     'description' => trans('route-descriptions.api_GET_changelog'),
-                    'authenticated' => false,
+                    'authentication_required' => false,
                     'parameters' => []
                 ]
             ]

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Route\Validate;
+use App\Validators\Request\Route;
 use App\Models\Category;
 use App\Models\ItemCategory;
 use App\Models\Transformers\ItemCategory as ItemCategoryTransformer;
@@ -34,7 +34,7 @@ class ItemCategoryController extends Controller
      */
     public function index(Request $request, string $resource_type_id, string $resource_id, string $item_id): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         $item_category = (new ItemCategory())->paginatedCollection(
             $resource_type_id,
@@ -76,7 +76,7 @@ class ItemCategoryController extends Controller
         string $item_category_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill') {
             UtilityResponse::notFound(trans('entities.item-category'));
@@ -116,7 +116,7 @@ class ItemCategoryController extends Controller
      */
     public function optionsIndex(Request $request, string $resource_type_id, string $resource_id, string $item_id): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         return $this->generateOptionsForIndex(
             [
@@ -155,7 +155,7 @@ class ItemCategoryController extends Controller
         string $item_category_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill') {
             UtilityResponse::notFound(trans('entities.item-category'));
@@ -203,7 +203,7 @@ class ItemCategoryController extends Controller
         string $item_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         $validator = (new ItemCategoryValidator)->create($request);
 
@@ -282,7 +282,7 @@ class ItemCategoryController extends Controller
         string $item_category_id
     ): JsonResponse
     {
-        Validate::itemCategory($resource_type_id, $resource_id, $item_id, $item_category_id);
+        Route::itemCategory($resource_type_id, $resource_id, $item_id, $item_category_id);
 
         $item_category = (new ItemCategory())->single(
             $resource_type_id,

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -124,6 +124,7 @@ class ItemCategoryController extends Controller
                 'parameters_config_string' => 'api.item-category.parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ],

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -120,18 +120,18 @@ class ItemCategoryController extends Controller
 
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.item_category_GET_index',
-                'parameters_config' => 'api.item-category.parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.item_category_GET_index',
+                'parameters_config_string' => 'api.item-category.parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.item_category_POST',
+                'description_localisation_string' => 'route-descriptions.item_category_POST',
                 'fields_config' => 'api.item-category.fields',
-                'conditionals' => $this->conditionalPostParameters($resource_type_id),
-                'authenticated' => true
+                'conditionals_config' => $this->conditionalPostParameters($resource_type_id),
+                'authentication_required' => true
             ]
         );
     }
@@ -174,14 +174,14 @@ class ItemCategoryController extends Controller
 
         return $this->generateOptionsForShow(
             [
-                'description_localisation' => 'route-descriptions.item_category_GET_show',
-                'parameters_config' => 'api.item-category.parameters.item',
-                'conditionals' => [],
-                'authenticated' => false
+                'description_localisation_string' => 'route-descriptions.item_category_GET_show',
+                'parameters_config_string' => 'api.item-category.parameters.item',
+                'conditionals_config' => [],
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.item_category_DELETE',
-                'authenticated' => true
+                'description_localisation_string' => 'route-descriptions.item_category_DELETE',
+                'authentication_required' => true
             ]
         );
     }

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -7,7 +7,7 @@ use App\Models\Category;
 use App\Models\ItemCategory;
 use App\Models\Transformers\ItemCategory as ItemCategoryTransformer;
 use App\Utilities\Response as UtilityResponse;
-use App\Http\Parameters\Request\Validators\ItemCategory as ItemCategoryValidator;
+use App\Validators\Request\Fields\ItemCategory as ItemCategoryValidator;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -154,18 +154,18 @@ class ItemController extends Controller
 
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.item_GET_index',
-                'parameters_config' => 'api.item.parameters.collection',
-                'conditionals' => $this->get_parameters,
+                'description_localisation_string' => 'route-descriptions.item_GET_index',
+                'parameters_config_string' => 'api.item.parameters.collection',
+                'conditionals_config' => $this->get_parameters,
                 'sortable_config' => 'api.item.sortable',
-                'pagination' => true,
-                'authenticated' => false
+                'enable_pagination' => true,
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.item_POST',
+                'description_localisation_string' => 'route-descriptions.item_POST',
                 'fields_config' => 'api.item.fields',
-                'conditionals' => [],
-                'authenticated' => true
+                'conditionals_config' => [],
+                'authentication_required' => true
             ]
         );
     }
@@ -197,20 +197,20 @@ class ItemController extends Controller
 
         return $this->generateOptionsForShow(
             [
-                'description_localisation' => 'route-descriptions.item_GET_show',
-                'parameters_config' => 'api.item.parameters.item',
-                'conditionals' => [],
-                'authenticated' => false
+                'description_localisation_string' => 'route-descriptions.item_GET_show',
+                'parameters_config_string' => 'api.item.parameters.item',
+                'conditionals_config' => [],
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.item_DELETE',
-                'authenticated' => true
+                'description_localisation_string' => 'route-descriptions.item_DELETE',
+                'authentication_required' => true
             ],
             [
-                'description_localisation' => 'route-descriptions.item_PATCH',
+                'description_localisation_string' => 'route-descriptions.item_PATCH',
                 'fields_config' => 'api.item.fields',
-                'conditionals' => [],
-                'authenticated' => true
+                'conditionals_config' => [],
+                'authentication_required' => true
             ]
         );
     }
@@ -398,17 +398,15 @@ class ItemController extends Controller
         }
 
         $categories = (new Category())->paginatedCollection($this->include_private, ['resource_type'=>$resource_type_id]);
-        array_map(
-            function($category) {
-                $this->get_parameters['category']['allowed_values'][$this->hash->encode('category', $category['category_id'])] = [
-                    'value' => $this->hash->encode('category', $category['category_id']),
-                    'name' => $category['category_name'],
-                    'description' => trans('resource-type-item/allowed-values.description-prefix-category') .
-                        $category['category_name'] . trans('resource-type-item/allowed-values.description-suffix-category')
-                ];
-            },
-            $categories
-        );
+
+        foreach ($categories as $category) {
+            $this->get_parameters['category']['allowed_values'][$this->hash->encode('category', $category['category_id'])] = [
+                'value' => $this->hash->encode('category', $category['category_id']),
+                'name' => $category['category_name'],
+                'description' => trans('item/allowed-values.description-prefix-category') .
+                    $category['category_name'] . trans('item/allowed-values.description-suffix-category')
+            ];
+        }
 
         if (array_key_exists('category', $this->collection_parameters) === true) {
             (new SubCategory())->paginatedCollection($this->collection_parameters['category'])->map(

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -230,6 +230,7 @@ class ItemController extends Controller
                 'resource_id' => $resource_id,
                 'description' => $request->input('description'),
                 'effective_date' => $request->input('effective_date'),
+                'publish_after' => $request->input('publish_after', null),
                 'total' => $request->input('total'),
                 'percentage' => $request->input('percentage', 100),
                 'user_id' => Auth::user()->id
@@ -282,7 +283,7 @@ class ItemController extends Controller
             UtilityResponse::invalidFieldsInRequest($invalid_fields);
         }
 
-        $item = (new Item())->single($resource_type_id, $resource_id, $item_id);
+        $item = (new Item())->instance($resource_type_id, $resource_id, $item_id);
 
         if ($item === null) {
             UtilityResponse::failedToSelectModelForUpdate();
@@ -296,6 +297,8 @@ class ItemController extends Controller
                 $update_actualised = true;
             }
         }
+
+        //print_r($item); die;
 
         if ($update_actualised === true) {
             $item->setActualisedTotal($item->total, $item->percentage);

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Parameters\Get;
-use App\Http\Parameters\Route\Validate;
+use App\Validators\Request\Route;
 use App\Models\Category;
 use App\Models\Item;
 use App\Models\SubCategory;
@@ -41,7 +41,7 @@ class ItemController extends Controller
      */
     public function index(Request $request, string $resource_type_id, string $resource_id): JsonResponse
     {
-        Validate::resourceRoute($resource_type_id, $resource_id);
+        Route::resourceRoute($resource_type_id, $resource_id);
 
         $this->collection_parameters = Get::parameters([
             'include-categories',
@@ -109,7 +109,7 @@ class ItemController extends Controller
         string $item_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         $item = (new Item())->single($resource_type_id, $resource_id, $item_id);
 
@@ -137,7 +137,7 @@ class ItemController extends Controller
      */
     public function optionsIndex(Request $request, string $resource_type_id, string $resource_id): JsonResponse
     {
-        Validate::resourceRoute($resource_type_id, $resource_id);
+        Route::resourceRoute($resource_type_id, $resource_id);
 
         $this->collection_parameters = Get::parameters(['year', 'month', 'category', 'subcategory']);
 
@@ -178,7 +178,7 @@ class ItemController extends Controller
         string $item_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         $item = (new Item())->single($resource_type_id, $resource_id, $item_id);
 
@@ -217,7 +217,7 @@ class ItemController extends Controller
      */
     public function create(Request $request, string $resource_type_id, string $resource_id): JsonResponse
     {
-        Validate::resourceRoute($resource_type_id, $resource_id);
+        Route::resourceRoute($resource_type_id, $resource_id);
 
         $validator = (new ItemValidator)->create($request);
 
@@ -267,7 +267,7 @@ class ItemController extends Controller
         string $item_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($this->isThereAnythingToPatchInRequest() === false) {
             UtilityResponse::nothingToPatch();
@@ -330,7 +330,7 @@ class ItemController extends Controller
         string $item_id
     ): JsonResponse
     {
-        Validate::resourceRoute($resource_type_id, $resource_id);
+        Route::resourceRoute($resource_type_id, $resource_id);
 
         $item = (new Item())->single($resource_type_id, $resource_id, $item_id);
 

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -158,6 +158,7 @@ class ItemController extends Controller
                 'parameters_config_string' => 'api.item.parameters.collection',
                 'conditionals_config' => $this->get_parameters,
                 'sortable_config' => 'api.item.sortable',
+                'searchable_config' => 'api.item.searchable',
                 'enable_pagination' => true,
                 'authentication_required' => false
             ],

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -240,8 +240,11 @@ class ItemController extends Controller
             UtilityResponse::failedToSaveModelForCreate();
         }
 
+        /**
+         * Fix this hack
+         */
         return response()->json(
-            (new ItemTransformer($item))->toArray(),
+            (new ItemTransformer((new Item())->single($resource_type_id, $resource_id, $item->id)))->toArray(),
             201
         );
     }

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -10,7 +10,7 @@ use App\Models\SubCategory;
 use App\Models\Transformers\Item as ItemTransformer;
 use App\Utilities\Pagination as UtilityPagination;
 use App\Utilities\Response as UtilityResponse;
-use App\Http\Parameters\Request\Validators\Item as ItemValidator;
+use App\Validators\Request\Fields\Item as ItemValidator;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Get;
+use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\Category;
 use App\Models\Item;
@@ -43,7 +43,7 @@ class ItemController extends Controller
     {
         Route::resourceRoute($resource_type_id, $resource_id);
 
-        $this->collection_parameters = Get::parameters([
+        $this->collection_parameters = Parameters::fetch([
             'include-categories',
             'include-subcategories',
             'year',
@@ -139,7 +139,7 @@ class ItemController extends Controller
     {
         Route::resourceRoute($resource_type_id, $resource_id);
 
-        $this->collection_parameters = Get::parameters(['year', 'month', 'category', 'subcategory']);
+        $this->collection_parameters = Parameters::fetch(['year', 'month', 'category', 'subcategory']);
 
         $this->setConditionalGetParameters($resource_type_id);
 

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -385,16 +385,17 @@ class ItemController extends Controller
             ];
         }
 
-        (new Category())->paginatedCollection($this->include_private, ['resource_type'=>$resource_type_id])->map(
-            function ($category)
-            {
-                $this->get_parameters['category']['allowed_values'][$this->hash->encode('category', $category->category_id)] = [
-                    'value' => $this->hash->encode('category', $category->category_id),
-                    'name' => $category->category_name,
-                    'description' => trans('item/allowed-values.description-prefix-category') .
-                        $category->category_name . trans('item/allowed-values.description-suffix-category')
+        $categories = (new Category())->paginatedCollection($this->include_private, ['resource_type'=>$resource_type_id]);
+        array_map(
+            function($category) {
+                $this->get_parameters['category']['allowed_values'][$this->hash->encode('category', $category['category_id'])] = [
+                    'value' => $this->hash->encode('category', $category['category_id']),
+                    'name' => $category['category_name'],
+                    'description' => trans('resource-type-item/allowed-values.description-prefix-category') .
+                        $category['category_name'] . trans('resource-type-item/allowed-values.description-suffix-category')
                 ];
-            }
+            },
+            $categories
         );
 
         if (array_key_exists('category', $this->collection_parameters) === true) {

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -11,6 +11,7 @@ use App\Models\Transformers\Item as ItemTransformer;
 use App\Utilities\Pagination as UtilityPagination;
 use App\Utilities\Response as UtilityResponse;
 use App\Validators\Request\Fields\Item as ItemValidator;
+use App\Validators\Request\SearchParameters;
 use App\Validators\Request\SortParameters;
 use Exception;
 use Illuminate\Database\QueryException;
@@ -61,10 +62,15 @@ class ItemController extends Controller
             'created'
         ]);
 
+        $search_conditions = SearchParameters::fetch([
+            'description'
+        ]);
+
         $total = (new Item())->totalCount(
             $resource_type_id,
             $resource_id,
-            $this->collection_parameters
+            $this->collection_parameters,
+            $search_conditions
         );
 
         $pagination = UtilityPagination::init($request->path(), $total)
@@ -77,7 +83,8 @@ class ItemController extends Controller
             $pagination['offset'],
             $pagination['limit'],
             $this->collection_parameters,
-            $sort_fields
+            $sort_fields,
+            $search_conditions
         );
 
         $headers = [

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -11,6 +11,7 @@ use App\Models\Transformers\Item as ItemTransformer;
 use App\Utilities\Pagination as UtilityPagination;
 use App\Utilities\Response as UtilityResponse;
 use App\Validators\Request\Fields\Item as ItemValidator;
+use App\Validators\Request\SortParameters;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -49,8 +50,15 @@ class ItemController extends Controller
             'year',
             'month',
             'category',
-            'subcategory',
-            'sort'
+            'subcategory'
+        ]);
+
+        $sort_fields = SortParameters::fetch([
+            'description',
+            'total',
+            'actualised_total',
+            'effective_date',
+            'created'
         ]);
 
         $total = (new Item())->totalCount(
@@ -68,7 +76,8 @@ class ItemController extends Controller
             $resource_id,
             $pagination['offset'],
             $pagination['limit'],
-            $this->collection_parameters
+            $this->collection_parameters,
+            $sort_fields
         );
 
         $headers = [

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -75,6 +75,8 @@ class ItemController extends Controller
 
         $pagination = UtilityPagination::init($request->path(), $total)
             ->setParameters($this->collection_parameters)
+            ->setSortParameters($sort_fields)
+            ->setSearchParameters($search_conditions)
             ->paging();
 
         $items = (new Item())->paginatedCollection(
@@ -420,8 +422,8 @@ class ItemController extends Controller
             (new SubCategory())->paginatedCollection($this->collection_parameters['category'])->map(
                 function ($sub_category)
                 {
-                    $this->get_parameters['subcategory']['allowed_values'][$this->hash->encode('sub_category', $sub_category->id)] = [
-                        'value' => $this->hash->encode('sub_category', $sub_category->id),
+                    $this->get_parameters['subcategory']['allowed_values'][$this->hash->encode('subcategory', $sub_category->id)] = [
+                        'value' => $this->hash->encode('subcategory', $sub_category->id),
                         'name' => $sub_category->name,
                         'description' => trans('item/allowed-values.description-prefix-subcategory') .
                             $sub_category->name . trans('item/allowed-values.description-suffix-subcategory')

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -8,7 +8,7 @@ use App\Models\ItemSubCategory;
 use App\Models\SubCategory;
 use App\Models\Transformers\ItemSubCategory as ItemSubCategoryTransformer;
 use App\Utilities\Response as UtilityResponse;
-use App\Http\Parameters\Request\Validators\ItemSubCategory as ItemSubCategoryValidator;
+use App\Validators\Request\Fields\ItemSubCategory as ItemSubCategoryValidator;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Route\Validate;
+use App\Validators\Request\Route;
 use App\Models\ItemCategory;
 use App\Models\ItemSubCategory;
 use App\Models\SubCategory;
@@ -42,7 +42,7 @@ class ItemSubCategoryController extends Controller
         string $item_category_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill') {
             UtilityResponse::notFound(trans('entities.item-sub-category'));
@@ -91,7 +91,7 @@ class ItemSubCategoryController extends Controller
         string $item_sub_category_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill' || $item_sub_category_id === 'nill') {
             UtilityResponse::notFound(trans('entities.item-sub-category'));
@@ -139,7 +139,7 @@ class ItemSubCategoryController extends Controller
         string $item_category_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill') {
             UtilityResponse::notFound(trans('entities.item-sub-category'));
@@ -189,7 +189,7 @@ class ItemSubCategoryController extends Controller
         string $item_sub_category_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill' || $item_sub_category_id === 'nill') {
             UtilityResponse::notFound(trans('entities.item-sub-category'));
@@ -240,7 +240,7 @@ class ItemSubCategoryController extends Controller
         string $item_category_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill') {
             UtilityResponse::notFound(trans('entities.item-sub-category'));
@@ -333,7 +333,7 @@ class ItemSubCategoryController extends Controller
         string $item_sub_category_id
     ): JsonResponse
     {
-        Validate::itemRoute($resource_type_id, $resource_id, $item_id);
+        Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill' || $item_sub_category_id === 'nill') {
             UtilityResponse::notFound(trans('entities.item-sub-category'));

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -152,18 +152,18 @@ class ItemSubCategoryController extends Controller
 
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.item_sub_category_GET_index',
-                'parameters_config' => 'api.item-subcategory.parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.item_sub_category_GET_index',
+                'parameters_config_string' => 'api.item-subcategory.parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.item_sub_category_POST',
+                'description_localisation_string' => 'route-descriptions.item_sub_category_POST',
                 'fields_config' => 'api.item-subcategory.fields',
-                'conditionals' => $this->conditionalPostParameters($item_category->category_id),
-                'authenticated' => true
+                'conditionals_config' => $this->conditionalPostParameters($item_category->category_id),
+                'authentication_required' => true
             ]
         );
     }
@@ -209,14 +209,14 @@ class ItemSubCategoryController extends Controller
 
         return $this->generateOptionsForShow(
             [
-                'description_localisation' => 'route-descriptions.item_sub_category_GET_show',
-                'parameters_config' => 'api.item-subcategory.parameters.item',
-                'conditionals' => [],
-                'authenticated' => false
+                'description_localisation_string' => 'route-descriptions.item_sub_category_GET_show',
+                'parameters_config_string' => 'api.item-subcategory.parameters.item',
+                'conditionals_config' => [],
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.item_sub_category_DELETE',
-                'authenticated' => true
+                'description_localisation_string' => 'route-descriptions.item_sub_category_DELETE',
+                'authentication_required' => true
             ]
         );
     }

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -297,7 +297,7 @@ class ItemSubCategoryController extends Controller
         $conditional_post_parameters = ['sub_category_id' => []];
 
         foreach ($sub_categories as $sub_category) {
-            $id = $this->hash->encode('sub_category', $sub_category->id);
+            $id = $this->hash->encode('subcategory', $sub_category->id);
 
             if ($id === false) {
                 UtilityResponse::unableToDecode();

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -156,6 +156,7 @@ class ItemSubCategoryController extends Controller
                 'parameters_config_string' => 'api.item-subcategory.parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ],

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Get;
+use App\Validators\Request\Parameters;
 use App\Models\RequestErrorLog;
 use App\Models\RequestLog;
 use App\Models\Transformers\RequestErrorLog as RequestErrorLogTransformer;
@@ -75,7 +75,7 @@ class RequestController extends Controller
     {
         $total = (new RequestLog())->totalCount();
 
-        $this->collection_parameters = Get::parameters(['source']);
+        $this->collection_parameters = Parameters::fetch(['source']);
 
         $pagination = UtilityPagination::init($request->path(), $total, 50)
             ->paging();

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -8,7 +8,7 @@ use App\Models\RequestLog;
 use App\Models\Transformers\RequestErrorLog as RequestErrorLogTransformer;
 use App\Models\Transformers\RequestLog as RequestLogTransformer;
 use App\Utilities\Pagination as UtilityPagination;
-use App\Http\Parameters\Request\Validators\RequestErrorLog as RequestErrorLogValidator;
+use App\Validators\Request\Fields\RequestErrorLog as RequestErrorLogValidator;
 use App\Utilities\Response as UtilityResponse;
 use Exception;
 use Illuminate\Http\JsonResponse;

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -119,6 +119,7 @@ class RequestController extends Controller
                 'parameters_config_string' => 'api.request.parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => true,
                 'authentication_required' => false
             ]
@@ -138,6 +139,7 @@ class RequestController extends Controller
                 'parameters_config_string' => [],
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ],

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -115,12 +115,12 @@ class RequestController extends Controller
     {
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.request_GET_access-log',
-                'parameters_config' => 'api.request.parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.request_GET_access-log',
+                'parameters_config_string' => 'api.request.parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => true,
-                'authenticated' => false
+                'enable_pagination' => true,
+                'authentication_required' => false
             ]
         );
     }
@@ -134,18 +134,18 @@ class RequestController extends Controller
     {
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.request_GET_error_log',
-                'parameters_config' => [],
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.request_GET_error_log',
+                'parameters_config_string' => [],
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.request_POST',
+                'description_localisation_string' => 'route-descriptions.request_POST',
                 'fields_config' => 'api.request.fields',
-                'conditionals' => [],
-                'authenticated' => false
+                'conditionals_config' => [],
+                'authentication_required' => false
             ]
         );
     }

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -6,7 +6,7 @@ use App\Http\Parameters\Route\Validate;
 use App\Models\Resource;
 use App\Models\Transformers\Resource as ResourceTransformer;
 use App\Utilities\Response as UtilityResponse;
-use App\Http\Parameters\Request\Validators\Resource as ResourceValidator;
+use App\Validators\Request\Fields\Resource as ResourceValidator;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Route\Validate;
+use App\Validators\Request\Route;
 use App\Models\Resource;
 use App\Models\Transformers\Resource as ResourceTransformer;
 use App\Utilities\Response as UtilityResponse;
@@ -31,7 +31,7 @@ class ResourceController extends Controller
      */
     public function index(Request $request, string $resource_type_id): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         $resources = (new Resource)->paginatedCollection($resource_type_id);
 
@@ -66,7 +66,7 @@ class ResourceController extends Controller
         string $resource_id
     ): JsonResponse
     {
-        Validate::resourceRoute($resource_type_id, $resource_id);
+        Route::resourceRoute($resource_type_id, $resource_id);
 
         $resource = (new Resource)->single($resource_type_id, $resource_id);
 
@@ -93,7 +93,7 @@ class ResourceController extends Controller
      */
     public function optionsIndex(Request $request, string $resource_type_id): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         return $this->generateOptionsForIndex(
             [
@@ -124,7 +124,7 @@ class ResourceController extends Controller
      */
     public function optionsShow(Request $request, string $resource_type_id, string $resource_id): JsonResponse
     {
-        Validate::resourceRoute($resource_type_id, $resource_id);
+        Route::resourceRoute($resource_type_id, $resource_id);
 
         $resource = (new Resource)->single(
             $resource_type_id,
@@ -159,7 +159,7 @@ class ResourceController extends Controller
      */
     public function create(Request $request, string $resource_type_id): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         $validator = (new ResourceValidator)->create($request, $resource_type_id);
 
@@ -200,7 +200,7 @@ class ResourceController extends Controller
         string $resource_id
     ): JsonResponse
     {
-        Validate::resourceRoute($resource_type_id, $resource_id);
+        Route::resourceRoute($resource_type_id, $resource_id);
 
         try {
             (new Resource())->find($resource_id)->delete();

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -101,6 +101,7 @@ class ResourceController extends Controller
                 'parameters_config_string' => 'api.resource.parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ],

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -97,18 +97,18 @@ class ResourceController extends Controller
 
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.resource_GET_index',
-                'parameters_config' => 'api.resource.parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.resource_GET_index',
+                'parameters_config_string' => 'api.resource.parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.resource_POST',
+                'description_localisation_string' => 'route-descriptions.resource_POST',
                 'fields_config' => 'api.resource.fields',
-                'conditionals' => [],
-                'authenticated' => true
+                'conditionals_config' => [],
+                'authentication_required' => true
             ]
         );
     }
@@ -137,14 +137,14 @@ class ResourceController extends Controller
 
         return $this->generateOptionsForShow(
             [
-                'description_localisation' => 'route-descriptions.resource_GET_show',
-                'parameters_config' => 'api.resource.parameters.item',
-                'conditionals' => [],
-                'authenticated' => false
+                'description_localisation_string' => 'route-descriptions.resource_GET_show',
+                'parameters_config_string' => 'api.resource.parameters.item',
+                'conditionals_config' => [],
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.resource_DELETE',
-                'authenticated' => true
+                'description_localisation_string' => 'route-descriptions.resource_DELETE',
+                'authentication_required' => true
             ]
         );
     }

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -98,6 +98,7 @@ class ResourceTypeController extends Controller
                 'parameters_config_string' => 'api.resource-type.parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ],

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -94,18 +94,18 @@ class ResourceTypeController extends Controller
     {
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.resource_type_GET_index',
-                'parameters_config' => 'api.resource-type.parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.resource_type_GET_index',
+                'parameters_config_string' => 'api.resource-type.parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.resource_type_POST',
+                'description_localisation_string' => 'route-descriptions.resource_type_POST',
                 'fields_config' => 'api.resource-type.fields',
-                'conditionals' => [],
-                'authenticated' => true
+                'conditionals_config' => [],
+                'authentication_required' => true
             ]
         );
     }
@@ -124,14 +124,14 @@ class ResourceTypeController extends Controller
 
         return $this->generateOptionsForShow(
             [
-                'description_localisation' => 'route-descriptions.resource_type_GET_show',
-                'parameters_config' => 'api.resource-type.parameters.item',
-                'conditionals' => [],
-                'authenticated' => false
+                'description_localisation_string' => 'route-descriptions.resource_type_GET_show',
+                'parameters_config_string' => 'api.resource-type.parameters.item',
+                'conditionals_config' => [],
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.resource_type_DELETE',
-                'authenticated' => true
+                'description_localisation_string' => 'route-descriptions.resource_type_DELETE',
+                'authentication_required' => true
             ]
         );
     }

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Parameters\Get;
-use App\Http\Parameters\Route\Validate;
+use App\Validators\Request\Route;
 use App\Models\ResourceType;
 use App\Models\Transformers\ResourceType as ResourceTypeTransformer;
 use App\Utilities\Response as UtilityResponse;
@@ -64,7 +64,7 @@ class ResourceTypeController extends Controller
      */
     public function show(Request $request, string $resource_type_id): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         $this->show_parameters = Get::parameters(['include-resources']);
 
@@ -120,7 +120,7 @@ class ResourceTypeController extends Controller
      */
     public function optionsShow(Request $request, string $resource_type_id): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         return $this->generateOptionsForShow(
             [
@@ -181,7 +181,7 @@ class ResourceTypeController extends Controller
         string $resource_type_id
     ): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         try {
             (new ResourceType())->find($resource_type_id)->delete();

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Get;
+use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\ResourceType;
 use App\Models\Transformers\ResourceType as ResourceTypeTransformer;
@@ -36,7 +36,7 @@ class ResourceTypeController extends Controller
     {
         $resource_types = (new ResourceType())->paginatedCollection($this->include_private);
 
-        $this->collection_parameters = Get::parameters(['include-resources']);
+        $this->collection_parameters = Parameters::fetch(['include-resources']);
 
         $headers = [
             'X-Total-Count' => count($resource_types)
@@ -66,7 +66,7 @@ class ResourceTypeController extends Controller
     {
         Route::resourceTypeRoute($resource_type_id);
 
-        $this->show_parameters = Get::parameters(['include-resources']);
+        $this->show_parameters = Parameters::fetch(['include-resources']);
 
         $resource_type = (new ResourceType())->single($resource_type_id, $this->include_private);
 

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -7,7 +7,7 @@ use App\Http\Parameters\Route\Validate;
 use App\Models\ResourceType;
 use App\Models\Transformers\ResourceType as ResourceTypeTransformer;
 use App\Utilities\Response as UtilityResponse;
-use App\Http\Parameters\Request\Validators\ResourceType as ResourceTypeValidator;
+use App\Validators\Request\Fields\ResourceType as ResourceTypeValidator;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Get;
+use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\Category;
 use App\Models\ResourceTypeItem;
@@ -35,7 +35,7 @@ class ResourceTypeItemController extends Controller
     {
         Route::resourceTypeRoute($resource_type_id);
 
-        $collection_parameters = Get::parameters([
+        $collection_parameters = Parameters::fetch([
             'include-categories',
             'include-subcategories',
             'year',
@@ -95,7 +95,7 @@ class ResourceTypeItemController extends Controller
 
         $this->conditionalGetParameters(
             $resource_type_id,
-            Get::parameters([
+            Parameters::fetch([
                 'category',
             ])
         );

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Parameters\Get;
-use App\Http\Parameters\Route\Validate;
+use App\Validators\Request\Route;
 use App\Models\Category;
 use App\Models\ResourceTypeItem;
 use App\Models\SubCategory;
@@ -33,7 +33,7 @@ class ResourceTypeItemController extends Controller
      */
     public function index(Request $request, string $resource_type_id): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         $collection_parameters = Get::parameters([
             'include-categories',
@@ -91,7 +91,7 @@ class ResourceTypeItemController extends Controller
      */
     public function optionsIndex(Request $request, string $resource_type_id): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         $this->conditionalGetParameters(
             $resource_type_id,

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -154,16 +154,17 @@ class ResourceTypeItemController extends Controller
             ];
         }
 
-        (new Category())->paginatedCollection($this->include_private, ['resource_type'=>$resource_type_id])->map(
-            function ($category)
-            {
-                $this->conditional_get_parameters['category']['allowed_values'][$this->hash->encode('category', $category->category_id)] = [
-                    'value' => $this->hash->encode('category', $category->category_id),
-                    'name' => $category->category_name,
+        $categories = (new Category())->paginatedCollection($this->include_private, ['resource_type'=>$resource_type_id]);
+        array_map(
+            function($category) {
+                $this->conditional_get_parameters['category']['allowed_values'][$this->hash->encode('category', $category['category_id'])] = [
+                    'value' => $this->hash->encode('category', $category['category_id']),
+                    'name' => $category['category_name'],
                     'description' => trans('resource-type-item/allowed-values.description-prefix-category') .
-                        $category->category_name . trans('resource-type-item/allowed-values.description-suffix-category')
+                        $category['category_name'] . trans('resource-type-item/allowed-values.description-suffix-category')
                 ];
-            }
+            },
+            $categories
         );
 
         if (array_key_exists('category', $collection_parameters) === true) {

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -172,8 +172,8 @@ class ResourceTypeItemController extends Controller
             (new SubCategory())->paginatedCollection($collection_parameters['category'])->map(
                 function ($sub_category)
                 {
-                    $this->conditional_get_parameters['subcategory']['allowed_values'][$this->hash->encode('sub_category', $sub_category->id)] = [
-                        'value' => $this->hash->encode('sub_category', $sub_category->id),
+                    $this->conditional_get_parameters['subcategory']['allowed_values'][$this->hash->encode('subcategory', $sub_category->id)] = [
+                        'value' => $this->hash->encode('subcategory', $sub_category->id),
                         'name' => $sub_category->name,
                         'description' => trans('resource-type-item/allowed-values.description-prefix-subcategory') .
                             $sub_category->name . trans('resource-type-item/allowed-values.description-suffix-subcategory')

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -106,6 +106,7 @@ class ResourceTypeItemController extends Controller
                 'parameters_config_string' => 'api.resource-type-item.parameters.collection',
                 'conditionals_config' => $this->conditional_get_parameters,
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => true,
                 'authentication_required' => false
             ]

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -102,12 +102,12 @@ class ResourceTypeItemController extends Controller
 
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.resource_type_item_GET_index',
-                'parameters_config' => 'api.resource-type-item.parameters.collection',
-                'conditionals' => $this->conditional_get_parameters,
+                'description_localisation_string' => 'route-descriptions.resource_type_item_GET_index',
+                'parameters_config_string' => 'api.resource-type-item.parameters.collection',
+                'conditionals_config' => $this->conditional_get_parameters,
                 'sortable_config' => null,
-                'pagination' => true,
-                'authenticated' => false
+                'enable_pagination' => true,
+                'authentication_required' => false
             ]
         );
     }

--- a/app/Http/Controllers/SubCategoryController.php
+++ b/app/Http/Controllers/SubCategoryController.php
@@ -104,6 +104,7 @@ class SubCategoryController extends Controller
                 'parameters_config_string' => 'api.subcategory.parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ],

--- a/app/Http/Controllers/SubCategoryController.php
+++ b/app/Http/Controllers/SubCategoryController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Route\Validate;
+use App\Validators\Request\Route;
 use App\Models\SubCategory;
 use App\Models\Transformers\SubCategory as SubCategoryTransformer;
 use App\Utilities\Response as UtilityResponse;
@@ -31,7 +31,7 @@ class SubCategoryController extends Controller
      */
     public function index(Request $request, string $category_id): JsonResponse
     {
-        Validate::categoryRoute($category_id);
+        Route::categoryRoute($category_id);
 
         $sub_categories = (new SubCategory())->paginatedCollection($category_id);
 
@@ -66,7 +66,7 @@ class SubCategoryController extends Controller
         string $sub_category_id
     ): JsonResponse
     {
-        Validate::subCategoryRoute($category_id, $sub_category_id);
+        Route::subCategoryRoute($category_id, $sub_category_id);
 
         $sub_category = (new SubCategory())->single(
             $category_id,
@@ -96,7 +96,7 @@ class SubCategoryController extends Controller
      */
     public function optionsIndex(Request $request, string $category_id): JsonResponse
     {
-        Validate::categoryRoute($category_id);
+        Route::categoryRoute($category_id);
 
         return $this->generateOptionsForIndex(
             [
@@ -131,7 +131,7 @@ class SubCategoryController extends Controller
         string $sub_category_id
     ): JsonResponse
     {
-        Validate::subCategoryRoute($category_id, $sub_category_id);
+        Route::subCategoryRoute($category_id, $sub_category_id);
 
         return $this->generateOptionsForShow(
             [
@@ -157,7 +157,7 @@ class SubCategoryController extends Controller
      */
     public function create(Request $request, string $category_id): JsonResponse
     {
-        Validate::categoryRoute($category_id);
+        Route::categoryRoute($category_id);
 
         $validator = (new SubCategoryValidator)->create($request, $category_id);
 
@@ -197,7 +197,7 @@ class SubCategoryController extends Controller
         string $sub_category_id
     ): JsonResponse
     {
-        Validate::subCategoryRoute($category_id, $sub_category_id);
+        Route::subCategoryRoute($category_id, $sub_category_id);
 
         $sub_category = (new SubCategory())->single(
             $category_id,

--- a/app/Http/Controllers/SubCategoryController.php
+++ b/app/Http/Controllers/SubCategoryController.php
@@ -100,18 +100,18 @@ class SubCategoryController extends Controller
 
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.sub_category_GET_index',
-                'parameters_config' => 'api.subcategory.parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.sub_category_GET_index',
+                'parameters_config_string' => 'api.subcategory.parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.sub_category_POST',
+                'description_localisation_string' => 'route-descriptions.sub_category_POST',
                 'fields_config' => 'api.subcategory.fields',
-                'conditionals' => [],
-                'authenticated' => true
+                'conditionals_config' => [],
+                'authentication_required' => true
             ]
         );
     }
@@ -135,14 +135,14 @@ class SubCategoryController extends Controller
 
         return $this->generateOptionsForShow(
             [
-                'description_localisation' => 'route-descriptions.sub_category_GET_show',
-                'parameters_config' => 'api.subcategory.parameters.item',
-                'conditionals' => [],
-                'authenticated' => false
+                'description_localisation_string' => 'route-descriptions.sub_category_GET_show',
+                'parameters_config_string' => 'api.subcategory.parameters.item',
+                'conditionals_config' => [],
+                'authentication_required' => false
             ],
             [
-                'description_localisation' => 'route-descriptions.sub_category_DELETE',
-                'authenticated' => true
+                'description_localisation_string' => 'route-descriptions.sub_category_DELETE',
+                'authentication_required' => true
             ]
         );
     }

--- a/app/Http/Controllers/SubCategoryController.php
+++ b/app/Http/Controllers/SubCategoryController.php
@@ -6,7 +6,7 @@ use App\Http\Parameters\Route\Validate;
 use App\Models\SubCategory;
 use App\Models\Transformers\SubCategory as SubCategoryTransformer;
 use App\Utilities\Response as UtilityResponse;
-use App\Http\Parameters\Request\Validators\SubCategory as SubCategoryValidator;
+use App\Validators\Request\Fields\SubCategory as SubCategoryValidator;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -330,12 +330,12 @@ class SummaryItemController extends Controller
 
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.summary_GET_resource-type_resource_items',
-                'parameters_config' => 'api.item.summary-parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.summary_GET_resource-type_resource_items',
+                'parameters_config_string' => 'api.item.summary-parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ]
         );
     }

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Parameters\Get;
-use App\Http\Parameters\Route\Validate;
+use App\Validators\Request\Route;
 use App\Models\Item;
 use App\Models\Transformers\ItemCategorySummary as ItemCategorySummaryTransformer;
 use App\Models\Transformers\ItemMonthSummary as ItemMonthSummaryTransformer;
@@ -37,7 +37,7 @@ class SummaryItemController extends Controller
      */
     public function index(Request $request, string $resource_type_id, string $resource_id): JsonResponse
     {
-        Validate::resourceRoute($resource_type_id, $resource_id);
+        Route::resourceRoute($resource_type_id, $resource_id);
 
         $this->resource_type_id = $resource_type_id;
         $this->resource_id = $resource_id;
@@ -239,7 +239,7 @@ class SummaryItemController extends Controller
      */
     public function categorySummary(int $category_id): JsonResponse
     {
-        Validate::categoryRoute($category_id);
+        Route::categoryRoute($category_id);
 
         $summary = (new Item())->categorySummary(
             $this->resource_type_id,
@@ -267,7 +267,7 @@ class SummaryItemController extends Controller
      */
     public function subcategoriesSummary(int $category_id): JsonResponse
     {
-        Validate::categoryRoute($category_id);
+        Route::categoryRoute($category_id);
 
         $summary = (new Item())->subCategoriesSummary(
             $this->resource_type_id,
@@ -297,7 +297,7 @@ class SummaryItemController extends Controller
      */
     public function subcategorySummary(int $category_id, int $sub_category_id): JsonResponse
     {
-        Validate::subCategoryRoute($category_id, $sub_category_id);
+        Route::subCategoryRoute($category_id, $sub_category_id);
 
         $summary = (new Item())->subCategorySummary(
             $this->resource_type_id,
@@ -326,7 +326,7 @@ class SummaryItemController extends Controller
      */
     public function optionsIndex(Request $request, string $resource_type_id, string $resource_id)
     {
-        Validate::resourceRoute($resource_type_id, $resource_id);
+        Route::resourceRoute($resource_type_id, $resource_id);
 
         return $this->generateOptionsForIndex(
             [

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Get;
+use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\Item;
 use App\Models\Transformers\ItemCategorySummary as ItemCategorySummaryTransformer;
@@ -42,7 +42,7 @@ class SummaryItemController extends Controller
         $this->resource_type_id = $resource_type_id;
         $this->resource_id = $resource_id;
 
-        $collection_parameters = Get::parameters([
+        $collection_parameters = Parameters::fetch([
             'year',
             'years',
             'month',

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -334,6 +334,7 @@ class SummaryItemController extends Controller
                 'parameters_config_string' => 'api.item.summary-parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ]

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -219,10 +219,11 @@ class SummaryItemController extends Controller
         );
 
         return response()->json(
-            $summary->map(
-                function ($category_summary) {
-                    return (new ItemCategorySummaryTransformer($category_summary))->toArray();
-                }
+            array_map(
+                function($category) {
+                    return (new ItemCategorySummaryTransformer($category))->toArray();
+                },
+                $summary
             ),
             200,
             [ 'X-Total-Count' => count($summary) ]
@@ -275,10 +276,11 @@ class SummaryItemController extends Controller
         );
 
         return response()->json(
-            $summary->map(
-                function ($category_summary) {
-                    return (new ItemSubCategorySummaryTransformer($category_summary))->toArray();
-                }
+            array_map(
+                function($subcategory) {
+                    return (new ItemSubCategorySummaryTransformer($subcategory))->toArray();
+                },
+                $summary
             ),
             200,
             [ 'X-Total-Count' => count($summary) ]

--- a/app/Http/Controllers/SummaryRequestController.php
+++ b/app/Http/Controllers/SummaryRequestController.php
@@ -55,6 +55,7 @@ class SummaryRequestController extends Controller
                 'parameters_config_string' => 'api.request.parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ]

--- a/app/Http/Controllers/SummaryRequestController.php
+++ b/app/Http/Controllers/SummaryRequestController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Get;
+use App\Validators\Request\Parameters;
 use App\Models\RequestLog;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -27,7 +27,7 @@ class SummaryRequestController extends Controller
      */
     public function monthlyAccessLog(Request $request): JsonResponse
     {
-        $this->collection_parameters = Get::parameters(['source']);
+        $this->collection_parameters = Parameters::fetch(['source']);
 
         $monthly_summary = (new RequestLog())->monthlyRequests($this->collection_parameters);
 

--- a/app/Http/Controllers/SummaryRequestController.php
+++ b/app/Http/Controllers/SummaryRequestController.php
@@ -51,12 +51,12 @@ class SummaryRequestController extends Controller
     {
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.summary_GET_request_access-log_monthly',
-                'parameters_config' => 'api.request.parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.summary_GET_request_access-log_monthly',
+                'parameters_config_string' => 'api.request.parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ]
         );
     }

--- a/app/Http/Controllers/SummaryResourceController.php
+++ b/app/Http/Controllers/SummaryResourceController.php
@@ -54,12 +54,12 @@ class SummaryResourceController extends Controller
 
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.summary-resource-GET-index',
-                'parameters_config' => 'api.resource.summary-parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.summary-resource-GET-index',
+                'parameters_config_string' => 'api.resource.summary-parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ]
         );
     }

--- a/app/Http/Controllers/SummaryResourceController.php
+++ b/app/Http/Controllers/SummaryResourceController.php
@@ -58,6 +58,7 @@ class SummaryResourceController extends Controller
                 'parameters_config_string' => 'api.resource.summary-parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ]

--- a/app/Http/Controllers/SummaryResourceController.php
+++ b/app/Http/Controllers/SummaryResourceController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Route\Validate;
+use App\Validators\Request\Route;
 use App\Models\Resource;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -26,7 +26,7 @@ class SummaryResourceController extends Controller
      */
     public function index(Request $request, string $resource_type_id): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         $summary = (new Resource())->totalCount($resource_type_id, $this->include_private);
 
@@ -50,7 +50,7 @@ class SummaryResourceController extends Controller
      */
     public function optionsIndex(Request $request, string $resource_type_id): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         return $this->generateOptionsForIndex(
             [

--- a/app/Http/Controllers/SummaryResourceTypeController.php
+++ b/app/Http/Controllers/SummaryResourceTypeController.php
@@ -47,12 +47,12 @@ class SummaryResourceTypeController extends Controller
     {
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.summary-resource-type-GET-index',
-                'parameters_config' => 'api.resource-type.summary-parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.summary-resource-type-GET-index',
+                'parameters_config_string' => 'api.resource-type.summary-parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ]
         );
     }

--- a/app/Http/Controllers/SummaryResourceTypeController.php
+++ b/app/Http/Controllers/SummaryResourceTypeController.php
@@ -51,6 +51,7 @@ class SummaryResourceTypeController extends Controller
                 'parameters_config_string' => 'api.resource-type.summary-parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ]

--- a/app/Http/Controllers/SummaryResourceTypeItemController.php
+++ b/app/Http/Controllers/SummaryResourceTypeItemController.php
@@ -355,12 +355,12 @@ class SummaryResourceTypeItemController extends Controller
 
         return $this->generateOptionsForIndex(
             [
-                'description_localisation' => 'route-descriptions.summary-resource-type-item-GET-index',
-                'parameters_config' => 'api.resource-type-item.summary-parameters.collection',
-                'conditionals' => [],
+                'description_localisation_string' => 'route-descriptions.summary-resource-type-item-GET-index',
+                'parameters_config_string' => 'api.resource-type-item.summary-parameters.collection',
+                'conditionals_config' => [],
                 'sortable_config' => null,
-                'pagination' => false,
-                'authenticated' => false
+                'enable_pagination' => false,
+                'authentication_required' => false
             ]
         );
     }

--- a/app/Http/Controllers/SummaryResourceTypeItemController.php
+++ b/app/Http/Controllers/SummaryResourceTypeItemController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Parameters\Get;
+use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\ResourceTypeItem;
 use App\Models\Transformers\ResourceTypeItemCategorySummary as ResourceTypeItemCategorySummaryTransformer;
@@ -40,7 +40,7 @@ class SummaryResourceTypeItemController extends Controller
 
         $this->resource_type_id = $resource_type_id;
 
-        $collection_parameters = Get::parameters([
+        $collection_parameters = Parameters::fetch([
             'resources',
             'year',
             'years',

--- a/app/Http/Controllers/SummaryResourceTypeItemController.php
+++ b/app/Http/Controllers/SummaryResourceTypeItemController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Parameters\Get;
-use App\Http\Parameters\Route\Validate;
+use App\Validators\Request\Route;
 use App\Models\ResourceTypeItem;
 use App\Models\Transformers\ResourceTypeItemCategorySummary as ResourceTypeItemCategorySummaryTransformer;
 use App\Models\Transformers\ResourceTypeItemMonthSummary as ResourceTypeItemMonthSummaryTransformer;
@@ -36,7 +36,7 @@ class SummaryResourceTypeItemController extends Controller
      */
     public function index(Request $request, string $resource_type_id): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         $this->resource_type_id = $resource_type_id;
 
@@ -351,7 +351,7 @@ class SummaryResourceTypeItemController extends Controller
      */
     public function optionsIndex(Request $request, string $resource_type_id): JsonResponse
     {
-        Validate::resourceTypeRoute($resource_type_id);
+        Route::resourceTypeRoute($resource_type_id);
 
         return $this->generateOptionsForIndex(
             [

--- a/app/Http/Controllers/SummaryResourceTypeItemController.php
+++ b/app/Http/Controllers/SummaryResourceTypeItemController.php
@@ -359,6 +359,7 @@ class SummaryResourceTypeItemController extends Controller
                 'parameters_config_string' => 'api.resource-type-item.summary-parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
+                'searchable_config' => null,
                 'enable_pagination' => false,
                 'authentication_required' => false
             ]

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -37,7 +37,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            'throttle:60,1',
+            'throttle:300,1',
             'bindings'
         ],
     ];

--- a/app/Http/Parameters/Get.php
+++ b/app/Http/Parameters/Get.php
@@ -37,6 +37,7 @@ class Get
 
                 switch ($parameter) {
                     case 'include-resources';
+                    case 'include-categories':
                     case 'include-subcategories';
                         self::$parameters[$parameter] = General::booleanValue($request_parameters[$parameter]);
                         break;

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -37,13 +37,18 @@ class Category extends Model
      * @param integer $offset
      * @param integer $limit
      *
-     * @return \Illuminate\Support\Collection
+     * @return array
      */
-    public function paginatedCollection(bool $include_private, array $collection_parameters, int $offset = 0, int $limit = 10)
-    {
+    public function paginatedCollection(
+        bool $include_private,
+        array $collection_parameters,
+        int $offset = 0,
+        int $limit = 10
+    ): array {
         $collection = $this->select(
             'category.id AS category_id',
             'category.name AS category_name',
+            'category.description AS category_description',
             'category.created_at AS category_created_at',
             'category.updated_at AS category_updated_at',
             'resource_type.id AS resource_type_id',
@@ -71,7 +76,7 @@ class Category extends Model
             $collection->where('resource_type.private', '=', 0);
         }
 
-        return $collection->get();
+        return $collection->get()->toArray();
     }
 
     /**
@@ -79,9 +84,9 @@ class Category extends Model
      *
      * @param integer $category_id
      *
-     * @return \Illuminate\Support\Collection
+     * @return array
      */
-    public function single(int $category_id)
+    public function single(int $category_id): array
     {
         return $this->join('resource_type', $this->table . '.resource_type_id', '=', 'resource_type.id')
             ->where('category.id', '=', intval($category_id))
@@ -96,7 +101,8 @@ class Category extends Model
                 'resource_type.id AS resource_type_id',
                 'resource_type.name AS resource_type_name'
             )
-            ->first();
+            ->first()
+            ->toArray();
     }
 
     /**

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -251,7 +251,11 @@ class Item extends Model
     public function categoriesSummary(int $resource_type_id, int $resource_id)
     {
         return $this->
-            selectRaw("category.id, category.name AS name, SUM(item.actualised_total) AS total")->
+            selectRaw('
+                category.id, 
+                category.name AS name, 
+                category.description AS description,
+                SUM(item.actualised_total) AS total')->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             join("item_category", "item_category.item_id", "item.id")->

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -77,6 +77,9 @@ class Item extends Model
             $collection->where('item_sub_category.sub_category_id', '=', $parameters_collection['subcategory']);
         }
 
+        $collection->whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()');
+
         return count($collection->get());
     }
 
@@ -200,6 +203,9 @@ class Item extends Model
             $collection->orderBy('item.effective_date', 'desc');
             $collection->orderBy('item.created_at', 'desc');
         }
+
+        $collection->whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()');
 
         return $collection->select($select_fields)->get()->toArray();
     }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -223,6 +223,25 @@ class Item extends Model
             ->toArray();
     }
 
+    public function instance(int $resource_type_id, int $resource_id, int $item_id)
+    {
+        return $this->where('resource_id', '=', $resource_id)
+            ->whereHas('resource', function ($query) use ($resource_type_id) {
+                $query->where('resource_type_id', '=', $resource_type_id);
+            })
+            ->select(
+                'item.id',
+                'item.description',
+                'item.effective_date',
+                'item.publish_after',
+                'item.total',
+                'item.percentage',
+                'item.actualised_total',
+                'item.created_at'
+            )
+            ->find($item_id);
+    }
+
     /**
      * Return the summary for items
      *

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -253,15 +253,18 @@ class Item extends Model
      *
      * @param int $resource_type_id
      * @param int $resource_id
-     * @return mixed
+     *
+     * @return array
      */
-    public function summary(int $resource_type_id, int $resource_id)
+    public function summary(int $resource_type_id, int $resource_id): array
     {
         return $this->selectRaw('sum(item.actualised_total) AS actualised_total')
             ->where('resource_id', '=', $resource_id)
             ->whereHas('resource', function ($query) use ($resource_type_id) {
                 $query->where('resource_type_id', '=', $resource_type_id);
             })
+            ->whereNull('item.publish_after')
+            ->orWhereRaw('item.publish_after < NOW()')
             ->get()
             ->toArray();
     }
@@ -288,6 +291,8 @@ class Item extends Model
             where("category.resource_type_id", "=", $resource_type_id)->
             where("resource_type.id", "=", $resource_type_id)->
             where("resource.id", "=", $resource_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("item_category.category_id")->
             orderBy("name")->
             get()->
@@ -310,6 +315,8 @@ class Item extends Model
             where("resource_type.id", "=", $resource_type_id)->
             where("resource.id", "=", $resource_id)->
             where("category.id", "=", $category_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("item_category.category_id")->
             orderBy("name")->
             get()->
@@ -333,6 +340,8 @@ class Item extends Model
             where("resource_type.id", "=", $resource_type_id)->
             where("resource.id", "=", $resource_id)->
             where("category.id", "=", $category_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("item_sub_category.sub_category_id")->
             orderBy("name")->
             get()->
@@ -362,6 +371,8 @@ class Item extends Model
             where("resource.id", "=", $resource_id)->
             where("category.id", "=", $category_id)->
             where("sub_category.id", "=", $sub_category_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("item_sub_category.sub_category_id")->
             orderBy("name")->
             get()->
@@ -376,6 +387,8 @@ class Item extends Model
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             where("resource_type.id", "=", $resource_type_id)->
             where("resource.id", "=", $resource_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("year")->
             orderBy("year")->
             get();
@@ -390,6 +403,8 @@ class Item extends Model
             where("resource_type.id", "=", $resource_type_id)->
             where("resource.id", "=", $resource_id)->
             whereRaw(\DB::raw("YEAR(item.effective_date) = '{$year}'"))->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("year")->
             get();
     }
@@ -403,6 +418,8 @@ class Item extends Model
             where("resource_type.id", "=", $resource_type_id)->
             where("resource.id", "=", $resource_id)->
             whereRaw(\DB::raw("YEAR(item.effective_date) = '{$year}'"))->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("month")->
             orderBy("month")->
             get();
@@ -418,6 +435,8 @@ class Item extends Model
             where("resource.id", "=", $resource_id)->
             whereRaw(\DB::raw("YEAR(item.effective_date) = '{$year}'"))->
             whereRaw(\DB::raw("MONTH(item.effective_date) = '{$month}'"))->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("month")->
             orderBy("month")->
             get();

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -86,7 +86,7 @@ class Item extends Model
         int $offset = 0,
         int $limit = 10,
         array $parameters_collection = []
-    )
+    ): array
     {
         $select_fields = [
             'item.id AS item_id',
@@ -204,7 +204,7 @@ class Item extends Model
         return $collection->select($select_fields)->get()->toArray();
     }
 
-    public function single(int $resource_type_id, int $resource_id, int $item_id)
+    public function single(int $resource_type_id, int $resource_id, int $item_id): array
     {
         return $this->where('resource_id', '=', $resource_id)
             ->whereHas('resource', function ($query) use ($resource_type_id) {
@@ -248,7 +248,7 @@ class Item extends Model
      * @param int $resource_id
      * @return mixed
      */
-    public function categoriesSummary(int $resource_type_id, int $resource_id)
+    public function categoriesSummary(int $resource_type_id, int $resource_id): array
     {
         return $this->
             selectRaw('
@@ -265,13 +265,18 @@ class Item extends Model
             where("resource.id", "=", $resource_id)->
             groupBy("item_category.category_id")->
             orderBy("name")->
-            get();
+            get()->
+            toArray();
     }
 
-    public function categorySummary(int $resource_type_id, int $resource_id, $category_id)
+    public function categorySummary(int $resource_type_id, int $resource_id, $category_id): array
     {
         return $this->
-            selectRaw("category.id, category.name AS name, SUM(item.actualised_total) AS total")->
+            selectRaw('
+                category.id, 
+                category.name AS name, 
+                category.description AS description, 
+                SUM(item.actualised_total) AS total')->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             join("item_category", "item_category.item_id", "item.id")->
@@ -282,13 +287,18 @@ class Item extends Model
             where("category.id", "=", $category_id)->
             groupBy("item_category.category_id")->
             orderBy("name")->
-            get();
+            get()->
+            toArray();
     }
 
-    public function subCategoriesSummary(int $resource_type_id, int $resource_id, int $category_id)
+    public function subCategoriesSummary(int $resource_type_id, int $resource_id, int $category_id): array
     {
         return $this->
-            selectRaw("sub_category.id, sub_category.name AS name, SUM(item.actualised_total) AS total")->
+            selectRaw('
+                sub_category.id, 
+                sub_category.name AS name, 
+                sub_category.description AS description,
+                SUM(item.actualised_total) AS total')->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             join("item_category", "item_category.item_id", "item.id")->
@@ -300,13 +310,23 @@ class Item extends Model
             where("category.id", "=", $category_id)->
             groupBy("item_sub_category.sub_category_id")->
             orderBy("name")->
-            get();
+            get()->
+            toArray();
     }
 
-    public function subCategorySummary(int $resource_type_id, int $resource_id, int $category_id, int $sub_category_id)
+    public function subCategorySummary(
+        int $resource_type_id,
+        int $resource_id,
+        int $category_id,
+        int $sub_category_id
+    ): array
     {
         return $this->
-            selectRaw("sub_category.id, sub_category.name AS name, SUM(item.actualised_total) AS total")->
+            selectRaw('
+                sub_category.id, 
+                sub_category.name AS name, 
+                sub_category.description AS description,
+                SUM(item.actualised_total) AS total')->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             join("item_category", "item_category.item_id", "item.id")->
@@ -319,7 +339,8 @@ class Item extends Model
             where("sub_category.id", "=", $sub_category_id)->
             groupBy("item_sub_category.sub_category_id")->
             orderBy("name")->
-            get();
+            get()->
+            toArray();
     }
 
     public function yearsSummary(int $resource_type_id, int $resource_id)
@@ -374,28 +395,6 @@ class Item extends Model
             whereRaw(\DB::raw("MONTH(item.effective_date) = '{$month}'"))->
             groupBy("month")->
             orderBy("month")->
-            get();
-    }
-
-    public function expandedCategoriesSummary(int $resource_type_id, int $resource_id)
-    {
-        return $this->
-            selectRaw("`category`.`name` AS `category`")->
-            selectRaw("`sub_category`.`name` AS `sub_category`")->
-            selectRaw("SUM(`item`.`actualised_total`) AS `actualised_total`")->
-            selectRaw("COUNT(`item`.`id`) AS `items`")->
-            join("item_category", "item_category.item_id", "item.id")->
-            join("item_sub_category", "item_sub_category.item_category_id", "item_category.id")->
-            join("category", "item_category.category_id", "category.id")->
-            join("sub_category", "item_sub_category.sub_category_id", "sub_category.id")->
-            join("resource", "item.resource_id", "resource.id")->
-            join("resource_type", "resource.resource_type_id", "resource_type.id")->
-            where('resource_type.id', '=', $resource_type_id)->
-            where('resource.id', '=', $resource_id)->
-            groupBy("sub_category.name")->
-            groupBy("category.name")->
-            orderBy("category.name")->
-            orderBy("sub_category.name")->
             get();
     }
 }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -88,7 +88,8 @@ class Item extends Model
         int $resource_id,
         int $offset = 0,
         int $limit = 10,
-        array $parameters_collection = []
+        array $parameters_collection = [],
+        array $sort_fields = []
     ): array
     {
         $select_fields = [
@@ -168,35 +169,16 @@ class Item extends Model
             $collection->where('item_sub_category.sub_category_id', '=', $parameters_collection['subcategory']);
         }
 
-        if (array_key_exists('sort', $parameters_collection) === true) {
-            $sorting_parameters = explode('|', $parameters_collection['sort']);
+        if (count($sort_fields) > 0) {
+            foreach ($sort_fields as $field => $direction) {
+                switch ($field) {
+                    case 'created':
+                        $collection->orderBy('created_at', $direction);
+                        break;
 
-            if (count($sorting_parameters) > 0) {
-                foreach ($sorting_parameters as $sort) {
-                    $sort = explode(':', $sort);
-
-                    if (
-                        is_array($sort) === true &&
-                        count($sort) === 2 &&
-                        in_array($sort[1], ['asc', 'desc']) === true &&
-                        in_array($sort[0], ["description", "total", "actualised_total", "effective_date", "created"]) === true
-                    ) {
-                        switch ($sort[0]) {
-                            case 'description':
-                            case 'total':
-                            case 'actualised_total':
-                            case 'effective_date':
-                                $collection->orderBy($sort[0], $sort[1]);
-                                break;
-
-                            case 'created':
-                                $collection->orderBy('created_at', $sort[1]);
-                                break;
-
-                            default:
-                                break;
-                        }
-                    }
+                    default:
+                        $collection->orderBy($field, $direction);
+                        break;
                 }
             }
         } else {

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -43,7 +43,8 @@ class Item extends Model
     public function totalCount(
         int $resource_type_id,
         int $resource_id,
-        array $parameters_collection = []
+        array $parameters_collection = [],
+        array $search_conditions = []
     )
     {
         $collection = $this->where('resource_id', '=', $resource_id)
@@ -77,6 +78,12 @@ class Item extends Model
             $collection->where('item_sub_category.sub_category_id', '=', $parameters_collection['subcategory']);
         }
 
+        if (count($search_conditions) > 0) {
+            foreach ($search_conditions as $field => $search_term) {
+                $collection->where('item.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
+        }
+
         $collection->whereNull('item.publish_after')->
             orWhereRaw('item.publish_after < NOW()');
 
@@ -89,7 +96,8 @@ class Item extends Model
         int $offset = 0,
         int $limit = 10,
         array $parameters_collection = [],
-        array $sort_fields = []
+        array $sort_fields = [],
+        array $search_conditions = []
     ): array
     {
         $select_fields = [
@@ -169,6 +177,15 @@ class Item extends Model
             $collection->where('item_sub_category.sub_category_id', '=', $parameters_collection['subcategory']);
         }
 
+        if (count($search_conditions) > 0) {
+            foreach ($search_conditions as $field => $search_term) {
+                $collection->where('item.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
+        }
+
+        $collection->whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()');
+
         if (count($sort_fields) > 0) {
             foreach ($sort_fields as $field => $direction) {
                 switch ($field) {
@@ -185,9 +202,6 @@ class Item extends Model
             $collection->orderBy('item.effective_date', 'desc');
             $collection->orderBy('item.created_at', 'desc');
         }
-
-        $collection->whereNull('item.publish_after')->
-            orWhereRaw('item.publish_after < NOW()');
 
         return $collection->select($select_fields)->get()->toArray();
     }

--- a/app/Models/ResourceTypeItem.php
+++ b/app/Models/ResourceTypeItem.php
@@ -195,6 +195,8 @@ class ResourceTypeItem extends Model
             join('resource', 'item.resource_id', 'resource.id')->
             join('resource_type', 'resource.resource_type_id', 'resource_type.id')->
             where('resource_type.id', '=', $resource_type_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             get()->
             toArray();
     }
@@ -213,6 +215,8 @@ class ResourceTypeItem extends Model
             join('resource', 'item.resource_id', 'resource.id')->
             join('resource_type', 'resource.resource_type_id', 'resource_type.id')->
             where('resource_type.id', '=', $resource_type_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy('resource.id')->
             orderBy('name')->
             get()->
@@ -233,6 +237,8 @@ class ResourceTypeItem extends Model
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             where("resource_type.id", "=", $resource_type_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("year")->
             orderBy("year")->
             get()->
@@ -255,6 +261,8 @@ class ResourceTypeItem extends Model
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             where("resource_type.id", "=", $resource_type_id)->
             where(DB::raw('YEAR(item.effective_date)'), '=', $year)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("month")->
             orderBy("month")->
             get()->
@@ -279,6 +287,8 @@ class ResourceTypeItem extends Model
             where("resource_type.id", "=", $resource_type_id)->
             where(DB::raw('YEAR(item.effective_date)'), '=', $year)->
             where(DB::raw('MONTH(item.effective_date)'), '=', $month)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("month")->
             orderBy("month")->
             get()->
@@ -301,6 +311,8 @@ class ResourceTypeItem extends Model
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             where("resource_type.id", "=", $resource_type_id)->
             where(DB::raw('YEAR(item.effective_date)'), '=', $year)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("year")->
             orderBy("year")->
             get()->
@@ -328,6 +340,8 @@ class ResourceTypeItem extends Model
             join("category", "category.id", "item_category.category_id")->
             where("category.resource_type_id", "=", $resource_type_id)->
             where("resource_type.id", "=", $resource_type_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("category.id")->
             orderBy("name")->
             get()->
@@ -357,6 +371,8 @@ class ResourceTypeItem extends Model
             where("category.resource_type_id", "=", $resource_type_id)->
             where("resource_type.id", "=", $resource_type_id)->
             where("category.id", '=', $category_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("category.id")->
             orderBy("name")->
             get()->
@@ -388,6 +404,8 @@ class ResourceTypeItem extends Model
             where("category.resource_type_id", "=", $resource_type_id)->
             where("resource_type.id", "=", $resource_type_id)->
             where("category.id", "=", $category_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("sub_category.id")->
             orderBy("name")->
             get()->
@@ -421,6 +439,8 @@ class ResourceTypeItem extends Model
             where("resource_type.id", "=", $resource_type_id)->
             where("category.id", "=", $category_id)->
             where('sub_category.id', '=', $subcategory_id)->
+            whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()')->
             groupBy("sub_category.id")->
             orderBy("name")->
             get()->

--- a/app/Models/ResourceTypeItem.php
+++ b/app/Models/ResourceTypeItem.php
@@ -312,7 +312,11 @@ class ResourceTypeItem extends Model
      */
     public function categoriesSummary(int $resource_type_id): array
     {
-        return $this->selectRaw("category.id, category.name AS name, SUM(item.actualised_total) AS total")->
+        return $this->selectRaw('
+                category.id, 
+                category.name AS name, 
+                category.description AS description,
+                SUM(item.actualised_total) AS total')->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             join("item_category", "item_category.item_id", "item.id")->
@@ -336,7 +340,11 @@ class ResourceTypeItem extends Model
      */
     public function categorySummary(int $resource_type_id, int $category_id): array
     {
-        return $this->selectRaw("category.id, category.name AS name, SUM(item.actualised_total) AS total")->
+        return $this->selectRaw('
+                category.id, 
+                category.name AS name, 
+                category.description, 
+                SUM(item.actualised_total) AS total')->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             join("item_category", "item_category.item_id", "item.id")->
@@ -361,7 +369,11 @@ class ResourceTypeItem extends Model
      */
     public function subcategoriesSummary(int $resource_type_id, int $category_id): array
     {
-        return $this->selectRaw("sub_category.id, sub_category.name AS name, SUM(item.actualised_total) AS total")->
+        return $this->selectRaw('
+                sub_category.id, 
+                sub_category.name AS name, 
+                sub_category.description AS description, 
+                SUM(item.actualised_total) AS total')->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             join("item_category", "item_category.item_id", "item.id")->
@@ -389,7 +401,11 @@ class ResourceTypeItem extends Model
      */
     public function subcategorySummary(int $resource_type_id, int $category_id, int $subcategory_id): array
     {
-        return $this->selectRaw("sub_category.id, sub_category.name AS name, SUM(item.actualised_total) AS total")->
+        return $this->selectRaw('
+                sub_category.id, 
+                sub_category.name AS name, 
+                sub_category.description AS description, 
+                SUM(item.actualised_total) AS total')->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             join("item_category", "item_category.item_id", "item.id")->

--- a/app/Models/ResourceTypeItem.php
+++ b/app/Models/ResourceTypeItem.php
@@ -59,6 +59,9 @@ class ResourceTypeItem extends Model
             }
         }
 
+        $collection->whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()');
+
         return count($collection->get());
     }
 
@@ -171,6 +174,8 @@ class ResourceTypeItem extends Model
             }
         }
 
+        $collection->whereNull('item.publish_after')->
+            orWhereRaw('item.publish_after < NOW()');
 
         $collection->select($select_fields);
 

--- a/app/Models/Transformers/Category.php
+++ b/app/Models/Transformers/Category.php
@@ -9,43 +9,47 @@ use App\Models\SubCategory as SubCategoryModel;
 /**
  * Transform the data returns from Eloquent into the format we want for the API
  *
+ * This is an updated version of the transformers, the other transformers need to
+ * be updated to operate on an array rather than collections
+ *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
 class Category extends Transformer
 {
-    private $category;
+    protected $data_to_transform;
+
     private $parameters = [];
 
-    private $sub_categories = [];
+    private $subcategories = [];
 
     /**
      * ResourceType constructor.
      *
-     * @param CategoryModel $category
+     * @param array $data_to_transform
      * @param array $parameters
      */
-    public function __construct(CategoryModel $category, array $parameters = [])
+    public function __construct(array $data_to_transform, array $parameters = [])
     {
         parent::__construct();
 
-        $this->category = $category;
+        $this->data_to_transform = $data_to_transform;
         $this->parameters = $parameters;
     }
 
     public function toArray(): array
     {
         $result = [
-            'id' => $this->hash->category()->encode($this->category->category_id),
-            'name' => $this->category->category_name,
-            'description' => $this->category->category_description,
-            'created' => $this->category->category_created_at,
+            'id' => $this->hash->category()->encode($this->data_to_transform['category_id']),
+            'name' => $this->data_to_transform['category_name'],
+            'description' => $this->data_to_transform['category_description'],
+            'created' => $this->data_to_transform['category_created_at'],
             'resource_type' => [
-                'id' => $this->hash->resourceType()->encode($this->category->resource_type_id),
-                'name' => $this->category->resource_type_name,
+                'id' => $this->hash->resourceType()->encode($this->data_to_transform['resource_type_id']),
+                'name' => $this->data_to_transform['resource_type_name'],
             ],
-            'subcategories_count' => $this->category->category_sub_categories
+            'subcategories_count' => $this->data_to_transform['category_sub_categories']
         ];
 
         if (
@@ -53,16 +57,16 @@ class Category extends Transformer
             $this->parameters['include-subcategories'] === true
         ) {
             $subCategoriesCollection = (new SubCategoryModel())->paginatedCollection(
-                $this->category->category_id
+                $this->data_to_transform['category_id']
             );
 
             $subCategoriesCollection->map(
                 function ($sub_category) {
-                    $this->sub_categories[] = (new SubCategory($sub_category))->toArray();
+                    $this->subcategories[] = (new SubCategory($sub_category))->toArray();
                 }
             );
 
-            $result['subcategories'] = $this->sub_categories;
+            $result['subcategories'] = $this->subcategories;
         }
 
         return $result;

--- a/app/Models/Transformers/Item.php
+++ b/app/Models/Transformers/Item.php
@@ -26,9 +26,9 @@ class Item extends Transformer
         $item = [
             'id' => $this->hash->item()->encode($this->item['item_id']),
             'description' => $this->item['item_description'],
-            'total' => number_format((float) $this->item['item_total'], 2),
+            'total' => (float) $this->item['item_total'],
             'percentage' => $this->item['item_percentage'],
-            'actualised_total' => number_format((float) $this->item['item_actualised_total'], 2),
+            'actualised_total' => (float) $this->item['item_actualised_total'],
             'effective_date' => $this->item['item_effective_date'],
             'created' => $this->item['item_created_at']
         ];

--- a/app/Models/Transformers/Item.php
+++ b/app/Models/Transformers/Item.php
@@ -26,9 +26,9 @@ class Item extends Transformer
         $item = [
             'id' => $this->hash->item()->encode($this->item['item_id']),
             'description' => $this->item['item_description'],
-            'total' => (float) $this->item['item_total'],
+            'total' => number_format((float) $this->item['item_total'],2),
             'percentage' => $this->item['item_percentage'],
-            'actualised_total' => (float) $this->item['item_actualised_total'],
+            'actualised_total' => number_format((float) $this->item['item_actualised_total'], 2),
             'effective_date' => $this->item['item_effective_date'],
             'created' => $this->item['item_created_at']
         ];

--- a/app/Models/Transformers/ItemCategorySummary.php
+++ b/app/Models/Transformers/ItemCategorySummary.php
@@ -35,7 +35,7 @@ class ItemCategorySummary extends Transformer
             'id' => $this->hash->category()->encode($this->data_to_transform['id']),
             'name' => $this->data_to_transform['name'],
             'description' => $this->data_to_transform['description'],
-            'total' => (float) $this->data_to_transform['total']
+            'total' => number_format((float) $this->data_to_transform['total'], 2)
         ];
     }
 }

--- a/app/Models/Transformers/ItemCategorySummary.php
+++ b/app/Models/Transformers/ItemCategorySummary.php
@@ -33,6 +33,7 @@ class ItemCategorySummary extends Transformer
         return [
             'id' => $this->hash->category()->encode($this->category_summary->id),
             'name' => $this->category_summary->name,
+            'description' => $this->category_summary->description,
             'total' => number_format((float) $this->category_summary->total, 2, '.', '')
         ];
     }

--- a/app/Models/Transformers/ItemCategorySummary.php
+++ b/app/Models/Transformers/ItemCategorySummary.php
@@ -3,10 +3,11 @@ declare(strict_types=1);
 
 namespace App\Models\Transformers;
 
-use App\Models\Item as ItemModel;
-
 /**
  * Transform the data returns from Eloquent into the format we want for the API
+ *
+ * This is an updated version of the transformers, the other transformers need to
+ * be updated to operate on an array rather than collections
  *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
@@ -14,27 +15,27 @@ use App\Models\Item as ItemModel;
  */
 class ItemCategorySummary extends Transformer
 {
-    private $category_summary;
+    private $data_to_transform;
 
     /**
      * ResourceType constructor.
      *
-     * @param ItemModel $category_summary
+     * @param array $data_to_transform
      */
-    public function __construct(ItemModel $category_summary)
+    public function __construct(array $data_to_transform)
     {
         parent::__construct();
 
-        $this->category_summary = $category_summary;
+        $this->data_to_transform = $data_to_transform;
     }
 
     public function toArray(): array
     {
         return [
-            'id' => $this->hash->category()->encode($this->category_summary->id),
-            'name' => $this->category_summary->name,
-            'description' => $this->category_summary->description,
-            'total' => number_format((float) $this->category_summary->total, 2, '.', '')
+            'id' => $this->hash->category()->encode($this->data_to_transform['id']),
+            'name' => $this->data_to_transform['name'],
+            'description' => $this->data_to_transform['description'],
+            'total' => (float) $this->data_to_transform['total']
         ];
     }
 }

--- a/app/Models/Transformers/ItemMonthSummary.php
+++ b/app/Models/Transformers/ItemMonthSummary.php
@@ -33,7 +33,7 @@ class ItemMonthSummary extends Transformer
         return [
             'id' => $this->month_summary->month,
             'month' => date("F", mktime(0, 0, 0, $this->month_summary->month, 1)),
-            'total' => number_format((float) $this->month_summary->total, 2, '.', '')
+            'total' => (float) $this->month_summary->total
         ];
     }
 }

--- a/app/Models/Transformers/ItemMonthSummary.php
+++ b/app/Models/Transformers/ItemMonthSummary.php
@@ -33,7 +33,7 @@ class ItemMonthSummary extends Transformer
         return [
             'id' => $this->month_summary->month,
             'month' => date("F", mktime(0, 0, 0, $this->month_summary->month, 1)),
-            'total' => (float) $this->month_summary->total
+            'total' => number_format((float) $this->month_summary->total, 2)
         ];
     }
 }

--- a/app/Models/Transformers/ItemSubCategorySummary.php
+++ b/app/Models/Transformers/ItemSubCategorySummary.php
@@ -37,7 +37,7 @@ class ItemSubCategorySummary extends Transformer
             'id' => $this->hash->subCategory()->encode($this->data_to_transform['id']),
             'name' => $this->data_to_transform['name'],
             'description' => $this->data_to_transform['description'],
-            'total' => (float) $this->data_to_transform['total']
+            'total' => number_format((float) $this->data_to_transform['total'],2)
         ];
     }
 }

--- a/app/Models/Transformers/ItemSubCategorySummary.php
+++ b/app/Models/Transformers/ItemSubCategorySummary.php
@@ -8,32 +8,36 @@ use App\Models\Item as ItemModel;
 /**
  * Transform the data returns from Eloquent into the format we want for the API
  *
+ * This is an updated version of the transformers, the other transformers need to
+ * be updated to operate on an array rather than collections
+ *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
 class ItemSubCategorySummary extends Transformer
 {
-    private $sub_category_summary;
+    private $data_to_transform;
 
     /**
      * ResourceType constructor.
      *
-     * @param ItemModel $sub_category_summary
+     * @param array $data_to_transform
      */
-    public function __construct(ItemModel $sub_category_summary)
+    public function __construct(array $data_to_transform)
     {
         parent::__construct();
 
-        $this->sub_category_summary = $sub_category_summary;
+        $this->data_to_transform = $data_to_transform;
     }
 
     public function toArray(): array
     {
         return [
-            'id' => $this->hash->subCategory()->encode($this->sub_category_summary->id),
-            'name' => $this->sub_category_summary->name,
-            'total' => number_format((float) $this->sub_category_summary->total, 2, '.', '')
+            'id' => $this->hash->subCategory()->encode($this->data_to_transform['id']),
+            'name' => $this->data_to_transform['name'],
+            'description' => $this->data_to_transform['description'],
+            'total' => (float) $this->data_to_transform['total']
         ];
     }
 }

--- a/app/Models/Transformers/ItemYearSummary.php
+++ b/app/Models/Transformers/ItemYearSummary.php
@@ -33,7 +33,7 @@ class ItemYearSummary extends Transformer
         return [
             'id' => $this->year_summary->year,
             'year' => $this->year_summary->year,
-            'total' => (float) $this->year_summary->total
+            'total' => number_format((float) $this->year_summary->total, 2)
         ];
     }
 }

--- a/app/Models/Transformers/ItemYearSummary.php
+++ b/app/Models/Transformers/ItemYearSummary.php
@@ -33,7 +33,7 @@ class ItemYearSummary extends Transformer
         return [
             'id' => $this->year_summary->year,
             'year' => $this->year_summary->year,
-            'total' => number_format((float) $this->year_summary->total, 2, '.', '')
+            'total' => (float) $this->year_summary->total
         ];
     }
 }

--- a/app/Models/Transformers/ResourceTypeItem.php
+++ b/app/Models/Transformers/ResourceTypeItem.php
@@ -37,9 +37,9 @@ class ResourceTypeItem extends Transformer
         $item = [
             'id' => $this->hash->item()->encode($this->item['item_id']),
             'description' => $this->item['item_description'],
-            'total' => number_format((float) $this->item['item_total'], 2),
+            'total' => (float) $this->item['item_total'],
             'percentage' => (int) $this->item['item_percentage'],
-            'actualised_total' => number_format((float) $this->item['item_actualised_total'], 2),
+            'actualised_total' => (float) $this->item['item_actualised_total'],
             'effective_date' => $this->item['item_effective_date'],
             'created' => $this->item['item_created_at'],
             'resource' => [

--- a/app/Models/Transformers/ResourceTypeItem.php
+++ b/app/Models/Transformers/ResourceTypeItem.php
@@ -37,9 +37,9 @@ class ResourceTypeItem extends Transformer
         $item = [
             'id' => $this->hash->item()->encode($this->item['item_id']),
             'description' => $this->item['item_description'],
-            'total' => (float) $this->item['item_total'],
+            'total' => number_format((float) $this->item['item_total'], 2),
             'percentage' => (int) $this->item['item_percentage'],
-            'actualised_total' => (float) $this->item['item_actualised_total'],
+            'actualised_total' => number_format((float) $this->item['item_actualised_total'], 2),
             'effective_date' => $this->item['item_effective_date'],
             'created' => $this->item['item_created_at'],
             'resource' => [

--- a/app/Models/Transformers/ResourceTypeItemCategorySummary.php
+++ b/app/Models/Transformers/ResourceTypeItemCategorySummary.php
@@ -34,7 +34,8 @@ class ResourceTypeItemCategorySummary extends Transformer
         return [
             'id' => $this->hash->category()->encode($this->data_to_transform['id']),
             'name' => $this->data_to_transform['name'],
-            'total' => number_format((float) $this->data_to_transform['total'], 2, '.', '')
+            'description' => $this->data_to_transform['description'],
+            'total' => (float) $this->data_to_transform['total']
         ];
     }
 }

--- a/app/Models/Transformers/ResourceTypeItemCategorySummary.php
+++ b/app/Models/Transformers/ResourceTypeItemCategorySummary.php
@@ -35,7 +35,7 @@ class ResourceTypeItemCategorySummary extends Transformer
             'id' => $this->hash->category()->encode($this->data_to_transform['id']),
             'name' => $this->data_to_transform['name'],
             'description' => $this->data_to_transform['description'],
-            'total' => (float) $this->data_to_transform['total']
+            'total' => number_format((float) $this->data_to_transform['total'], 2)
         ];
     }
 }

--- a/app/Models/Transformers/ResourceTypeItemMonthSummary.php
+++ b/app/Models/Transformers/ResourceTypeItemMonthSummary.php
@@ -35,7 +35,7 @@ class ResourceTypeItemMonthSummary extends Transformer
         return [
             'id' => $this->data_to_transform['month'],
             'month' => date("F", mktime(0, 0, 0, $this->data_to_transform['month'], 1)),
-            'total' => number_format((float)$this->data_to_transform['total'], 2, '.', '')
+            'total' => (float)$this->data_to_transform['total']
         ];
     }
 }

--- a/app/Models/Transformers/ResourceTypeItemResourceSummary.php
+++ b/app/Models/Transformers/ResourceTypeItemResourceSummary.php
@@ -34,7 +34,7 @@ class ResourceTypeItemResourceSummary extends Transformer
         return [
             'id' => $this->hash->resource()->encode($this->data_to_transform['id']),
             'name' => $this->data_to_transform['name'],
-            'total' => number_format((float) $this->data_to_transform['total'], 2, '.', '')
+            'total' => (float) $this->data_to_transform['total']
         ];
     }
 }

--- a/app/Models/Transformers/ResourceTypeItemResourceSummary.php
+++ b/app/Models/Transformers/ResourceTypeItemResourceSummary.php
@@ -34,7 +34,7 @@ class ResourceTypeItemResourceSummary extends Transformer
         return [
             'id' => $this->hash->resource()->encode($this->data_to_transform['id']),
             'name' => $this->data_to_transform['name'],
-            'total' => (float) $this->data_to_transform['total']
+            'total' => number_format((float) $this->data_to_transform['total'], 2)
         ];
     }
 }

--- a/app/Models/Transformers/ResourceTypeItemSubcategorySummary.php
+++ b/app/Models/Transformers/ResourceTypeItemSubcategorySummary.php
@@ -35,7 +35,7 @@ class ResourceTypeItemSubcategorySummary extends Transformer
             'id' => $this->hash->subCategory()->encode($this->data_to_transform['id']),
             'name' => $this->data_to_transform['name'],
             'description' => $this->data_to_transform['description'],
-            'total' => (float) $this->data_to_transform['total']
+            'total' => number_format((float) $this->data_to_transform['total'], 2)
         ];
     }
 }

--- a/app/Models/Transformers/ResourceTypeItemSubcategorySummary.php
+++ b/app/Models/Transformers/ResourceTypeItemSubcategorySummary.php
@@ -34,7 +34,8 @@ class ResourceTypeItemSubcategorySummary extends Transformer
         return [
             'id' => $this->hash->subCategory()->encode($this->data_to_transform['id']),
             'name' => $this->data_to_transform['name'],
-            'total' => number_format((float) $this->data_to_transform['total'], 2, '.', '')
+            'description' => $this->data_to_transform['description'],
+            'total' => (float) $this->data_to_transform['total']
         ];
     }
 }

--- a/app/Models/Transformers/ResourceTypeItemYearSummary.php
+++ b/app/Models/Transformers/ResourceTypeItemYearSummary.php
@@ -35,7 +35,7 @@ class ResourceTypeItemYearSummary extends Transformer
         return [
             'id' => $this->year_summary['year'],
             'year' => $this->year_summary['year'],
-            'total' => number_format((float)$this->year_summary['total'], 2, '.', '')
+            'total' => (float)$this->year_summary['total']
         ];
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,8 +23,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        if ($this->app->environment() !== 'production') {
-            $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
-        }
+        //
     }
 }

--- a/app/Utilities/Hash.php
+++ b/app/Utilities/Hash.php
@@ -32,7 +32,7 @@ class Hash
         $this->min_length = Config::get('api.hashids.min_length');
 
         $this->hashers['category'] = new Hashids(Config::get('api.hashids.category'), $this->min_length);
-        $this->hashers['sub_category'] = new Hashids(Config::get('api.hashids.sub_category'), $this->min_length);
+        $this->hashers['subcategory'] = new Hashids(Config::get('api.hashids.sub_category'), $this->min_length);
         $this->hashers['resource_type'] = new Hashids(Config::get('api.hashids.resource_type'), $this->min_length);
         $this->hashers['resource'] = new Hashids(Config::get('api.hashids.resource'), $this->min_length);
         $this->hashers['item'] = new Hashids(Config::get('api.hashids.item'), $this->min_length);
@@ -92,7 +92,7 @@ class Hash
      */
     public function subCategory(): Hashids
     {
-        return $this->hashers['sub_category'];
+        return $this->hashers['subcategory'];
     }
 
     /**

--- a/app/Validators/Request/Fields/Category.php
+++ b/app/Validators/Request/Fields/Category.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Request\Validators;
+namespace App\Validators\Request\Fields;
 
-use App\Http\Parameters\Request\Validators\Validator as BaseValidator;
+use App\Validators\Request\Fields\Validator as BaseValidator;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;

--- a/app/Validators/Request/Fields/Item.php
+++ b/app/Validators/Request/Fields/Item.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Request\Validators;
+namespace App\Validators\Request\Fields;
 
-use App\Http\Parameters\Request\Validators\Validator as BaseValidator;
+use App\Validators\Request\Fields\Validator as BaseValidator;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;

--- a/app/Validators/Request/Fields/ItemCategory.php
+++ b/app/Validators/Request/Fields/ItemCategory.php
@@ -1,22 +1,22 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Request\Validators;
+namespace App\Validators\Request\Fields;
 
-use App\Http\Parameters\Request\Validators\Validator as BaseValidator;
+use App\Validators\Request\Fields\Validator as BaseValidator;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 /**
- * Validation helper class for resource types, returns the generated validator objects
+ * Validation helper class for item category, returns the generated validator objects
  *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class ResourceType extends BaseValidator
+class ItemCategory extends BaseValidator
 {
     /**
      * Return the validator object for the create request
@@ -27,15 +27,16 @@ class ResourceType extends BaseValidator
      */
     public function create(Request $request): Validator
     {
-        $messages = [];
-        foreach (Config::get('api.resource-type.validation.POST.messages') as $key => $custom_message) {
-            $messages[$key] = trans($custom_message);
-        };
+        $decode = $this->hash->category()->decode($request->input('category_id'));
+        $category_id = null;
+        if (count($decode) === 1) {
+            $category_id = $decode[0];
+        }
 
         return ValidatorFacade::make(
-            $request->all(),
-            Config::get('api.resource-type.validation.POST.fields'),
-            $this->translateMessages('api.resource-type.validation.POST.messages')
+            ['category_id' => $category_id],
+            Config::get('api.item-category.validation.POST.fields'),
+            $this->translateMessages('api.item-category.validation.POST.messages')
         );
     }
 }

--- a/app/Validators/Request/Fields/ItemSubCategory.php
+++ b/app/Validators/Request/Fields/ItemSubCategory.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Request\Validators;
+namespace App\Validators\Request\Fields;
 
-use App\Http\Parameters\Request\Validators\Validator as BaseValidator;
+use App\Validators\Request\Fields\Validator as BaseValidator;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;

--- a/app/Validators/Request/Fields/RequestErrorLog.php
+++ b/app/Validators/Request/Fields/RequestErrorLog.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Request\Validators;
+namespace App\Validators\Request\Fields;
 
-use App\Http\Parameters\Request\Validators\Validator as BaseValidator;
+use App\Validators\Request\Fields\Validator as BaseValidator;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;

--- a/app/Validators/Request/Fields/Resource.php
+++ b/app/Validators/Request/Fields/Resource.php
@@ -1,41 +1,41 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Request\Validators;
+namespace App\Validators\Request\Fields;
 
-use App\Http\Parameters\Request\Validators\Validator as BaseValidator;
+use App\Validators\Request\Fields\Validator as BaseValidator;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 /**
- * Validation helper class for sub categories, returns the generated validator objects
+ * Validation helper class for resources, returns the generated validator objects
  *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class SubCategory extends BaseValidator
+class Resource extends BaseValidator
 {
     /**
-     * Create the validation rules for the create (POST) request
+     * Create the validation rules for the create request
      *
-     * @param integer $category_id
+     * @param integer $resource_type_id
      *
      * @return array
      */
-    private function createRules(int $category_id): array
+    private function createRules(int $resource_type_id): array
     {
         return array_merge(
             [
                 'name' => [
                     'required',
                     'string',
-                    'unique:sub_category,name,null,id,category_id,' . $category_id
+                    'unique:resource,name,null,id,resource_type_id,' . $resource_type_id
                 ],
             ],
-            Config::get('api.subcategory.validation.POST.fields')
+            Config::get('api.resource.validation.POST.fields')
         );
     }
 
@@ -43,16 +43,16 @@ class SubCategory extends BaseValidator
      * Return the validator object for the create request
      *
      * @param Request $request
-     * @param integer category_id
+     * @param integer $resource_type_id
      *
      * @return Validator
      */
-    public function create(Request $request, int $category_id): Validator
+    public function create(Request $request, int $resource_type_id): Validator
     {
         return ValidatorFacade::make(
             $request->all(),
-            self::createRules($category_id),
-            $this->translateMessages('api.subcategory.validation.POST.messages')
+            self::createRules($resource_type_id),
+            $this->translateMessages('api.resource.validation.POST.messages')
         );
     }
 }

--- a/app/Validators/Request/Fields/ResourceType.php
+++ b/app/Validators/Request/Fields/ResourceType.php
@@ -1,22 +1,22 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Request\Validators;
+namespace App\Validators\Request\Fields;
 
-use App\Http\Parameters\Request\Validators\Validator as BaseValidator;
+use App\Validators\Request\Fields\Validator as BaseValidator;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 /**
- * Validation helper class for item category, returns the generated validator objects
+ * Validation helper class for resource types, returns the generated validator objects
  *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class ItemCategory extends BaseValidator
+class ResourceType extends BaseValidator
 {
     /**
      * Return the validator object for the create request
@@ -27,16 +27,15 @@ class ItemCategory extends BaseValidator
      */
     public function create(Request $request): Validator
     {
-        $decode = $this->hash->category()->decode($request->input('category_id'));
-        $category_id = null;
-        if (count($decode) === 1) {
-            $category_id = $decode[0];
-        }
+        $messages = [];
+        foreach (Config::get('api.resource-type.validation.POST.messages') as $key => $custom_message) {
+            $messages[$key] = trans($custom_message);
+        };
 
         return ValidatorFacade::make(
-            ['category_id' => $category_id],
-            Config::get('api.item-category.validation.POST.fields'),
-            $this->translateMessages('api.item-category.validation.POST.messages')
+            $request->all(),
+            Config::get('api.resource-type.validation.POST.fields'),
+            $this->translateMessages('api.resource-type.validation.POST.messages')
         );
     }
 }

--- a/app/Validators/Request/Fields/SubCategory.php
+++ b/app/Validators/Request/Fields/SubCategory.php
@@ -1,41 +1,41 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Request\Validators;
+namespace App\Validators\Request\Fields;
 
-use App\Http\Parameters\Request\Validators\Validator as BaseValidator;
+use App\Validators\Request\Fields\Validator as BaseValidator;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Validator as ValidatorFacade;
 
 /**
- * Validation helper class for resources, returns the generated validator objects
+ * Validation helper class for sub categories, returns the generated validator objects
  *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class Resource extends BaseValidator
+class SubCategory extends BaseValidator
 {
     /**
-     * Create the validation rules for the create request
+     * Create the validation rules for the create (POST) request
      *
-     * @param integer $resource_type_id
+     * @param integer $category_id
      *
      * @return array
      */
-    private function createRules(int $resource_type_id): array
+    private function createRules(int $category_id): array
     {
         return array_merge(
             [
                 'name' => [
                     'required',
                     'string',
-                    'unique:resource,name,null,id,resource_type_id,' . $resource_type_id
+                    'unique:sub_category,name,null,id,category_id,' . $category_id
                 ],
             ],
-            Config::get('api.resource.validation.POST.fields')
+            Config::get('api.subcategory.validation.POST.fields')
         );
     }
 
@@ -43,16 +43,16 @@ class Resource extends BaseValidator
      * Return the validator object for the create request
      *
      * @param Request $request
-     * @param integer $resource_type_id
+     * @param integer category_id
      *
      * @return Validator
      */
-    public function create(Request $request, int $resource_type_id): Validator
+    public function create(Request $request, int $category_id): Validator
     {
         return ValidatorFacade::make(
             $request->all(),
-            self::createRules($resource_type_id),
-            $this->translateMessages('api.resource.validation.POST.messages')
+            self::createRules($category_id),
+            $this->translateMessages('api.subcategory.validation.POST.messages')
         );
     }
 }

--- a/app/Validators/Request/Fields/Validator.php
+++ b/app/Validators/Request/Fields/Validator.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Request\Validators;
+namespace App\Validators\Request\Fields;
 
 use App\Utilities\Hash;
 use Illuminate\Support\Facades\Config;

--- a/app/Validators/Request/Parameters.php
+++ b/app/Validators/Request/Parameters.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters;
+namespace App\Validators\Request;
 
 use App\Models\Category;
 use App\Models\ResourceType;
@@ -9,23 +9,23 @@ use App\Models\SubCategory;
 use App\Utilities\General;
 
 /**
- * Fetch any GET parameters attached to the end of the URI and validate
+ * Fetch any GET parameters attached to the URI and validate them, silently
+ * ignore any invalid parameters
  *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class Get
+class Parameters
 {
     private static $parameters = [];
 
     /**
-     * Fetch GET parameters from the URI and check to see if they are valid for
-     * the request
+     * Fetch any GET parameters from the URI and alter the type if necessary
      *
      * @param array $parameter_names
      */
-    private static function fetch(array $parameter_names = [])
+    private static function find(array $parameter_names = [])
     {
         $request_parameters = request()->all();
         self::$parameters = [];
@@ -198,9 +198,9 @@ class Get
      *
      * @return array
      */
-    public static function parameters(array $parameter_names = []): array
+    public static function fetch(array $parameter_names = []): array
     {
-        self::fetch($parameter_names);
+        self::find($parameter_names);
         self::validate();
 
         return self::$parameters;

--- a/app/Validators/Request/Parameters.php
+++ b/app/Validators/Request/Parameters.php
@@ -147,14 +147,6 @@ class Parameters
                     }
                     break;
 
-                case 'sort':
-                    if (array_key_exists($key, self::$parameters) === true) {
-                        if (strlen(self::$parameters[$key]) < 1) {
-                            unset(self::$parameters[$key]);
-                        }
-                    }
-                    break;
-
                 case 'year':
                     if (array_key_exists($key, self::$parameters) === true) {
                         if (intval(self::$parameters[$key]) < 2013 ||

--- a/app/Validators/Request/Route.php
+++ b/app/Validators/Request/Route.php
@@ -1,15 +1,15 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Route;
+namespace App\Validators\Request;
 
-use App\Http\Parameters\Route\Validators\Category;
-use App\Http\Parameters\Route\Validators\Item;
-use App\Http\Parameters\Route\Validators\ItemCategory;
-use App\Http\Parameters\Route\Validators\ItemSubCategory;
-use App\Http\Parameters\Route\Validators\Resource;
-use App\Http\Parameters\Route\Validators\ResourceType;
-use App\Http\Parameters\Route\Validators\SubCategory;
+use App\Validators\Request\Routes\Category;
+use App\Validators\Request\Routes\Item;
+use App\Validators\Request\Routes\ItemCategory;
+use App\Validators\Request\Routes\ItemSubCategory;
+use App\Validators\Request\Routes\Resource;
+use App\Validators\Request\Routes\ResourceType;
+use App\Validators\Request\Routes\SubCategory;
 use App\Utilities\Response as UtilityResponse;
 
 /**
@@ -19,7 +19,7 @@ use App\Utilities\Response as UtilityResponse;
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class Validate
+class Route
 {
     static public function categoryRoute($category_id)
     {

--- a/app/Validators/Request/Routes/Category.php
+++ b/app/Validators/Request/Routes/Category.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Route\Validators;
+namespace App\Validators\Request\Routes;
 
 use App\Models\Category as CategoryModel;
 

--- a/app/Validators/Request/Routes/Item.php
+++ b/app/Validators/Request/Routes/Item.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Route\Validators;
+namespace App\Validators\Request\Routes;
 
 use App\Models\Item as ItemModel;
 

--- a/app/Validators/Request/Routes/ItemCategory.php
+++ b/app/Validators/Request/Routes/ItemCategory.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Route\Validators;
+namespace App\Validators\Request\Routes;
 
 use App\Models\ItemCategory as ItemCategoryModel;
 

--- a/app/Validators/Request/Routes/ItemSubCategory.php
+++ b/app/Validators/Request/Routes/ItemSubCategory.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Route\Validators;
+namespace App\Validators\Request\Routes;
 
 use App\Models\ItemSubCategory as ItemSubCategoryModel;
 

--- a/app/Validators/Request/Routes/Resource.php
+++ b/app/Validators/Request/Routes/Resource.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Route\Validators;
+namespace App\Validators\Request\Routes;
 
 use App\Models\Resource as ResourceModel;
 

--- a/app/Validators/Request/Routes/ResourceType.php
+++ b/app/Validators/Request/Routes/ResourceType.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Route\Validators;
+namespace App\Validators\Request\Routes;
 
 use App\Models\ResourceType as ResourceTypeModel;
 

--- a/app/Validators/Request/Routes/SubCategory.php
+++ b/app/Validators/Request/Routes/SubCategory.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Http\Parameters\Route\Validators;
+namespace App\Validators\Request\Routes;
 
 use App\Models\Category as CategoryModel;
 use App\Models\SubCategory as SubCategoryModel;

--- a/app/Validators/Request/SearchParameters.php
+++ b/app/Validators/Request/SearchParameters.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Validators\Request;
+
+/**
+ * Fetch and validate any search parameters
+ *
+ * @author Dean Blackborough <dean@g3d-development.com>
+ * @copyright Dean Blackborough 2018-2019
+ * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
+ */
+class SearchParameters
+{
+    private static $searchable_fields = [];
+
+    /**
+     * Check the URI for the search parameter, if the format is valid split the
+     * string and set a search array of search terms and search fields
+     */
+    private static function find()
+    {
+        $search_string = request()->get('search');
+
+        if (is_string($search_string) && strlen($search_string) > 3) {
+            $search_parameters = explode('|', $search_string);
+
+            foreach ($search_parameters as $search) {
+                $search = explode(':', $search);
+
+                if (
+                    is_array($search) === true &&
+                    count($search) === 2
+                ) {
+                    self::$searchable_fields[$search[0]] = $search[1];
+                }
+            }
+        }
+    }
+
+    /**
+     * Validate the supplied search parameters array, if they aren't in the
+     * expected array they are silently rejected
+     *
+     * @param array $searchable_fields
+     */
+    private static function validate(array $searchable_fields)
+    {
+        foreach (array_keys(self::$searchable_fields) as $key) {
+            if (in_array($key, $searchable_fields) === false) {
+                unset(self::$searchable_fields[$key]);
+            }
+        }
+    }
+
+    /**
+     * Return all the valid search parameters, check the supplied array against
+     * the set search parameters
+     *
+     * @param array $searchable_fields
+     *
+     * @return array
+     */
+    public static function fetch(array $searchable_fields = []): array
+    {
+        self::find();
+        self::validate($searchable_fields);
+
+        return self::$searchable_fields;
+    }
+}

--- a/app/Validators/Request/SortParameters.php
+++ b/app/Validators/Request/SortParameters.php
@@ -3,9 +3,8 @@ declare(strict_types=1);
 
 namespace App\Validators\Request;
 
-
 /**
- * Validate the sort parameters
+ * Fetch and validate any sort parameters
  *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
@@ -13,5 +12,61 @@ namespace App\Validators\Request;
  */
 class SortParameters
 {
+    private static $sortable_fields = [];
 
+    /**
+     * Check the URI for the sort parameter, if the format is valid split the
+     * string and set a sort array of field direction
+     */
+    private static function find()
+    {
+        $sort_string = request()->get('sort');
+
+        if (is_string($sort_string) && strlen($sort_string) > 3) {
+            $sort_parameters = explode('|', $sort_string);
+
+            foreach ($sort_parameters as $sort) {
+                $sort = explode(':', $sort);
+
+                if (
+                    is_array($sort) === true &&
+                    count($sort) === 2 &&
+                    in_array($sort[1], ['asc', 'desc']) === true
+                ) {
+                    self::$sortable_fields[$sort[0]] = $sort[1];
+                }
+            }
+        }
+    }
+
+    /**
+     * Validate the supplied sort parameters array, if they aren't in the
+     * expected array they are silently rejected
+     *
+     * @param array $sortable_fields
+     */
+    private static function validate(array $sortable_fields)
+    {
+        foreach (array_keys(self::$sortable_fields) as $key) {
+            if (in_array($key, $sortable_fields) === false) {
+                unset(self::$sortable_fields[$key]);
+            }
+        }
+    }
+
+    /**
+     * Return all the valid sort parameters, check the supplied array against
+     * the set sort parameters
+     *
+     * @param array $sortable_fields
+     *
+     * @return array
+     */
+    public static function fetch(array $sortable_fields = []): array
+    {
+        self::find();
+        self::validate($sortable_fields);
+
+        return self::$sortable_fields;
+    }
 }

--- a/app/Validators/Request/SortParameters.php
+++ b/app/Validators/Request/SortParameters.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Validators\Request;
+
+
+/**
+ * Validate the sort parameters
+ *
+ * @author Dean Blackborough <dean@g3d-development.com>
+ * @copyright Dean Blackborough 2018-2019
+ * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
+ */
+class SortParameters
+{
+
+}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "laravel/tinker": "^1.0"
     },
     "require-dev": {
-        "barryvdh/laravel-ide-helper": "^2.4",
         "filp/whoops": "^2.0",
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "0902bde35607c31304e37c3a7500b7f5",
-    "content-hash": "2462eeb01d5719ec043d7e4445968809",
+    "content-hash": "4778410acb4a7343f74780483224b96b",
     "packages": [
         {
             "name": "defuse/php-encryption",
@@ -68,7 +67,7 @@
                 "security",
                 "symmetric key cryptography"
             ],
-            "time": "2018-07-24 23:27:56"
+            "time": "2018-07-24T23:27:56+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -101,7 +100,7 @@
                 "MIT"
             ],
             "description": "implementation of xdg base directory specification for php",
-            "time": "2014-10-24 07:27:01"
+            "time": "2014-10-24T07:27:01+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -168,24 +167,27 @@
                 "singularize",
                 "string"
             ],
-            "time": "2018-01-09 20:05:19"
+            "time": "2018-01-09T20:05:19+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "v1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
-                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/1febd6c3ef84253d7c815bed85fc622ad207a9f8",
+                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5"
             },
             "type": "library",
             "extra": {
@@ -194,8 +196,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Lexer\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -216,35 +218,43 @@
                     "email": "schmittjoh@gmail.com"
                 }
             ],
-            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
-            "homepage": "http://www.doctrine-project.org",
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
             "keywords": [
+                "annotations",
+                "docblock",
                 "lexer",
-                "parser"
+                "parser",
+                "php"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2019-06-08T11:03:04+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
-            "version": "v2.2.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dragonmantank/cron-expression.git",
-                "reference": "92a2c3768d50e21a1f26a53cb795ce72806266c5"
+                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/92a2c3768d50e21a1f26a53cb795ce72806266c5",
-                "reference": "92a2c3768d50e21a1f26a53cb795ce72806266c5",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/72b6fbf76adb3cf5bc0db68559b33d41219aba27",
+                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.4"
+                "phpunit/phpunit": "^6.4|^7.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Cron\\": "src/Cron/"
@@ -271,20 +281,20 @@
                 "cron",
                 "schedule"
             ],
-            "time": "2018-06-06 03:12:17"
+            "time": "2019-03-31T00:38:28+00:00"
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.7",
+            "version": "2.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "709f21f92707308cdf8f9bcfa1af4cb26586521e"
+                "reference": "c26463ff9241f27907112fbcd0c86fa670cfef98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/709f21f92707308cdf8f9bcfa1af4cb26586521e",
-                "reference": "709f21f92707308cdf8f9bcfa1af4cb26586521e",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/c26463ff9241f27907112fbcd0c86fa670cfef98",
+                "reference": "c26463ff9241f27907112fbcd0c86fa670cfef98",
                 "shasum": ""
             },
             "require": {
@@ -328,20 +338,20 @@
                 "validation",
                 "validator"
             ],
-            "time": "2018-12-04 22:38:24"
+            "time": "2019-05-16T22:02:54+00:00"
         },
         {
             "name": "erusev/parsedown",
-            "version": "v1.7.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/erusev/parsedown.git",
-                "reference": "d60bcdc46978357759ecb13cb4b078da783f8faf"
+                "reference": "6d893938171a817f4e9bc9e86f2da1e370b7bcd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/d60bcdc46978357759ecb13cb4b078da783f8faf",
-                "reference": "d60bcdc46978357759ecb13cb4b078da783f8faf",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/6d893938171a817f4e9bc9e86f2da1e370b7bcd7",
+                "reference": "6d893938171a817f4e9bc9e86f2da1e370b7bcd7",
                 "shasum": ""
             },
             "require": {
@@ -374,7 +384,7 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2019-03-17 17:19:46"
+            "time": "2019-03-17T18:48:37+00:00"
         },
         {
             "name": "fideloper/proxy",
@@ -428,7 +438,7 @@
                 "proxy",
                 "trusted proxy"
             ],
-            "time": "2019-01-10 14:06:47"
+            "time": "2019-01-10T14:06:47+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -474,7 +484,7 @@
             ],
             "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
             "homepage": "https://github.com/firebase/php-jwt",
-            "time": "2017-06-27 22:17:23"
+            "time": "2017-06-27T22:17:23+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -539,7 +549,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2018-04-22 15:46:56"
+            "time": "2018-04-22T15:46:56+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -590,7 +600,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-12-20 10:07:11"
+            "time": "2016-12-20T10:07:11+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -657,7 +667,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2018-12-04 20:46:45"
+            "time": "2018-12-04T20:46:45+00:00"
         },
         {
             "name": "hashids/hashids",
@@ -723,7 +733,7 @@
                 "obfuscate",
                 "youtube"
             ],
-            "time": "2018-03-12 16:30:09"
+            "time": "2018-03-12T16:30:09+00:00"
         },
         {
             "name": "jakub-onderka/php-console-color",
@@ -765,7 +775,7 @@
                     "email": "jakub.onderka@gmail.com"
                 }
             ],
-            "time": "2018-09-29 17:23:10"
+            "time": "2018-09-29T17:23:10+00:00"
         },
         {
             "name": "jakub-onderka/php-console-highlighter",
@@ -811,7 +821,52 @@
                 }
             ],
             "description": "Highlight PHP code in terminal",
-            "time": "2018-09-29 18:48:56"
+            "time": "2018-09-29T18:48:56+00:00"
+        },
+        {
+            "name": "kylekatarnls/update-helper",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kylekatarnls/update-helper.git",
+                "reference": "b34a46d7f5ec1795b4a15ac9d46b884377262df9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kylekatarnls/update-helper/zipball/b34a46d7f5ec1795b4a15ac9d46b884377262df9",
+                "reference": "b34a46d7f5ec1795b4a15ac9d46b884377262df9",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "dev-master",
+                "composer/composer": "^2.0.x-dev",
+                "phpunit/phpunit": ">=4.8.35 <6.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "UpdateHelper\\ComposerPlugin"
+            },
+            "autoload": {
+                "psr-0": {
+                    "UpdateHelper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyle",
+                    "email": "kylekatarnls@gmail.com"
+                }
+            ],
+            "description": "Update helper",
+            "time": "2019-06-05T08:34:23+00:00"
         },
         {
             "name": "laravel/framework",
@@ -957,7 +1012,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2019-02-26 15:41:34"
+            "time": "2019-02-26T15:41:34+00:00"
         },
         {
             "name": "laravel/nexmo-notification-channel",
@@ -1014,20 +1069,20 @@
                 "nexmo",
                 "notifications"
             ],
-            "time": "2018-12-04 12:57:08"
+            "time": "2018-12-04T12:57:08+00:00"
         },
         {
             "name": "laravel/passport",
-            "version": "v7.2.2",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/passport.git",
-                "reference": "c0c3fca80d8f5af90dcbf65e62bdd1abee9ac25d"
+                "reference": "758e143052f0a353df8dff9349f84601579e457d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/passport/zipball/c0c3fca80d8f5af90dcbf65e62bdd1abee9ac25d",
-                "reference": "c0c3fca80d8f5af90dcbf65e62bdd1abee9ac25d",
+                "url": "https://api.github.com/repos/laravel/passport/zipball/758e143052f0a353df8dff9349f84601579e457d",
+                "reference": "758e143052f0a353df8dff9349f84601579e457d",
                 "shasum": ""
             },
             "require": {
@@ -1084,7 +1139,7 @@
                 "oauth",
                 "passport"
             ],
-            "time": "2019-03-13 14:21:06"
+            "time": "2019-05-28T16:06:20+00:00"
         },
         {
             "name": "laravel/slack-notification-channel",
@@ -1141,7 +1196,7 @@
                 "notifications",
                 "slack"
             ],
-            "time": "2018-12-12 13:12:06"
+            "time": "2018-12-12T13:12:06+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -1204,36 +1259,33 @@
                 "laravel",
                 "psysh"
             ],
-            "time": "2018-10-12 19:39:35"
+            "time": "2018-10-12T19:39:35+00:00"
         },
         {
             "name": "lcobucci/jwt",
-            "version": "3.2.5",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "82be04b4753f8b7693b62852b7eab30f97524f9b"
+                "reference": "a11ec5f4b4d75d1fcd04e133dede4c317aac9e18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/82be04b4753f8b7693b62852b7eab30f97524f9b",
-                "reference": "82be04b4753f8b7693b62852b7eab30f97524f9b",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/a11ec5f4b4d75d1fcd04e133dede4c317aac9e18",
+                "reference": "a11ec5f4b4d75d1fcd04e133dede4c317aac9e18",
                 "shasum": ""
             },
             "require": {
+                "ext-mbstring": "*",
                 "ext-openssl": "*",
-                "php": ">=5.5"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "mdanter/ecc": "~0.3.1",
                 "mikey179/vfsstream": "~1.5",
                 "phpmd/phpmd": "~2.2",
                 "phpunit/php-invoker": "~1.1",
-                "phpunit/phpunit": "~4.5",
+                "phpunit/phpunit": "^5.7 || ^7.3",
                 "squizlabs/php_codesniffer": "~2.3"
-            },
-            "suggest": {
-                "mdanter/ecc": "Required to use Elliptic Curves based algorithms."
             },
             "type": "library",
             "extra": {
@@ -1262,7 +1314,7 @@
                 "JWS",
                 "jwt"
             ],
-            "time": "2018-11-11 12:22:26"
+            "time": "2019-05-24T18:30:49+00:00"
         },
         {
             "name": "league/event",
@@ -1312,20 +1364,20 @@
                 "event",
                 "listener"
             ],
-            "time": "2018-11-26 11:52:41"
+            "time": "2018-11-26T11:52:41+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.50",
+            "version": "1.0.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "dab4e7624efa543a943be978008f439c333f2249"
+                "reference": "c5a5097156387970e6f0ccfcdf03f752856f3391"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/dab4e7624efa543a943be978008f439c333f2249",
-                "reference": "dab4e7624efa543a943be978008f439c333f2249",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/c5a5097156387970e6f0ccfcdf03f752856f3391",
+                "reference": "c5a5097156387970e6f0ccfcdf03f752856f3391",
                 "shasum": ""
             },
             "require": {
@@ -1396,20 +1448,20 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2019-02-01 08:50:36"
+            "time": "2019-05-20T20:21:14+00:00"
         },
         {
             "name": "league/oauth2-server",
-            "version": "7.3.2",
+            "version": "7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/oauth2-server.git",
-                "reference": "b71f382cd76e3f6905dfc53ef8148b3eebe1fd41"
+                "reference": "2eb1cf79e59d807d89c256e7ac5e2bf8bdbd4acf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/b71f382cd76e3f6905dfc53ef8148b3eebe1fd41",
-                "reference": "b71f382cd76e3f6905dfc53ef8148b3eebe1fd41",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/2eb1cf79e59d807d89c256e7ac5e2bf8bdbd4acf",
+                "reference": "2eb1cf79e59d807d89c256e7ac5e2bf8bdbd4acf",
                 "shasum": ""
             },
             "require": {
@@ -1473,7 +1525,7 @@
                 "secure",
                 "server"
             ],
-            "time": "2018-11-21 21:42:43"
+            "time": "2019-05-05T09:22:01+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1551,35 +1603,38 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2018-11-05 09:00:11"
+            "time": "2018-11-05T09:00:11+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "1.36.2",
+            "version": "1.38.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "cd324b98bc30290f233dd0e75e6ce49f7ab2a6c9"
+                "reference": "8dd4172bfe1784952c4d58c4db725d183b1c23ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/cd324b98bc30290f233dd0e75e6ce49f7ab2a6c9",
-                "reference": "cd324b98bc30290f233dd0e75e6ce49f7ab2a6c9",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/8dd4172bfe1784952c4d58c4db725d183b1c23ad",
+                "reference": "8dd4172bfe1784952c4d58c4db725d183b1c23ad",
                 "shasum": ""
             },
             "require": {
+                "kylekatarnls/update-helper": "^1.1",
                 "php": ">=5.3.9",
                 "symfony/translation": "~2.6 || ~3.0 || ~4.0"
             },
             "require-dev": {
+                "composer/composer": "^1.2",
+                "friendsofphp/php-cs-fixer": "~2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
-            "suggest": {
-                "friendsofphp/php-cs-fixer": "Needed for the `composer phpcs` command. Allow to automatically fix code style.",
-                "phpstan/phpstan": "Needed for the `composer phpstan` command. Allow to detect potential errors."
-            },
+            "bin": [
+                "bin/upgrade-carbon"
+            ],
             "type": "library",
             "extra": {
+                "update-helper": "Carbon\\Upgrade",
                 "laravel": {
                     "providers": [
                         "Carbon\\Laravel\\ServiceProvider"
@@ -1609,20 +1664,20 @@
                 "datetime",
                 "time"
             ],
-            "time": "2018-12-28 10:07:33"
+            "time": "2019-06-03T15:41:40+00:00"
         },
         {
             "name": "nexmo/client",
-            "version": "1.6.3",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nexmo/nexmo-php.git",
-                "reference": "29f6856b4d918f3565bf56c26bc01dd664988b24"
+                "reference": "182d41a02ebd3e4be147baea45458ccfe2f528c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nexmo/nexmo-php/zipball/29f6856b4d918f3565bf56c26bc01dd664988b24",
-                "reference": "29f6856b4d918f3565bf56c26bc01dd664988b24",
+                "url": "https://api.github.com/repos/Nexmo/nexmo-php/zipball/182d41a02ebd3e4be147baea45458ccfe2f528c4",
+                "reference": "182d41a02ebd3e4be147baea45458ccfe2f528c4",
                 "shasum": ""
             },
             "require": {
@@ -1630,7 +1685,7 @@
                 "php": ">=5.6",
                 "php-http/client-implementation": "^1.0",
                 "php-http/guzzle6-adapter": "^1.0",
-                "zendframework/zend-diactoros": "^1.3"
+                "zendframework/zend-diactoros": "^1.8.4 || ^2.0"
             },
             "require-dev": {
                 "estahn/phpunit-json-assertions": "^1.0.0",
@@ -1657,20 +1712,20 @@
                 }
             ],
             "description": "PHP Client for using Nexmo's API.",
-            "time": "2019-03-15 11:47:11"
+            "time": "2019-05-13T20:27:43+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.2.1",
+            "version": "v4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0"
+                "reference": "1bd73cc04c3843ad8d6b0bfc0956026a151fc420"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/5221f49a608808c1e4d436df32884cbc1b821ac0",
-                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bd73cc04c3843ad8d6b0bfc0956026a151fc420",
+                "reference": "1bd73cc04c3843ad8d6b0bfc0956026a151fc420",
                 "shasum": ""
             },
             "require": {
@@ -1708,20 +1763,20 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-02-16 20:54:15"
+            "time": "2019-05-25T20:07:01+00:00"
         },
         {
             "name": "opis/closure",
-            "version": "3.1.6",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opis/closure.git",
-                "reference": "ccb8e3928c5c8181c76cdd0ed9366c5bcaafd91b"
+                "reference": "f846725591203098246276b2e7b9e8b7814c4965"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opis/closure/zipball/ccb8e3928c5c8181c76cdd0ed9366c5bcaafd91b",
-                "reference": "ccb8e3928c5c8181c76cdd0ed9366c5bcaafd91b",
+                "url": "https://api.github.com/repos/opis/closure/zipball/f846725591203098246276b2e7b9e8b7814c4965",
+                "reference": "f846725591203098246276b2e7b9e8b7814c4965",
                 "shasum": ""
             },
             "require": {
@@ -1729,12 +1784,12 @@
             },
             "require-dev": {
                 "jeremeamia/superclosure": "^2.0",
-                "phpunit/phpunit": "^4.0|^5.0|^6.0|^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "3.3.x-dev"
                 }
             },
             "autoload": {
@@ -1769,7 +1824,7 @@
                 "serialization",
                 "serialize"
             ],
-            "time": "2019-02-22 10:30:00"
+            "time": "2019-05-31T20:04:32+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -1814,7 +1869,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2018-07-02 15:55:56"
+            "time": "2018-07-02T15:55:56+00:00"
         },
         {
             "name": "php-http/guzzle6-adapter",
@@ -1874,7 +1929,7 @@
                 "Guzzle",
                 "http"
             ],
-            "time": "2016-05-10 06:13:32"
+            "time": "2016-05-10T06:13:32+00:00"
         },
         {
             "name": "php-http/httplug",
@@ -1930,7 +1985,7 @@
                 "client",
                 "http"
             ],
-            "time": "2016-08-31 08:30:17"
+            "time": "2016-08-31T08:30:17+00:00"
         },
         {
             "name": "php-http/promise",
@@ -1980,20 +2035,20 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-01-26 13:27:02"
+            "time": "2016-01-26T13:27:02+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.15",
+            "version": "2.0.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "11cf67cf78dc4acb18dc9149a57be4aee5036ce0"
+                "reference": "3ca5b88d582c69178c8d01fd9d02b94e15042bb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/11cf67cf78dc4acb18dc9149a57be4aee5036ce0",
-                "reference": "11cf67cf78dc4acb18dc9149a57be4aee5036ce0",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/3ca5b88d582c69178c8d01fd9d02b94e15042bb8",
+                "reference": "3ca5b88d582c69178c8d01fd9d02b94e15042bb8",
                 "shasum": ""
             },
             "require": {
@@ -2072,7 +2127,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2019-03-10 16:53:45"
+            "time": "2019-05-26T20:38:34+00:00"
         },
         {
             "name": "psr/container",
@@ -2121,7 +2176,59 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14 16:28:37"
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2019-04-30T12:38:16+00:00"
         },
         {
             "name": "psr/http-message",
@@ -2171,7 +2278,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",
@@ -2218,7 +2325,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-11-20 15:27:04"
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -2266,7 +2373,7 @@
                 "psr-16",
                 "simple-cache"
             ],
-            "time": "2017-10-23 01:57:42"
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "psy/psysh",
@@ -2340,7 +2447,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2018-10-13 15:16:03"
+            "time": "2018-10-13T15:16:03+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -2380,7 +2487,7 @@
                 }
             ],
             "description": "A polyfill for getallheaders.",
-            "time": "2016-02-11 07:05:27"
+            "time": "2016-02-11T07:05:27+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -2462,20 +2569,20 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2018-07-19 23:38:55"
+            "time": "2018-07-19T23:38:55+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v6.2.0",
+            "version": "v6.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "6fa3232ff9d3f8237c0fae4b7ff05e1baa4cd707"
+                "reference": "5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/6fa3232ff9d3f8237c0fae4b7ff05e1baa4cd707",
-                "reference": "6fa3232ff9d3f8237c0fae4b7ff05e1baa4cd707",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a",
+                "reference": "5397cd05b0a0f7937c47b0adcb4c60e5ab936b6a",
                 "shasum": ""
             },
             "require": {
@@ -2524,29 +2631,31 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2019-03-10 07:52:41"
+            "time": "2019-04-21T09:21:45+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.2.4",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9"
+                "reference": "d50bbeeb0e17e6dd4124ea391eff235e932cbf64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9dc2299a016497f9ee620be94524e6c0af0280a9",
-                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d50bbeeb0e17e6dd4124ea391eff235e932cbf64",
+                "reference": "d50bbeeb0e17e6dd4124ea391eff235e932cbf64",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/service-contracts": "^1.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<4.3",
                 "symfony/process": "<3.3"
             },
             "provide": {
@@ -2556,9 +2665,10 @@
                 "psr/log": "~1.0",
                 "symfony/config": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/event-dispatcher": "^4.3",
                 "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.4|~4.0"
+                "symfony/process": "~3.4|~4.0",
+                "symfony/var-dumper": "^4.3"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -2569,7 +2679,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -2596,88 +2706,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23 15:17:42"
-        },
-        {
-            "name": "symfony/contracts",
-            "version": "v1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/contracts.git",
-                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
-                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3"
-            },
-            "require-dev": {
-                "psr/cache": "^1.0",
-                "psr/container": "^1.0"
-            },
-            "suggest": {
-                "psr/cache": "When using the Cache contracts",
-                "psr/container": "When using the Service contracts",
-                "symfony/cache-contracts-implementation": "",
-                "symfony/service-contracts-implementation": "",
-                "symfony/translation-contracts-implementation": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\": ""
-                },
-                "exclude-from-classmap": [
-                    "**/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A set of abstractions extracted out of the Symfony components",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "time": "2018-12-05 08:06:11"
+            "time": "2019-06-05T13:25:51+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v4.2.4",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "48eddf66950fa57996e1be4a55916d65c10c604a"
+                "reference": "105c98bb0c5d8635bea056135304bd8edcc42b4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/48eddf66950fa57996e1be4a55916d65c10c604a",
-                "reference": "48eddf66950fa57996e1be4a55916d65c10c604a",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/105c98bb0c5d8635bea056135304bd8edcc42b4d",
+                "reference": "105c98bb0c5d8635bea056135304bd8edcc42b4d",
                 "shasum": ""
             },
             "require": {
@@ -2686,7 +2728,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -2717,20 +2759,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16 20:31:39"
+            "time": "2019-01-16T21:53:39+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v4.2.4",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "de73f48977b8eaf7ce22814d66e43a1662cc864f"
+                "reference": "4e025104f1f9adb1f7a2d14fb102c9986d6e97c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/de73f48977b8eaf7ce22814d66e43a1662cc864f",
-                "reference": "de73f48977b8eaf7ce22814d66e43a1662cc864f",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/4e025104f1f9adb1f7a2d14fb102c9986d6e97c6",
+                "reference": "4e025104f1f9adb1f7a2d14fb102c9986d6e97c6",
                 "shasum": ""
             },
             "require": {
@@ -2746,7 +2788,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -2773,34 +2815,40 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-03 18:11:24"
+            "time": "2019-05-30T16:10:05+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.2.4",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "3354d2e6af986dd71f68b4e5cf4a933ab58697fb"
+                "reference": "4e6c670af81c4fb0b6c08b035530a9915d0b691f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/3354d2e6af986dd71f68b4e5cf4a933ab58697fb",
-                "reference": "3354d2e6af986dd71f68b4e5cf4a933ab58697fb",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/4e6c670af81c4fb0b6c08b035530a9915d0b691f",
+                "reference": "4e6c670af81c4fb0b6c08b035530a9915d0b691f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.0"
+                "symfony/event-dispatcher-contracts": "^1.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "1.1"
             },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
                 "symfony/expression-language": "~3.4|~4.0",
+                "symfony/http-foundation": "^3.4|^4.0",
+                "symfony/service-contracts": "^1.1",
                 "symfony/stopwatch": "~3.4|~4.0"
             },
             "suggest": {
@@ -2810,7 +2858,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -2837,20 +2885,78 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23 15:17:42"
+            "time": "2019-05-30T16:10:05+00:00"
         },
         {
-            "name": "symfony/finder",
-            "version": "v4.2.4",
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "267b7002c1b70ea80db0833c3afe05f0fbde580a"
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "8fa2cf2177083dd59cf8e44ea4b6541764fbda69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/267b7002c1b70ea80db0833c3afe05f0fbde580a",
-                "reference": "267b7002c1b70ea80db0833c3afe05f0fbde580a",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/8fa2cf2177083dd59cf8e44ea4b6541764fbda69",
+                "reference": "8fa2cf2177083dd59cf8e44ea4b6541764fbda69",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/event-dispatcher": "",
+                "symfony/event-dispatcher-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-05-22T12:23:29+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "b3d4f4c0e4eadfdd8b296af9ca637cfbf51d8176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/b3d4f4c0e4eadfdd8b296af9ca637cfbf51d8176",
+                "reference": "b3d4f4c0e4eadfdd8b296af9ca637cfbf51d8176",
                 "shasum": ""
             },
             "require": {
@@ -2859,7 +2965,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -2886,24 +2992,25 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23 15:42:05"
+            "time": "2019-05-26T20:47:49+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v4.2.4",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "850a667d6254ccf6c61d853407b16f21c4579c77"
+                "reference": "b7e4945dd9b277cd24e93566e4da0a87956392a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/850a667d6254ccf6c61d853407b16f21c4579c77",
-                "reference": "850a667d6254ccf6c61d853407b16f21c4579c77",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/b7e4945dd9b277cd24e93566e4da0a87956392a9",
+                "reference": "b7e4945dd9b277cd24e93566e4da0a87956392a9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
+                "symfony/mime": "^4.3",
                 "symfony/polyfill-mbstring": "~1.1"
             },
             "require-dev": {
@@ -2913,7 +3020,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -2940,34 +3047,35 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-26 08:03:39"
+            "time": "2019-06-06T10:05:02+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v4.2.4",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "895ceccaa8149f9343e6134e607c21da42d73b7a"
+                "reference": "738ad561cd6a8d1c44ee1da941b2e628e264c429"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/895ceccaa8149f9343e6134e607c21da42d73b7a",
-                "reference": "895ceccaa8149f9343e6134e607c21da42d73b7a",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/738ad561cd6a8d1c44ee1da941b2e628e264c429",
+                "reference": "738ad561cd6a8d1c44ee1da941b2e628e264c429",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "psr/log": "~1.0",
-                "symfony/contracts": "^1.0.2",
                 "symfony/debug": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~4.1",
+                "symfony/event-dispatcher": "^4.3",
                 "symfony/http-foundation": "^4.1.1",
-                "symfony/polyfill-ctype": "~1.8"
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php73": "^1.9"
             },
             "conflict": {
+                "symfony/browser-kit": "<4.3",
                 "symfony/config": "<3.4",
-                "symfony/dependency-injection": "<4.2",
+                "symfony/dependency-injection": "<4.3",
                 "symfony/translation": "<4.2",
                 "symfony/var-dumper": "<4.1.1",
                 "twig/twig": "<1.34|<2.4,>=2"
@@ -2977,11 +3085,11 @@
             },
             "require-dev": {
                 "psr/cache": "~1.0",
-                "symfony/browser-kit": "~3.4|~4.0",
+                "symfony/browser-kit": "^4.3",
                 "symfony/config": "~3.4|~4.0",
                 "symfony/console": "~3.4|~4.0",
                 "symfony/css-selector": "~3.4|~4.0",
-                "symfony/dependency-injection": "^4.2",
+                "symfony/dependency-injection": "^4.3",
                 "symfony/dom-crawler": "~3.4|~4.0",
                 "symfony/expression-language": "~3.4|~4.0",
                 "symfony/finder": "~3.4|~4.0",
@@ -2990,7 +3098,9 @@
                 "symfony/stopwatch": "~3.4|~4.0",
                 "symfony/templating": "~3.4|~4.0",
                 "symfony/translation": "~4.2",
-                "symfony/var-dumper": "^4.1.1"
+                "symfony/translation-contracts": "^1.1",
+                "symfony/var-dumper": "^4.1.1",
+                "twig/twig": "^1.34|^2.4"
             },
             "suggest": {
                 "symfony/browser-kit": "",
@@ -3002,7 +3112,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -3029,20 +3139,79 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-03 19:38:09"
+            "time": "2019-06-06T13:23:34+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "name": "symfony/mime",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "ec2c5565de60e03f33d4296a655e3273f0ad1f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/ec2c5565de60e03f33d4296a655e3273f0ad1f8b",
+                "reference": "ec2c5565de60e03f33d4296a655e3273f0ad1f8b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.0",
+                "symfony/dependency-injection": "~3.4|^4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A library to manipulate MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "time": "2019-06-04T09:22:54+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
                 "shasum": ""
             },
             "require": {
@@ -3054,7 +3223,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -3087,20 +3256,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06 14:22:27"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "97001cfc283484c9691769f51cdf25259037eba2"
+                "reference": "f037ea22acfaee983e271dd9c3b8bb4150bd8ad7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/97001cfc283484c9691769f51cdf25259037eba2",
-                "reference": "97001cfc283484c9691769f51cdf25259037eba2",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/f037ea22acfaee983e271dd9c3b8bb4150bd8ad7",
+                "reference": "f037ea22acfaee983e271dd9c3b8bb4150bd8ad7",
                 "shasum": ""
             },
             "require": {
@@ -3112,7 +3281,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -3146,20 +3315,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21 06:26:08"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "89de1d44f2c059b266f22c9cc9124ddc4cd0987a"
+                "reference": "c766e95bec706cdd89903b1eda8afab7d7a6b7af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/89de1d44f2c059b266f22c9cc9124ddc4cd0987a",
-                "reference": "89de1d44f2c059b266f22c9cc9124ddc4cd0987a",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/c766e95bec706cdd89903b1eda8afab7d7a6b7af",
+                "reference": "c766e95bec706cdd89903b1eda8afab7d7a6b7af",
                 "shasum": ""
             },
             "require": {
@@ -3208,20 +3377,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-30 16:36:12"
+            "time": "2019-03-04T13:44:35+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
                 "shasum": ""
             },
             "require": {
@@ -3233,7 +3402,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -3267,20 +3436,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21 13:07:52"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631"
+                "reference": "ab50dcf166d5f577978419edd37aa2bb8eabce0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
-                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/ab50dcf166d5f577978419edd37aa2bb8eabce0c",
+                "reference": "ab50dcf166d5f577978419edd37aa2bb8eabce0c",
                 "shasum": ""
             },
             "require": {
@@ -3289,7 +3458,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -3322,20 +3491,78 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21 13:07:52"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v4.2.4",
+            "name": "symfony/polyfill-php73",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "6c05edb11fbeff9e2b324b4270ecb17911a8b7ad"
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "d1fb4abcc0c47be136208ad9d68bf59f1ee17abd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/6c05edb11fbeff9e2b324b4270ecb17911a8b7ad",
-                "reference": "6c05edb11fbeff9e2b324b4270ecb17911a8b7ad",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/d1fb4abcc0c47be136208ad9d68bf59f1ee17abd",
+                "reference": "d1fb4abcc0c47be136208ad9d68bf59f1ee17abd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-02-06T07:57:58+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "856d35814cf287480465bb7a6c413bb7f5f5e69c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/856d35814cf287480465bb7a6c413bb7f5f5e69c",
+                "reference": "856d35814cf287480465bb7a6c413bb7f5f5e69c",
                 "shasum": ""
             },
             "require": {
@@ -3344,7 +3571,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -3371,7 +3598,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-24 22:05:03"
+            "time": "2019-05-30T16:10:05+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -3436,20 +3663,20 @@
                 "psr-17",
                 "psr-7"
             ],
-            "time": "2019-03-11 18:22:33"
+            "time": "2019-03-11T18:22:33+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v4.2.4",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "ff03eae644e6b1e26d4a04b2385fe3a1a7f04e42"
+                "reference": "9b31cd24f6ad2cebde6845f6daa9c6d69efe2465"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/ff03eae644e6b1e26d4a04b2385fe3a1a7f04e42",
-                "reference": "ff03eae644e6b1e26d4a04b2385fe3a1a7f04e42",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/9b31cd24f6ad2cebde6845f6daa9c6d69efe2465",
+                "reference": "9b31cd24f6ad2cebde6845f6daa9c6d69efe2465",
                 "shasum": ""
             },
             "require": {
@@ -3461,7 +3688,7 @@
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.0",
+                "doctrine/annotations": "~1.2",
                 "psr/log": "~1.0",
                 "symfony/config": "~4.2",
                 "symfony/dependency-injection": "~3.4|~4.0",
@@ -3472,7 +3699,6 @@
             "suggest": {
                 "doctrine/annotations": "For using the annotation loader",
                 "symfony/config": "For using the all-in-one router or any loader",
-                "symfony/dependency-injection": "For loading routes from a service",
                 "symfony/expression-language": "For using expression matching",
                 "symfony/http-foundation": "For using a Symfony Request object",
                 "symfony/yaml": "For using the YAML loader"
@@ -3480,7 +3706,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -3513,26 +3739,84 @@
                 "uri",
                 "url"
             ],
-            "time": "2019-02-23 15:17:42"
+            "time": "2019-06-05T09:16:20+00:00"
         },
         {
-            "name": "symfony/translation",
-            "version": "v4.2.4",
+            "name": "symfony/service-contracts",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "748464177a77011f8f4cdd076773862ce4915f8f"
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/748464177a77011f8f4cdd076773862ce4915f8f",
-                "reference": "748464177a77011f8f4cdd076773862ce4915f8f",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/191afdcb5804db960d26d8566b7e9a2843cab3a0",
+                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "psr/container": "",
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-05-28T07:50:59+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "5dda505e5f65d759741dfaf4e54b36010a4b57aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/5dda505e5f65d759741dfaf4e54b36010a4b57aa",
+                "reference": "5dda505e5f65d759741dfaf4e54b36010a4b57aa",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/contracts": "^1.0.2",
-                "symfony/polyfill-mbstring": "~1.0"
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^1.1.2"
             },
             "conflict": {
                 "symfony/config": "<3.4",
@@ -3540,7 +3824,7 @@
                 "symfony/yaml": "<3.4"
             },
             "provide": {
-                "symfony/translation-contracts-implementation": "1.0"
+                "symfony/translation-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
@@ -3548,7 +3832,10 @@
                 "symfony/console": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
                 "symfony/finder": "~2.8|~3.0|~4.0",
+                "symfony/http-kernel": "~3.4|~4.0",
                 "symfony/intl": "~3.4|~4.0",
+                "symfony/service-contracts": "^1.1.2",
+                "symfony/var-dumper": "~3.4|~4.0",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -3559,7 +3846,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -3586,20 +3873,77 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-27 03:31:50"
+            "time": "2019-06-03T20:27:40+00:00"
         },
         {
-            "name": "symfony/var-dumper",
-            "version": "v4.2.4",
+            "name": "symfony/translation-contracts",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "9f87189ac10b42edf7fb8edc846f1937c6d157cf"
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "93597ce975d91c52ebfaca1253343cd9ccb7916d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9f87189ac10b42edf7fb8edc846f1937c6d157cf",
-                "reference": "9f87189ac10b42edf7fb8edc846f1937c6d157cf",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/93597ce975d91c52ebfaca1253343cd9ccb7916d",
+                "reference": "93597ce975d91c52ebfaca1253343cd9ccb7916d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "suggest": {
+                "symfony/translation-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-05-27T08:16:38+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "f974f448154928d2b5fb7c412bd23b81d063f34b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/f974f448154928d2b5fb7c412bd23b81d063f34b",
+                "reference": "f974f448154928d2b5fb7c412bd23b81d063f34b",
                 "shasum": ""
             },
             "require": {
@@ -3628,7 +3972,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -3662,7 +4006,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2019-02-23 15:17:42"
+            "time": "2019-06-05T02:08:12+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -3709,7 +4053,7 @@
             ],
             "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
-            "time": "2017-11-27 11:13:29"
+            "time": "2017-11-27T11:13:29+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -3760,42 +4104,45 @@
                 "env",
                 "environment"
             ],
-            "time": "2019-01-29 11:11:52"
+            "time": "2019-01-29T11:11:52+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.8.6",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "20da13beba0dde8fb648be3cc19765732790f46e"
+                "reference": "37bf68b428850ee26ed7c3be6c26236dd95a95f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/20da13beba0dde8fb648be3cc19765732790f46e",
-                "reference": "20da13beba0dde8fb648be3cc19765732790f46e",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/37bf68b428850ee26ed7c3be6c26236dd95a95f1",
+                "reference": "37bf68b428850ee26ed7c3be6c26236dd95a95f1",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "php": "^7.1",
+                "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0"
             },
             "provide": {
+                "psr/http-factory-implementation": "1.0",
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
+                "http-interop/http-factory-tests": "^0.5.0",
                 "php-http/psr7-integration-tests": "dev-master",
-                "phpunit/phpunit": "^5.7.16 || ^6.0.8 || ^7.2.7",
-                "zendframework/zend-coding-standard": "~1.0"
+                "phpunit/phpunit": "^7.0.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev",
-                    "dev-develop": "1.9.x-dev",
-                    "dev-release-2.0": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev",
+                    "dev-develop": "2.2.x-dev",
+                    "dev-release-1.8": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -3815,468 +4162,43 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-2-Clause"
+                "BSD-3-Clause"
             ],
             "description": "PSR HTTP Message implementations",
-            "homepage": "https://github.com/zendframework/zend-diactoros",
             "keywords": [
                 "http",
                 "psr",
                 "psr-7"
             ],
-            "time": "2018-09-05 19:29:37"
+            "time": "2019-04-29T21:11:00+00:00"
         }
     ],
     "packages-dev": [
         {
-            "name": "barryvdh/laravel-ide-helper",
-            "version": "v2.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/barryvdh/laravel-ide-helper.git",
-                "reference": "725711022be71c6fa2e7bc8f9648bf125986f027"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/725711022be71c6fa2e7bc8f9648bf125986f027",
-                "reference": "725711022be71c6fa2e7bc8f9648bf125986f027",
-                "shasum": ""
-            },
-            "require": {
-                "barryvdh/reflection-docblock": "^2.0.6",
-                "composer/composer": "^1.6",
-                "illuminate/console": "^5.5,<5.9",
-                "illuminate/filesystem": "^5.5,<5.9",
-                "illuminate/support": "^5.5,<5.9",
-                "php": ">=7"
-            },
-            "require-dev": {
-                "doctrine/dbal": "~2.3",
-                "illuminate/config": "^5.1,<5.9",
-                "illuminate/view": "^5.1,<5.9",
-                "phpro/grumphp": "^0.14",
-                "phpunit/phpunit": "4.*",
-                "scrutinizer/ocular": "~1.1",
-                "squizlabs/php_codesniffer": "^3"
-            },
-            "suggest": {
-                "doctrine/dbal": "Load information from the database about models for phpdocs (~2.3)"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev"
-                },
-                "laravel": {
-                    "providers": [
-                        "Barryvdh\\LaravelIdeHelper\\IdeHelperServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Barryvdh\\LaravelIdeHelper\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Barry vd. Heuvel",
-                    "email": "barryvdh@gmail.com"
-                }
-            ],
-            "description": "Laravel IDE Helper, generates correct PHPDocs for all Facade classes, to improve auto-completion.",
-            "keywords": [
-                "autocomplete",
-                "codeintel",
-                "helper",
-                "ide",
-                "laravel",
-                "netbeans",
-                "phpdoc",
-                "phpstorm",
-                "sublime"
-            ],
-            "time": "2019-03-05 09:24:51"
-        },
-        {
-            "name": "barryvdh/reflection-docblock",
-            "version": "v2.0.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/barryvdh/ReflectionDocBlock.git",
-                "reference": "6b69015d83d3daf9004a71a89f26e27d27ef6a16"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/barryvdh/ReflectionDocBlock/zipball/6b69015d83d3daf9004a71a89f26e27d27ef6a16",
-                "reference": "6b69015d83d3daf9004a71a89f26e27d27ef6a16",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0,<4.5"
-            },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Barryvdh": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
-                }
-            ],
-            "time": "2018-12-13 10:34:14"
-        },
-        {
-            "name": "composer/ca-bundle",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
-                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "ext-pcre": "*",
-                "php": "^5.3.2 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
-                "psr/log": "^1.0",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\CaBundle\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
-            "keywords": [
-                "cabundle",
-                "cacert",
-                "certificate",
-                "ssl",
-                "tls"
-            ],
-            "time": "2019-01-28 09:30:10"
-        },
-        {
-            "name": "composer/composer",
-            "version": "1.8.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/composer.git",
-                "reference": "bc364c2480c17941e2135cfc568fa41794392534"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/bc364c2480c17941e2135cfc568fa41794392534",
-                "reference": "bc364c2480c17941e2135cfc568fa41794392534",
-                "shasum": ""
-            },
-            "require": {
-                "composer/ca-bundle": "^1.0",
-                "composer/semver": "^1.0",
-                "composer/spdx-licenses": "^1.2",
-                "composer/xdebug-handler": "^1.1",
-                "justinrainbow/json-schema": "^3.0 || ^4.0 || ^5.0",
-                "php": "^5.3.2 || ^7.0",
-                "psr/log": "^1.0",
-                "seld/jsonlint": "^1.4",
-                "seld/phar-utils": "^1.0",
-                "symfony/console": "^2.7 || ^3.0 || ^4.0",
-                "symfony/filesystem": "^2.7 || ^3.0 || ^4.0",
-                "symfony/finder": "^2.7 || ^3.0 || ^4.0",
-                "symfony/process": "^2.7 || ^3.0 || ^4.0"
-            },
-            "conflict": {
-                "symfony/console": "2.8.38"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7",
-                "phpunit/phpunit-mock-objects": "^2.3 || ^3.0"
-            },
-            "suggest": {
-                "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
-                "ext-zip": "Enabling the zip extension allows you to unzip archives",
-                "ext-zlib": "Allow gzip compression of HTTP requests"
-            },
-            "bin": [
-                "bin/composer"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.8-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\": "src/Composer"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Composer helps you declare, manage and install dependencies of PHP projects, ensuring you have the right stack everywhere.",
-            "homepage": "https://getcomposer.org/",
-            "keywords": [
-                "autoload",
-                "dependency",
-                "package"
-            ],
-            "time": "2019-02-11 09:52:10"
-        },
-        {
-            "name": "composer/semver",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
-                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.5 || ^5.0.5",
-                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "time": "2019-03-19 17:25:45"
-        },
-        {
-            "name": "composer/spdx-licenses",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "7a9556b22bd9d4df7cad89876b00af58ef20d3a2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/7a9556b22bd9d4df7cad89876b00af58ef20d3a2",
-                "reference": "7a9556b22bd9d4df7cad89876b00af58ef20d3a2",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
-                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Spdx\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "SPDX licenses list and validation library.",
-            "keywords": [
-                "license",
-                "spdx",
-                "validator"
-            ],
-            "time": "2018-11-01 09:45:54"
-        },
-        {
-            "name": "composer/xdebug-handler",
-            "version": "1.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "d17708133b6c276d6e42ef887a877866b909d892"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/d17708133b6c276d6e42ef887a877866b909d892",
-                "reference": "d17708133b6c276d6e42ef887a877866b909d892",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0",
-                "psr/log": "^1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Composer\\XdebugHandler\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "John Stevenson",
-                    "email": "john-stevenson@blueyonder.co.uk"
-                }
-            ],
-            "description": "Restarts a process without xdebug.",
-            "keywords": [
-                "Xdebug",
-                "performance"
-            ],
-            "time": "2019-01-28 20:25:53"
-        },
-        {
             "name": "doctrine/instantiator",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3",
-                "squizlabs/php_codesniffer": "^3.0.2"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -4301,12 +4223,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22 11:58:36"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "filp/whoops",
@@ -4367,7 +4289,7 @@
                 "throwable",
                 "whoops"
             ],
-            "time": "2018-10-23 09:00:00"
+            "time": "2018-10-23T09:00:00+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -4417,7 +4339,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2018-07-12 10:23:15"
+            "time": "2018-07-12T10:23:15+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -4465,73 +4387,7 @@
             "keywords": [
                 "test"
             ],
-            "time": "2016-01-20 08:20:44"
-        },
-        {
-            "name": "justinrainbow/json-schema",
-            "version": "5.2.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "dcb6e1006bb5fd1e392b4daa68932880f37550d4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/dcb6e1006bb5fd1e392b4daa68932880f37550d4",
-                "reference": "dcb6e1006bb5fd1e392b4daa68932880f37550d4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.2.20",
-                "json-schema/json-schema-test-suite": "1.2.0",
-                "phpunit/phpunit": "^4.8.35"
-            },
-            "bin": [
-                "bin/validate-json"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "JsonSchema\\": "src/JsonSchema/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bruno Prieto Reis",
-                    "email": "bruno.p.reis@gmail.com"
-                },
-                {
-                    "name": "Justin Rainbow",
-                    "email": "justin.rainbow@gmail.com"
-                },
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                },
-                {
-                    "name": "Robert Schönthal",
-                    "email": "seroscho@googlemail.com"
-                }
-            ],
-            "description": "A library to validate a json schema.",
-            "homepage": "https://github.com/justinrainbow/json-schema",
-            "keywords": [
-                "json",
-                "schema"
-            ],
-            "time": "2019-01-14 23:55:14"
+            "time": "2016-01-20T08:20:44+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -4596,20 +4452,20 @@
                 "test double",
                 "testing"
             ],
-            "time": "2019-02-13 09:37:52"
+            "time": "2019-02-13T09:37:52+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.8.1",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
-                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
                 "shasum": ""
             },
             "require": {
@@ -4644,7 +4500,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2018-06-11 23:09:50"
+            "time": "2019-04-07T13:18:21+00:00"
         },
         {
             "name": "nunomaduro/collision",
@@ -4708,7 +4564,7 @@
                 "php",
                 "symfony"
             ],
-            "time": "2018-11-21 21:40:54"
+            "time": "2018-11-21T21:40:54+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -4763,7 +4619,7 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2018-07-08 19:23:20"
+            "time": "2018-07-08T19:23:20+00:00"
         },
         {
             "name": "phar-io/version",
@@ -4810,7 +4666,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2018-07-08 19:19:57"
+            "time": "2018-07-08T19:19:57+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4864,20 +4720,20 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11 18:02:19"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
-                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
@@ -4915,7 +4771,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-30 07:14:17"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -4962,7 +4818,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14 14:27:02"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -5025,7 +4881,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05 17:53:17"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5088,7 +4944,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-31 16:06:48"
+            "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -5138,7 +4994,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2018-09-13 20:33:42"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -5179,20 +5035,20 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b389aebe1b8b0578430bda0c7c95a829608e059",
-                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
@@ -5228,7 +5084,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-02-20 10:12:59"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -5277,20 +5133,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-10-30 05:52:18"
+            "time": "2018-10-30T05:52:18+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.7",
+            "version": "7.5.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "eb343b86753d26de07ecba7868fa983104361948"
+                "reference": "9ba59817745b0fe0c1a5a3032dfd4a6d2994ad1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/eb343b86753d26de07ecba7868fa983104361948",
-                "reference": "eb343b86753d26de07ecba7868fa983104361948",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ba59817745b0fe0c1a5a3032dfd4a6d2994ad1c",
+                "reference": "9ba59817745b0fe0c1a5a3032dfd4a6d2994ad1c",
                 "shasum": ""
             },
             "require": {
@@ -5361,7 +5217,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-03-16 07:31:17"
+            "time": "2019-05-28T11:59:40+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -5406,7 +5262,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04 06:30:41"
+            "time": "2017-03-04T06:30:41+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -5470,7 +5326,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-07-12 15:12:46"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -5526,20 +5382,20 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2019-02-04 06:01:07"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.1.0",
+            "version": "4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656"
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6fda8ce1974b62b14935adc02a9ed38252eca656",
-                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
                 "shasum": ""
             },
             "require": {
@@ -5554,7 +5410,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -5579,7 +5435,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-02-01 05:27:49"
+            "time": "2019-05-05T09:05:15+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -5646,7 +5502,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03 13:19:02"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -5697,7 +5553,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27 15:39:26"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -5744,7 +5600,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03 12:35:26"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
             "name": "sebastian/object-reflector",
@@ -5789,7 +5645,7 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29 09:07:27"
+            "time": "2017-03-29T09:07:27+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -5842,7 +5698,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03 06:23:57"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -5884,7 +5740,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2018-10-04 04:07:39"
+            "time": "2018-10-04T04:07:39+00:00"
         },
         {
             "name": "sebastian/version",
@@ -5927,163 +5783,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03 07:35:21"
-        },
-        {
-            "name": "seld/jsonlint",
-            "version": "1.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/d15f59a67ff805a44c50ea0516d2341740f81a38",
-                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
-            },
-            "bin": [
-                "bin/jsonlint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "JSON Linter",
-            "keywords": [
-                "json",
-                "linter",
-                "parser",
-                "validator"
-            ],
-            "time": "2018-01-24 12:46:19"
-        },
-        {
-            "name": "seld/phar-utils",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/phar-utils.git",
-                "reference": "7009b5139491975ef6486545a39f3e6dad5ac30a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/7009b5139491975ef6486545a39f3e6dad5ac30a",
-                "reference": "7009b5139491975ef6486545a39f3e6dad5ac30a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Seld\\PharUtils\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "PHAR file format utilities, for when PHP phars you up",
-            "keywords": [
-                "phra"
-            ],
-            "time": "2015-10-13 18:44:15"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v4.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e16b9e471703b2c60b95f14d31c1239f68f11601",
-                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Filesystem Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-02-07 11:40:08"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/1c42705be2b6c1de5904f8afacef5895cab44bf8",
+                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8",
                 "shasum": ""
             },
             "require": {
@@ -6110,7 +5823,7 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07 12:08:54"
+            "time": "2019-04-04T09:56:43+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -6161,7 +5874,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25 11:19:39"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],

--- a/config/api/item/fields.php
+++ b/config/api/item/fields.php
@@ -17,6 +17,13 @@ return [
         'type' => 'date (yyyy-mm-dd)',
         'required' => true
     ],
+    'publish_after' => [
+        'field' => 'publish_after',
+        'title' => 'item/fields.title-publish_after',
+        'description' => 'item/fields.description-publish_after',
+        'type' => 'date (yyyy-mm-dd)',
+        'required' => false
+    ],
     'total' => [
         'field' => 'total',
         'title' => 'item/fields.title-total',

--- a/config/api/item/parameters.php
+++ b/config/api/item/parameters.php
@@ -12,6 +12,14 @@ return [
             "type" => "string",
             "required" => false
         ],
+        'search' => [
+            "parameter" => "search",
+            "title" => 'searchable.title',
+            "description" => 'searchable.description',
+            "default" => null,
+            "type" => "string",
+            "required" => false
+        ],
         'include-categories' => [
             'field' => 'include-categories',
             'title' => 'resource-type-item/parameters.title-include-categories',

--- a/config/api/item/searchable.php
+++ b/config/api/item/searchable.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'description'
+];

--- a/config/api/item/validation.php
+++ b/config/api/item/validation.php
@@ -7,6 +7,7 @@ return [
         'fields' => [
             'description' => 'required|string',
             'effective_date' => 'required|date_format:Y-m-d',
+            'publish_after' => 'sometimes|date_format:Y-m-d',
             'total' => 'required|string|regex:/^\d+\.\d{2}$/',
             'percentage' => 'sometimes|required|integer|between:1,100'
         ],
@@ -18,6 +19,7 @@ return [
         'fields' => [
             'description' => 'sometimes|string',
             'effective_date' => 'sometimes|date_format:Y-m-d',
+            'publish_after' => 'sometimes|date_format:Y-m-d',
             'total' => 'sometimes|string|regex:/^\d+\.\d{2}$/',
             'percentage' => 'sometimes|integer|between:1,100'
         ],

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '1.14.3',
+    'version'=> '1.15.0',
     'prefix' => 'v1',
-    'release_date' => '2019-06-02',
+    'release_date' => '2019-06-09',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/database/migrations/2019_06_05_225550_publish_at_field.php
+++ b/database/migrations/2019_06_05_225550_publish_at_field.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class PublishAtField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('item', function (Blueprint $table) {
+            $table->date('publish_after')
+                ->after('effective_date')
+                ->nullable();
+            $table->index('publish_after');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('item', function (Blueprint $table) {
+            $table->dropIndex('item_publish_after_index');
+            $table->dropColumn('publish_after');
+        });
+    }
+}

--- a/resources/lang/en/item/fields.php
+++ b/resources/lang/en/item/fields.php
@@ -9,6 +9,9 @@ return [
     'title-effective_date' => 'Item effective date',
     'description-effective_date' => 'Enter an effective date for the item',
 
+    'title-publish_after' => 'Publish after this date',
+    'description-publish_after' => 'Enter a date to withhold publishing until',
+
     'title-total' => 'Item total',
     'description-total' => 'Enter the total cost for the item',
 

--- a/resources/lang/en/searchable.php
+++ b/resources/lang/en/searchable.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Search options',
+    'description' => 'Run a partial search on searchable fields as per this example, search=field1:partial_term|field2:partial_term'
+];

--- a/resources/lang/en/searchable.php
+++ b/resources/lang/en/searchable.php
@@ -4,5 +4,5 @@ declare(strict_types=1);
 
 return [
     'title' => 'Search options',
-    'description' => 'Run a partial search on searchable fields as per this example, search=field1:partial_term|field2:partial_term'
+    'description' => 'Run a partial search on searchable fields, example search=field1:partial_term|field2:partial_term'
 ];


### PR DESCRIPTION
### Added
- `publish_after` field added to item, POST and PATCH updated.
- Tests for POSTMAN, now up to 280 tests.
- /resource-types/[resource-type]/resources/[resource]/items collection updated to not include unpublished items.
- /resource-types/[resource-type]/items collection updated to not include unpublished items.
- /summary/resource-types/[resource-type]/resources/[resource]/items updated to not include unpublished items.
- /summary/resource-types/[resource-type]/items updated to not include unpublished items.
- search support added to /summary/resource-types/[resource-type]/resources/[resource]/items

### Changed
- `description` added to /summary/resource-types/[resource-type]/resources/[resource]/items?categories=true summary
- `description` added to /summary/resource-types/[resource-type]/items?categories=true summary
- `description` added to /summary/resource-types/[resource-type]/resources/[resource]/items?category=[category]&subcategories=true
- `description` added to /summary/resource-types/[resource-type]/items?category=[category]&subcategories=true
- Category, ItemCategorySummary and ItemSubCategorySummary transformers updated to new setup.
- Up the throttle limit.
- Don't format numbers in output, leave that to the apps.
- Moved fields validators.
- Moved route validators.
- Moved the class used to fetch GET parameters.
- Refactored the sort parameters code, added validation and the code now resides in its own class, now reusable.
- General refactoring, never happy with the design.

### Fixed
- Collection parameters not being passed through to the category transformer. 
- Header indents incorrect for the v1.14.3 changelog entry.
- Description missing from /categories collection.
- Pagination helper not hashing subcategory value before adding to URI.
- Sort and search conditions added to pagination URIs.
- Section value cleared in changelog parser when new release found.