### PR TITLE
v1.16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
-## [v1.16.3] - 2017-07-17
+## [v1.16.4] - 2019-07-xx
+### Changed 
+
+
+### Fixed
+- Corrected dates in the CHANGELOG, the last two releases were not two years ago.
+
+## [v1.16.3] - 2019-07-17
 ### Fixed
 - Search terms generate invalid SQL.
 
-## [v1.16.2] - 2017-07-16
+## [v1.16.2] - 2019-07-16
 ### Changed
 - Tweak to the Docker setup, read values from the .env file. At this time, Docker is for development, that may change in the future; obviously, the passwords in the .env file were not real passwords.
 - Moved Xdebug into Docker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
-## [v1.16.4] - 2019-07-xx
+## [v1.16.4] - 2019-07-22
 ### Changed 
-
+- I have reworked the `/summary/resource-types/[resource-type]/resources/[resource]/items` summary. Previously if you defined a time-based filter parameter,  category and subcategory parameters are ignored. 
 
 ### Fixed
 - Corrected dates in the CHANGELOG, the last two releases were not two years ago.

--- a/app/Validators/Request/Parameters.php
+++ b/app/Validators/Request/Parameters.php
@@ -82,7 +82,6 @@ class Parameters
                     if (array_key_exists($key, self::$parameters) === true) {
                         if (intval(self::$parameters[$key]) < 1 ||
                             self::$parameters[$key] > 12) {
-
                             unset(self::$parameters[$key]);
                         }
                     }

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '1.16.3',
+    'version'=> '1.16.4',
     'prefix' => 'v1',
-    'release_date' => '2019-07-17',
+    'release_date' => '2019-07-22',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'


### PR DESCRIPTION
### Changed  

- I have reworked the `/summary/resource-types/[resource-type]/resources/[resource]/items` summary. Previously if you defined a time-based filter parameter,  category and subcategory parameters are ignored.  

### Fixed 
- Corrected dates in the CHANGELOG, the last two releases were not two years ago.