### PR TITLE
v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - We have added pagination to the `/v1/categories/[category]/subcategories` GET endpoint.
 - We have added pagination to the `/v1/resource-tyes` GET endpoint.
 - We have added pagination to the `/v1/resource-types/[resource-type]/resources` GET endpoint.
+- We have added search to the `/v1/categories` GET endpoint; you can search on `name` and `description`.
 
 ### Changed
 - We have modified the year GET parameter to include 'next' year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, an issue has been created to find a better solution).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ## [v1.17.0] - 2019-08-xx
 ### Added 
 - The `v1/summary/resource-types/items` summary supports all the same features as the main `items` summary; you can make a filtered request and even include a search term.
+- Added pagination to the `/v1/categories` GET endpoint.
 
 ### Changed
 - We have modified the year GET parameter to include 'next' year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, later we will correct this error).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.17.0] - 2019-08-xx
+### Added 
+- The `v1/summary/resource-types/items` summary supports all the same features as the main `items` summary; you can make a filtered request and even include a search term.
+
+### Changed
+- We have modified the year GET parameter to include 'next' year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, later we will correct this error).
+- Refactoring to remove unnecessary clauses in the base validation switch statement.
+
+### Fixed
+- The resource type items summaries are not using the `include-unpublished` parameter.
+- The response for a summary request that returns no results returns a 200, not a 404, the endpoint is correct it just no longer returns results because of the GET parameters.
+
 ## [v1.16.5] - 2019-07-29
 ### Added
 - Validation added to validators, check to ensure the required indexes set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - We have added pagination to the `/v1/resource-tyes` GET endpoint.
 - We have added pagination to the `/v1/resource-types/[resource-type]/resources` GET endpoint.
 - We have added search to the `/v1/categories` GET endpoint; you can search on `name` and `description`.
+- We have added search to the `/v1/resource-types` GET endpoint; you can search on `name` and `description`.
 
 ### Changed
 - We have modified the year GET parameter to include "next" year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, an issue has been created to find a better solution).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ### Added 
 - The `v1/summary/resource-types/items` summary supports all the same features as the main `items` summary; you can make a filtered request and even include a search term.
 - Added pagination to the `/v1/categories` GET endpoint.
+- Added pagination to the `/v1/categories/[category]/subcategories` GET endpoint.
 
 ### Changed
 - We have modified the year GET parameter to include 'next' year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, later we will correct this error).
 - Refactoring to remove unnecessary clauses in the base validation switch statement.
+- General refactoring, class renaming, corrected property names etc.
 
 ### Fixed
 - The resource type items summaries are not using the `include-unpublished` parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - We have added search to the `/v1/categories` GET endpoint; you can search on `name` and `description`.
 - We have added search to the `/v1/resource-types` GET endpoint; you can search on `name` and `description`.
 - We have added search to the `/v1/categories/[category]/subcategories` GET endpoint; you can search on `name` and `description`.
-
+- We have added search to the `/v1/resource-types/[resource-type]/resources` GET endpoint; you can search on `name` and `description`.
 
 ### Changed
 - We have modified the year GET parameter to include "next" year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, an issue has been created to find a better solution).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,22 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ## [v1.17.0] - 2019-08-xx
 ### Added 
 - The `v1/summary/resource-types/items` summary supports all the same features as the main `items` summary; you can make a filtered request and even include a search term.
-- Added pagination to the `/v1/categories` GET endpoint.
-- Added pagination to the `/v1/categories/[category]/subcategories` GET endpoint.
+- We have added pagination to the `/v1/categories` GET endpoint.
+- We have added pagination to the `/v1/categories/[category]/subcategories` GET endpoint.
+- We have added pagination to the `/v1/resource-tyes` GET endpoint.
+- We have added pagination to the `/v1/resource-types/[resource-type]/resources` GET endpoint.
 
 ### Changed
-- We have modified the year GET parameter to include 'next' year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, later we will correct this error).
-- Refactoring to remove unnecessary clauses in the base validation switch statement.
-- General refactoring, class renaming, corrected property names etc.
+- We have modified the year GET parameter to include 'next' year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, an issue has been created to find a better solution).
+- We have removed unnecessary clauses in the base validation switch statement.
 
 ### Fixed
 - The resource type items summaries are not using the `include-unpublished` parameter.
 - The response for a summary request that returns no results returns a 200, not a 404, the endpoint is correct it just no longer returns results because of the GET parameters.
+- Transformers should not call models, only transform data, corrected the ResourceType transformer.
+
+### Removed
+- The `include-resources` parameter excluded from the resource type collection, not useful at the collection level and causes unnecessary SQL requests, remains an option when requesting a single resource type.
 
 ## [v1.16.5] - 2019-07-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - We have added pagination to the `/v1/resource-types/[resource-type]/resources` GET endpoint.
 - We have added search to the `/v1/categories` GET endpoint; you can search on `name` and `description`.
 - We have added search to the `/v1/resource-types` GET endpoint; you can search on `name` and `description`.
+- We have added search to the `/v1/categories/[category]/subcategories` GET endpoint; you can search on `name` and `description`.
+
 
 ### Changed
 - We have modified the year GET parameter to include "next" year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, an issue has been created to find a better solution).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
-## [v1.17.0] - 2019-08-xx
+## [v1.17.0] - 2019-08-06
 ### Added 
 - The `v1/summary/resource-types/items` summary supports all the same features as the main `items` summary; you can make a filtered request and even include a search term.
 - We have added pagination to the `/v1/categories` GET endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - We have added search to the `/v1/categories` GET endpoint; you can search on `name` and `description`.
 
 ### Changed
-- We have modified the year GET parameter to include 'next' year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, an issue has been created to find a better solution).
+- We have modified the year GET parameter to include "next" year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, an issue has been created to find a better solution).
 - We have removed unnecessary clauses in the base validation switch statement.
+- We have altered the format of the included resources and subcategories when the `include-resources` or `include-subcategories` parameters exist in the request.
 
 ### Fixed
 - The resource type items summaries are not using the `include-unpublished` parameter.
@@ -21,7 +22,8 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - Transformers should not call models, only transform data, corrected the ResourceType transformer.
 
 ### Removed
-- The `include-resources` parameter excluded from the resource type collection, not useful at the collection level and causes unnecessary SQL requests, remains an option when requesting a single resource type.
+- Removed the `include-resources` parameter from the resource type collection, not useful at the collection level and causes unnecessary SQL requests, remains an option when requesting a single resource type.
+- Removed the `include-subcategories` parameter from the categories collection, not useful at the collection level and causes unnecessary SQL requests, remains an option when requesting a single category.
 
 ## [v1.16.5] - 2019-07-29
 ### Added

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -231,7 +231,7 @@ class CategoryController extends Controller
 
         $conditional_post_fields = ['resource_type_id' => []];
         foreach ($resource_types as $resource_type) {
-            $id = $this->hash->encode('resource_type', $resource_type->resource_type_id);
+            $id = $this->hash->encode('resource_type', $resource_type['resource_type_id']);
 
             if ($id === false) {
                 UtilityResponse::unableToDecode();
@@ -239,8 +239,8 @@ class CategoryController extends Controller
 
             $conditional_post_fields['resource_type_id']['allowed_values'][$id] = [
                 'value' => $id,
-                'name' => $resource_type->resource_type_name,
-                'description' => $resource_type->resource_type_description
+                'name' => $resource_type['resource_type_name'],
+                'description' => $resource_type['resource_type_description']
             ];
         }
 

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -76,12 +76,11 @@ class CategoryController extends Controller
     /**
      * Return a single category
      *
-     * @param Request $request
      * @param string $category_id
      *
      * @return JsonResponse
      */
-    public function show(Request $request, $category_id): JsonResponse
+    public function show($category_id): JsonResponse
     {
         Route::categoryRoute($category_id);
 

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -401,7 +401,12 @@ class ItemController extends Controller
             ];
         }
 
-        $categories = (new Category())->paginatedCollection($this->include_private, ['resource_type'=>$resource_type_id]);
+        $categories = (new Category())->paginatedCollection(
+            $this->include_private,
+            0,
+            100,
+            ['resource_type'=>$resource_type_id]
+        );
 
         foreach ($categories as $category) {
             $conditional_parameters['category']['allowed_values'][$this->hash->encode('category', $category['category_id'])] = [

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -29,7 +29,6 @@ use Illuminate\Support\Facades\Auth;
 class ItemController extends Controller
 {
     protected $collection_parameters = [];
-    protected $get_parameters = [];
     protected $pagination = [];
 
     /**

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -28,9 +28,6 @@ use Illuminate\Support\Facades\Auth;
  */
 class ItemController extends Controller
 {
-    protected $collection_parameters = [];
-    protected $pagination = [];
-
     /**
      * Return all the items based on the set filter options
      *

--- a/app/Http/Controllers/PassportController.php
+++ b/app/Http/Controllers/PassportController.php
@@ -28,10 +28,14 @@ class PassportController extends Controller
                     'email' => request('email'),
                     'password' => request('password')
                 ]
-            ) === true) {
+        ) === true) {
+            $token = Auth::user()->createToken('costs-to-expect-api');
 
-            $user = Auth::user();
-            $success['token'] = $user->createToken('costs-to-expect')->accessToken;
+            $success = [
+                'type' => 'Bearer',
+                'token' => $token->accessToken,
+                'expires' => $token->token->expires_at
+            ];
 
             return response()->json($success, 200);
         } else {

--- a/app/Http/Controllers/PassportController.php
+++ b/app/Http/Controllers/PassportController.php
@@ -31,13 +31,14 @@ class PassportController extends Controller
         ) === true) {
             $token = Auth::user()->createToken('costs-to-expect-api');
 
-            $success = [
-                'type' => 'Bearer',
-                'token' => $token->accessToken,
-                'expires' => $token->token->expires_at
-            ];
-
-            return response()->json($success, 200);
+            return response()->json(
+                [
+                    'type' => 'Bearer',
+                    'token' => $token->accessToken,
+                    'expires' => $token->token->expires_at
+                ],
+                200
+            );
         } else {
             return response()->json(['message' => 'Unauthorised, credentials invalid'], 401);
         }

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -137,7 +137,7 @@ class RequestController extends Controller
         return $this->generateOptionsForIndex(
             [
                 'description_localisation_string' => 'route-descriptions.request_GET_error_log',
-                'parameters_config_string' => [],
+                'parameters_config_string' => null,
                 'conditionals_config' => [],
                 'sortable_config' => null,
                 'searchable_config' => null,

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -10,6 +10,7 @@ use App\Models\ResourceType;
 use App\Models\Transformers\ResourceType as ResourceTypeTransformer;
 use App\Utilities\Response as UtilityResponse;
 use App\Validators\Request\Fields\ResourceType as ResourceTypeValidator;
+use App\Validators\Request\SearchParameters;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -30,8 +31,14 @@ class ResourceTypeController extends Controller
      */
     public function index(): JsonResponse
     {
+        $search_parameters = SearchParameters::fetch([
+            'name',
+            'description'
+        ]);
+
         $total = (new ResourceType())->totalCount(
-            $this->include_private
+            $this->include_private,
+            $search_parameters
         );
 
         $pagination = UtilityPagination::init(request()->path(), $total)
@@ -40,7 +47,8 @@ class ResourceTypeController extends Controller
         $resource_types = (new ResourceType())->paginatedCollection(
             $this->include_private,
             $pagination['offset'],
-            $pagination['limit']
+            $pagination['limit'],
+            $search_parameters
         );
 
         $headers = [
@@ -118,7 +126,7 @@ class ResourceTypeController extends Controller
                 'parameters_config_string' => [],
                 'conditionals_config' => [],
                 'sortable_config' => null,
-                'searchable_config' => null,
+                'searchable_config' => 'api.resource-type.searchable',
                 'enable_pagination' => true,
                 'authentication_required' => false
             ],

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -22,32 +22,29 @@ use Illuminate\Http\Request;
  */
 class ResourceTypeController extends Controller
 {
-    private $collection_parameters = [];
     private $show_parameters = [];
 
     /**
      * Return all the resource types
      *
-     * @param Request $request
-     *
      * @return JsonResponse
      */
-    public function index(Request $request): JsonResponse
+    public function index(): JsonResponse
     {
         $resource_types = (new ResourceType())->paginatedCollection($this->include_private);
 
-        $this->collection_parameters = Parameters::fetch(['include-resources']);
+        $parameters = Parameters::fetch(['include-resources']);
 
         $headers = [
             'X-Total-Count' => count($resource_types)
         ];
 
         return response()->json(
-            $resource_types->map(
-                function ($resource_type)
-                {
-                    return (new ResourceTypeTransformer($resource_type, $this->collection_parameters))->toArray();
-                }
+            array_map(
+                function($resource_type) use ($parameters) {
+                    return (new ResourceTypeTransformer($resource_type, $parameters))->toArray();
+                },
+                $resource_types
             ),
             200,
             $headers
@@ -164,7 +161,7 @@ class ResourceTypeController extends Controller
         }
 
         return response()->json(
-            (new ResourceTypeTransformer($resource_type))->toArray(),
+            (new ResourceTypeTransformer((New ResourceType())->instanceToArray($resource_type)))->toArray(),
             201
         );
     }

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -91,7 +91,9 @@ class ResourceTypeController extends Controller
             array_key_exists('include-resources', $parameters) === true &&
             $parameters['include-resources'] === true
         ) {
-            $resources = (new Resource())->paginatedCollection($resource_type_id);
+            $resources = (new Resource())->paginatedCollection(
+                $resource_type_id
+            );
         }
 
         return response()->json(

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -130,12 +130,11 @@ class ResourceTypeController extends Controller
     /**
      * Generate the OPTIONS request fir a specific resource type
      *
-     * @param Request $request
      * @param string $resource_type_id
      *
      * @return JsonResponse
      */
-    public function optionsShow(Request $request, string $resource_type_id): JsonResponse
+    public function optionsShow(string $resource_type_id): JsonResponse
     {
         Route::resourceTypeRoute($resource_type_id);
 
@@ -156,11 +155,9 @@ class ResourceTypeController extends Controller
     /**
      * Create a new resource type
      *
-     * @param Request $request
-     *
      * @return JsonResponse
      */
-    public function create(Request $request): JsonResponse
+    public function create(): JsonResponse
     {
         $validator = (new ResourceTypeValidator)->create();
 
@@ -170,9 +167,9 @@ class ResourceTypeController extends Controller
 
         try {
             $resource_type = new ResourceType([
-                'name' => $request->input('name'),
-                'description' => $request->input('description'),
-                'private' => $request->input('private', 0)
+                'name' => request()->input('name'),
+                'description' => request()->input('description'),
+                'private' => request()->input('private', 0)
             ]);
             $resource_type->save();
         } catch (Exception $e) {
@@ -188,13 +185,11 @@ class ResourceTypeController extends Controller
     /**
      * Delete the requested resource type
      *
-     * @param Request $request,
      * @param string $resource_type_id
      *
      * @return JsonResponse
      */
     public function delete(
-        Request $request,
         string $resource_type_id
     ): JsonResponse
     {

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -173,7 +173,12 @@ class ResourceTypeItemController extends Controller
             ];
         }
 
-        $categories = (new Category())->paginatedCollection($this->include_private, ['resource_type'=>$resource_type_id]);
+        $categories = (new Category())->paginatedCollection(
+            $this->include_private,
+            0,
+            100,
+            ['resource_type'=>$resource_type_id]
+        );
         array_map(
             function($category) {
                 $this->conditional_get_parameters['category']['allowed_values'][$this->hash->encode('category', $category['category_id'])] = [

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -19,7 +19,7 @@ use Illuminate\Http\Request;
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class SubCategoryController extends Controller
+class SubcategoryController extends Controller
 {
     /**
      * Return all the sub categories assigned to the given category

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -8,6 +8,7 @@ use App\Models\SubCategory;
 use App\Models\Transformers\SubCategory as SubCategoryTransformer;
 use App\Utilities\Response as UtilityResponse;
 use App\Validators\Request\Fields\SubCategory as SubCategoryValidator;
+use App\Validators\Request\SearchParameters;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -33,15 +34,25 @@ class SubcategoryController extends Controller
     {
         Route::categoryRoute($category_id);
 
-        $total = (new SubCategory())->totalCount($category_id);
+        $search_parameters = SearchParameters::fetch([
+            'name',
+            'description'
+        ]);
 
-        $pagination = UtilityPagination::init(request()->path(), $total)
-            ->paging();
+        $total = (new SubCategory())->totalCount(
+            $category_id,
+            $search_parameters
+        );
+
+        $pagination = UtilityPagination::init(request()->path(), $total)->
+            setSearchParameters($search_parameters)->
+            paging();
 
         $subcategories = (new SubCategory())->paginatedCollection(
             $category_id,
             $pagination['offset'],
-            $pagination['limit']
+            $pagination['limit'],
+            $search_parameters
         );
 
         $headers = [
@@ -117,7 +128,7 @@ class SubcategoryController extends Controller
                 'parameters_config_string' => 'api.subcategory.parameters.collection',
                 'conditionals_config' => [],
                 'sortable_config' => null,
-                'searchable_config' => null,
+                'searchable_config' => 'api.subcategory.searchable',
                 'enable_pagination' => true,
                 'authentication_required' => false
             ],

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -264,7 +264,7 @@ class SummaryItemController extends Controller
      *
      * @return JsonResponse
      */
-    public function categoriesSummary(): JsonResponse
+    private function categoriesSummary(): JsonResponse
     {
         $summary = (new ItemSummary())->categoriesSummary(
             $this->resource_type_id,
@@ -295,7 +295,7 @@ class SummaryItemController extends Controller
      *
      * @return JsonResponse
      */
-    public function filteredSummary(
+    private function filteredSummary(
         int $category_id = null,
         int $subcategory_id = null,
         int $year = null,
@@ -334,7 +334,7 @@ class SummaryItemController extends Controller
      *
      * @return JsonResponse
      */
-    public function categorySummary(int $category_id): JsonResponse
+    private function categorySummary(int $category_id): JsonResponse
     {
         Route::categoryRoute($category_id);
 
@@ -363,7 +363,7 @@ class SummaryItemController extends Controller
      *
      * @return JsonResponse
      */
-    public function subcategoriesSummary(int $category_id): JsonResponse
+    private function subcategoriesSummary(int $category_id): JsonResponse
     {
         Route::categoryRoute($category_id);
 
@@ -394,7 +394,7 @@ class SummaryItemController extends Controller
      *
      * @return JsonResponse
      */
-    public function subcategorySummary(int $category_id, int $sub_category_id): JsonResponse
+    private function subcategorySummary(int $category_id, int $sub_category_id): JsonResponse
     {
         Route::subCategoryRoute($category_id, $sub_category_id);
 

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Utilities\Response;
 use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\ItemSummary;
@@ -143,6 +144,10 @@ class SummaryItemController extends Controller
             $this->include_unpublished
         );
 
+        if (count($summary) === 0) {
+            Response::successEmptyContent(true);
+        }
+
         return response()->json(
             [
                 'total' => number_format($summary[0]['actualised_total'], 2, '.', '')
@@ -164,6 +169,10 @@ class SummaryItemController extends Controller
             $this->resource_id,
             $this->include_unpublished
         );
+
+        if (count($summary) === 0) {
+            Response::successEmptyContent(true);
+        }
 
         return response()->json(
             $summary->map(
@@ -192,8 +201,8 @@ class SummaryItemController extends Controller
             $this->include_unpublished
         );
 
-        if (count($summary) !== 1) {
-            UtilityResponse::notFound();
+        if (count($summary) === 0) {
+            Response::successEmptyContent();
         }
 
         return response()->json(
@@ -218,6 +227,10 @@ class SummaryItemController extends Controller
             $year,
             $this->include_unpublished
         );
+
+        if (count($summary) === 0) {
+            Response::successEmptyContent(true);
+        }
 
         return response()->json(
             $summary->map(
@@ -248,8 +261,8 @@ class SummaryItemController extends Controller
             $this->include_unpublished
         );
 
-        if (count($summary) !== 1) {
-            UtilityResponse::notFound();
+        if (count($summary) === 0) {
+            Response::successEmptyContent();
         }
 
         return response()->json(
@@ -271,6 +284,10 @@ class SummaryItemController extends Controller
             $this->resource_id,
             $this->include_unpublished
         );
+
+        if (count($summary) === 0) {
+            Response::successEmptyContent(true);
+        }
 
         return response()->json(
             array_map(
@@ -314,8 +331,8 @@ class SummaryItemController extends Controller
             $this->include_unpublished
         );
 
-        if (count($summary) !== 1) {
-            UtilityResponse::notFound();
+        if (count($summary) === 0) {
+            Response::successEmptyContent(true);
         }
 
         return response()->json(
@@ -345,8 +362,8 @@ class SummaryItemController extends Controller
             $this->include_unpublished
         );
 
-        if (count($summary) !== 1) {
-            UtilityResponse::notFound();
+        if (count($summary) === 0) {
+            Response::successEmptyContent();
         }
 
         return response()->json(
@@ -373,6 +390,10 @@ class SummaryItemController extends Controller
             $category_id,
             $this->include_unpublished
         );
+
+        if (count($summary) === 0) {
+            Response::successEmptyContent(true);
+        }
 
         return response()->json(
             array_map(
@@ -406,8 +427,8 @@ class SummaryItemController extends Controller
             $this->include_unpublished
         );
 
-        if (count($summary) !== 1) {
-            UtilityResponse::notFound();
+        if (count($summary) === 0) {
+            Response::successEmptyContent();
         }
 
         return response()->json(

--- a/app/Http/Controllers/SummaryResourceTypeItemController.php
+++ b/app/Http/Controllers/SummaryResourceTypeItemController.php
@@ -154,6 +154,10 @@ class SummaryResourceTypeItemController extends Controller
             $this->include_unpublished
         );
 
+        if (count($summary) === 0) {
+            UtilityResponse::successEmptyContent(true);
+        }
+
         return response()->json(
             [
                 'total' => number_format(
@@ -181,6 +185,10 @@ class SummaryResourceTypeItemController extends Controller
             $this->include_unpublished
         );
 
+        if (count($summary) === 0) {
+            UtilityResponse::successEmptyContent(true);
+        }
+
         return response()->json(
             array_map(
                 function ($resource) {
@@ -205,6 +213,10 @@ class SummaryResourceTypeItemController extends Controller
             $this->resource_type_id,
             $this->include_unpublished
         );
+
+        if (count($summary) === 0) {
+            UtilityResponse::successEmptyContent(true);
+        }
 
         return response()->json(
             array_map(
@@ -233,8 +245,8 @@ class SummaryResourceTypeItemController extends Controller
             $this->include_unpublished
         );
 
-        if (count($summary) !== 1) {
-            UtilityResponse::notFound();
+        if (count($summary) === 0) {
+            UtilityResponse::successEmptyContent();
         }
 
         return response()->json(
@@ -259,6 +271,10 @@ class SummaryResourceTypeItemController extends Controller
             $year,
             $this->include_unpublished
         );
+
+        if (count($summary) === 0) {
+            UtilityResponse::successEmptyContent(true);
+        }
 
         return response()->json(
             array_map(
@@ -290,8 +306,8 @@ class SummaryResourceTypeItemController extends Controller
             $this->include_unpublished
         );
 
-        if (count($summary) !== 1) {
-            UtilityResponse::notFound();
+        if (count($summary) === 0) {
+            UtilityResponse::successEmptyContent();
         }
 
         return response()->json(
@@ -313,6 +329,10 @@ class SummaryResourceTypeItemController extends Controller
             $this->resource_type_id,
             $this->include_unpublished
         );
+
+        if (count($summary) === 0) {
+            UtilityResponse::successEmptyContent(true);
+        }
 
         return response()->json(
             array_map(
@@ -342,12 +362,54 @@ class SummaryResourceTypeItemController extends Controller
             $this->include_unpublished
         );
 
-        if (count($summary) !== 1) {
-            UtilityResponse::notFound();
+        if (count($summary) === 0) {
+            UtilityResponse::successEmptyContent();
         }
 
         return response()->json(
             (new ResourceTypeItemCategorySummaryTransformer($summary[0]))->toArray(),
+            200,
+            ['X-Total-Count' => 1]
+        );
+    }
+
+    /**
+     * Return a filtered summary
+     *
+     * @param int|null $category_id
+     * @param int|null $subcategory_id
+     * @param int|null $year
+     * @param int|null $month
+     * @param array $search_parameters
+     *
+     * @return JsonResponse
+     */
+    public function filteredSummary(
+        int $category_id = null,
+        int $subcategory_id = null,
+        int $year = null,
+        int $month = null,
+        array $search_parameters = []
+    ): JsonResponse
+    {
+        $summary = (new ResourceTypeItem())->filteredSummary(
+            $this->resource_type_id,
+            $category_id,
+            $subcategory_id,
+            $year,
+            $month,
+            $search_parameters,
+            $this->include_unpublished
+        );
+
+        if (count($summary) === 0) {
+            UtilityResponse::successEmptyContent();
+        }
+
+        return response()->json(
+            [
+                'total' => number_format($summary[0]['total'], 2, '.', '')
+            ],
             200,
             ['X-Total-Count' => 1]
         );
@@ -368,6 +430,10 @@ class SummaryResourceTypeItemController extends Controller
             $category_id,
             $this->include_unpublished
         );
+
+        if (count($summary) === 0) {
+            UtilityResponse::successEmptyContent(true);
+        }
 
         return response()->json(
             array_map(
@@ -399,12 +465,17 @@ class SummaryResourceTypeItemController extends Controller
             $this->include_unpublished
         );
 
+        if (count($summary) === 0) {
+            UtilityResponse::successEmptyContent();
+        }
+
         return response()->json(
             (new ResourceTypeItemSubcategorySummaryTransformer($summary[0]))->toArray(),
             200,
             ['X-Total-Count' => 1]
         );
     }
+
 
     /**
      * Generate the OPTIONS request for items summary route

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -3,8 +3,9 @@ declare(strict_types=1);
 
 namespace App\Models;
 
-use DB;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Category model
@@ -14,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
  *
  * Categories are private if they are related to a private resource type
  *
+ * @mixin QueryBuilder
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -30,10 +30,38 @@ class Category extends Model
     }
 
     /**
+     * @param boolean $include_private
+     * @param array $parameters
+     *
+     * @return integer
+     */
+    public function totalCount(
+        bool $include_private,
+        array $parameters = []
+    ): int
+    {
+        $collection = $this->select('category.id')->
+            join("resource_type", "category.resource_type_id", "resource_type.id");
+
+        if (
+            array_key_exists('resource_type', $parameters) === true &&
+            $parameters['resource_type'] !== null
+        ) {
+            $collection->where('category.resource_type_id', '=', $parameters['resource_type']);
+        }
+
+        if ($include_private === false) {
+            $collection->where('resource_type.private', '=', 0);
+        }
+
+        return count($collection->get());
+    }
+
+    /**
      * Return the paginated collection
      *
      * @param boolean $include_private Should we include private categories?
-     * @param array $collection_parameters
+     * @param array $parameters
      * @param integer $offset
      * @param integer $limit
      *
@@ -41,7 +69,7 @@ class Category extends Model
      */
     public function paginatedCollection(
         bool $include_private,
-        array $collection_parameters,
+        array $parameters = [],
         int $offset = 0,
         int $limit = 10
     ): array {
@@ -66,15 +94,18 @@ class Category extends Model
         )->join("resource_type", "category.resource_type_id", "resource_type.id");
 
         if (
-            array_key_exists('resource_type', $collection_parameters) === true &&
-            $collection_parameters['resource_type'] !== null
+            array_key_exists('resource_type', $parameters) === true &&
+            $parameters['resource_type'] !== null
         ) {
-            $collection->where('category.resource_type_id', '=', $collection_parameters['resource_type']);
+            $collection->where('category.resource_type_id', '=', $parameters['resource_type']);
         }
 
         if ($include_private === false) {
             $collection->where('resource_type.private', '=', 0);
         }
+
+        $collection->offset($offset);
+        $collection->limit($limit);
 
         return $collection->get()->toArray();
     }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -102,7 +102,7 @@ class Category extends Model
                     `sub_category` 
                 WHERE 
                     `sub_category`.`category_id` = `category`.`id`
-            ) AS `category_sub_categories`'
+            ) AS `category_subcategories`'
         )->join("resource_type", "category.resource_type_id", "resource_type.id");
 
         if (
@@ -146,7 +146,7 @@ class Category extends Model
                 'category.description AS category_description',
                 'category.created_at AS category_created_at',
                 'category.updated_at AS category_updated_at',
-                DB::raw('(SELECT COUNT(sub_category.id) FROM sub_category WHERE sub_category.category_id = category.id) AS category_sub_categories'),
+                DB::raw('(SELECT COUNT(sub_category.id) FROM sub_category WHERE sub_category.category_id = category.id) AS category_subcategories'),
                 'resource_type.id AS resource_type_id',
                 'resource_type.name AS resource_type_name'
             )

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -34,12 +34,14 @@ class Category extends Model
     /**
      * @param boolean $include_private
      * @param array $parameters
+     * @param array $search_parameters
      *
      * @return integer
      */
     public function totalCount(
         bool $include_private,
-        array $parameters = []
+        array $parameters = [],
+        array $search_parameters = []
     ): int
     {
         $collection = $this->select('category.id')->
@@ -56,6 +58,12 @@ class Category extends Model
             $collection->where('resource_type.private', '=', 0);
         }
 
+        if (count($search_parameters) > 0) {
+            foreach ($search_parameters as $field => $search_term) {
+                $collection->where('category.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
+        }
+
         return count($collection->get());
     }
 
@@ -63,17 +71,19 @@ class Category extends Model
      * Return the paginated collection
      *
      * @param boolean $include_private Should we include private categories?
-     * @param array $parameters
      * @param integer $offset
      * @param integer $limit
+     * @param array $parameters
+     * @param array $search_parameters
      *
      * @return array
      */
     public function paginatedCollection(
         bool $include_private,
-        array $parameters = [],
         int $offset = 0,
-        int $limit = 10
+        int $limit = 10,
+        array $parameters = [],
+        array $search_parameters = []
     ): array {
         $collection = $this->select(
             'category.id AS category_id',
@@ -104,6 +114,12 @@ class Category extends Model
 
         if ($include_private === false) {
             $collection->where('resource_type.private', '=', 0);
+        }
+
+        if (count($search_parameters) > 0) {
+            foreach ($search_parameters as $field => $search_term) {
+                $collection->where('category.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
         }
 
         $collection->offset($offset);

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -7,6 +7,7 @@ use App\Utilities\General;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Item model
@@ -68,14 +69,14 @@ class Item extends Model
             array_key_exists('year', $parameters) === true &&
             $parameters['year'] !== null
         ) {
-            $collection->whereRaw(\DB::raw("YEAR(item.effective_date) = '{$parameters['year']}'"));
+            $collection->whereRaw(DB::raw("YEAR(item.effective_date) = '{$parameters['year']}'"));
         }
 
         if (
             array_key_exists('month', $parameters) === true &&
             $parameters['month'] !== null
         ) {
-            $collection->whereRaw(\DB::raw("MONTH(item.effective_date) = '{$parameters['month']}'"));
+            $collection->whereRaw(DB::raw("MONTH(item.effective_date) = '{$parameters['month']}'"));
         }
 
         if (

--- a/app/Models/ItemSummary.php
+++ b/app/Models/ItemSummary.php
@@ -310,12 +310,12 @@ class ItemSummary extends Model
     /**
      * Work out if we should be hiding unpublished items, by default we don't show them
      *
-     * @param Builder $collection
+     * @param $collection
      * @param boolean $include_unpublished
      *
      * @return Builder
      */
-    private function includeUnpublished(Builder $collection, bool $include_unpublished): Builder
+    private function includeUnpublished($collection, bool $include_unpublished): Builder
     {
         if ($include_unpublished === false) {
             $collection->where(function ($sql) {

--- a/app/Models/ItemSummary.php
+++ b/app/Models/ItemSummary.php
@@ -5,8 +5,10 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 
 /**
+ * @mixin QueryBuilder
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 
 /**
  * Resource model
  *
+ * @mixin QueryBuilder
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
@@ -26,7 +28,10 @@ class Resource extends Model
      *
      * @return integer
      */
-    public function totalCount(int $resource_type_id, bool $include_private = false): int
+    public function totalCount(
+        int $resource_type_id,
+        bool $include_private = false
+    ): int
     {
         $collection = $this->select("resource.id")->
             join('resource_type', 'resource.resource_type_id', 'resource_type.id')->
@@ -62,20 +67,27 @@ class Resource extends Model
                 'resource.effective_date AS resource_effective_date',
                 'resource.created_at AS resource_created_at'
             )->
-            where('resource_type_id', '=', $resource_type_id)->
-            latest()->
+            where('resource_type_id', '=', $resource_type_id);
+
+        return $collection->latest()->
             offset($offset)->
             limit($limit)->
             get()->
             toArray();
-
-        return $collection;
     }
 
     public function single(int $resource_type_id, int $resource_id)
     {
-        return $this->where('resource_type_id', '=', $resource_type_id)
-            ->find($resource_id);
+        return $this->select(
+                'resource.id AS resource_id',
+                'resource.name AS resource_name',
+                'resource.description AS resource_description',
+                'resource.effective_date AS resource_effective_date',
+                'resource.created_at AS resource_created_at'
+            )->
+            where('resource_type_id', '=', $resource_type_id)->
+            find($resource_id)->
+            toArray();
     }
 
     /**

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -49,12 +49,33 @@ class Resource extends Model
         return $this->belongsTo(ResourceType::class, 'resource_type_id', 'id');
     }
 
-    public function paginatedCollection(int $resource_type_id, int $offset = 0, int $limit = 10)
+    public function paginatedCollection(
+        int $resource_type_id,
+        int $offset = 0,
+        int $limit = 10
+    )
     {
         return $this->where('resource_type_id', '=', $resource_type_id)
             ->latest()
             ->get();
     }
+
+    // New method, return resources array
+    /*public function paginatedCollection(
+        int $resource_type_id,
+        int $offset = 0,
+        int $limit = 10
+    ): array
+    {
+        $collection = $this->where('resource_type_id', '=', $resource_type_id)->
+            latest()->
+            offset($offset)->
+            limit($limit)->
+            get()->
+            toArray();
+
+        return $collection;
+    }*/
 
     public function single(int $resource_type_id, int $resource_id)
     {
@@ -71,7 +92,10 @@ class Resource extends Model
      *
      * @return array
      */
-    public function resourcesForResourceType(int $resource_type_id, int $exclude_id = null): array
+    public function resourcesForResourceType(
+        int $resource_type_id,
+        int $exclude_id = null
+    ): array
     {
         $collection = $this->where('resource_type_id', '=', $resource_type_id);
 

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -25,12 +25,14 @@ class Resource extends Model
      *
      * @param integer $resource_type_id
      * @param boolean $include_private Include resources attached to private resource types
+     * @param array $search_parameters
      *
      * @return integer
      */
     public function totalCount(
         int $resource_type_id,
-        bool $include_private = false
+        bool $include_private = false,
+        array $search_parameters = []
     ): int
     {
         $collection = $this->select("resource.id")->
@@ -39,6 +41,12 @@ class Resource extends Model
 
         if ($include_private === false) {
             $collection->where('resource_type.private', '=', 0);
+        }
+
+        if (count($search_parameters) > 0) {
+            foreach ($search_parameters as $field => $search_term) {
+                $collection->where('resource.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
         }
 
         return count($collection->get());
@@ -57,7 +65,8 @@ class Resource extends Model
     public function paginatedCollection(
         int $resource_type_id,
         int $offset = 0,
-        int $limit = 10
+        int $limit = 10,
+        array $search_parameters = []
     ): array
     {
         $collection = $this->select(
@@ -68,6 +77,12 @@ class Resource extends Model
                 'resource.created_at AS resource_created_at'
             )->
             where('resource_type_id', '=', $resource_type_id);
+
+        if (count($search_parameters) > 0) {
+            foreach ($search_parameters as $field => $search_term) {
+                $collection->where('resource.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
+        }
 
         return $collection->latest()->
             offset($offset)->

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -53,21 +53,16 @@ class Resource extends Model
         int $resource_type_id,
         int $offset = 0,
         int $limit = 10
-    )
-    {
-        return $this->where('resource_type_id', '=', $resource_type_id)
-            ->latest()
-            ->get();
-    }
-
-    // New method, return resources array
-    /*public function paginatedCollection(
-        int $resource_type_id,
-        int $offset = 0,
-        int $limit = 10
     ): array
     {
-        $collection = $this->where('resource_type_id', '=', $resource_type_id)->
+        $collection = $this->select(
+                'resource.id AS resource_id',
+                'resource.name AS resource_name',
+                'resource.description AS resource_description',
+                'resource.effective_date AS resource_effective_date',
+                'resource.created_at AS resource_created_at'
+            )->
+            where('resource_type_id', '=', $resource_type_id)->
             latest()->
             offset($offset)->
             limit($limit)->
@@ -75,7 +70,7 @@ class Resource extends Model
             toArray();
 
         return $collection;
-    }*/
+    }
 
     public function single(int $resource_type_id, int $resource_id)
     {
@@ -110,5 +105,23 @@ class Resource extends Model
             )->
             get()->
             toArray();
+    }
+
+    /**
+     * Convert the model instance to an array for use with the transformer
+     *
+     * @param Resource
+     *
+     * @return array
+     */
+    public function instanceToArray(Resource $resource): array
+    {
+        return [
+            'resource_id' => $resource->id,
+            'resource_name' => $resource->name,
+            'resource_description' => $resource->description,
+            'resource_effective_date' => $resource->effective_date,
+            'resource_created_at' => $resource->created_at->toDateTimeString()
+        ];
     }
 }

--- a/app/Models/ResourceType.php
+++ b/app/Models/ResourceType.php
@@ -107,12 +107,30 @@ class ResourceType extends Model
         bool $include_private = false
     ): array
     {
+        $collection = $this->select(
+                'resource_type.id AS resource_type_id',
+                'resource_type.name AS resource_type_name',
+                'resource_type.description AS resource_type_description',
+                'resource_type.created_at AS resource_type_created_at',
+                'resource_type.private AS resource_type_private'
+            )->selectRaw('
+                (
+                    SELECT 
+                        COUNT(resource.id) 
+                    FROM 
+                        resource 
+                    WHERE 
+                        resource.resource_type_id = resource_type.id
+                ) AS resource_type_resources'
+            )->
+            leftJoin("resource", "resource_type.id", "resource.id");
+
         if ($include_private === false) {
-            return $this->where('private', '=', 0)->
+            return $collection->where('resource_type.private', '=', 0)->
                 find($resource_type_id)->
                 toArray();
         } else {
-            return $this->find($resource_type_id)->
+            return $collection->find($resource_type_id)->
                 toArray();
         }
     }

--- a/app/Models/ResourceType.php
+++ b/app/Models/ResourceType.php
@@ -27,14 +27,25 @@ class ResourceType extends Model
      * Return the total number of resource types
      *
      * @param boolean $include_private Include private resource types
+     * @param array $search_parameters
      *
      * @return integer
      */
-    public function totalCount(bool $include_private = false): int
+    public function totalCount(
+        bool $include_private = false,
+        array $search_parameters = []
+    ): int
     {
         $collection = $this->select("resource_type.id");
+
         if ($include_private === false) {
             $collection->where('resource_type.private', '=', 0);
+        }
+
+        if (count($search_parameters) > 0) {
+            foreach ($search_parameters as $field => $search_term) {
+                $collection->where('resource_type.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
         }
 
         return count($collection->get());
@@ -56,13 +67,15 @@ class ResourceType extends Model
      * @param boolean $include_private Also include private resource type
      * @param integer $offset Paging offset
      * @param integer $limit Paging limit
+     * @param array $search_parameters
      *
      * @return array
      */
     public function paginatedCollection(
         bool $include_private = false,
         int $offset = 0,
-        int $limit = 10
+        int $limit = 10,
+        array $search_parameters = []
     ): array
     {
         $collection = $this->select(
@@ -86,6 +99,12 @@ class ResourceType extends Model
 
         if ($include_private === false) {
             $collection->where('private', '=', 0);
+        }
+
+        if (count($search_parameters) > 0) {
+            foreach ($search_parameters as $field => $search_term) {
+                $collection->where('resource_type.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
         }
 
         $collection->offset($offset);

--- a/app/Models/ResourceTypeItem.php
+++ b/app/Models/ResourceTypeItem.php
@@ -234,19 +234,20 @@ class ResourceTypeItem extends Model
      * Return the summary for all items for the resources in the requested resource type
      *
      * @param int $resource_type_id
+     * @param boolean $include_unpublished = false
      *
      * @return array
      */
-    public function summary(int $resource_type_id): array
+    public function summary(int $resource_type_id, bool $include_unpublished): array
     {
-        return $this->selectRaw('sum(item.actualised_total) AS actualised_total')->
+        $collection = $this->selectRaw('sum(item.actualised_total) AS actualised_total')->
             join('resource', 'item.resource_id', 'resource.id')->
             join('resource_type', 'resource.resource_type_id', 'resource_type.id')->
-            where('resource_type.id', '=', $resource_type_id)->
-            where(function ($sql) {
-                $sql->whereNull('item.publish_after')->
-                    orWhereRaw('item.publish_after < NOW()');
-            })->
+            where('resource_type.id', '=', $resource_type_id);
+
+        $collection = $this->includeUnpublished($collection, $include_unpublished);
+
+        return $collection->
             get()->
             toArray();
     }

--- a/app/Models/ResourceTypeItem.php
+++ b/app/Models/ResourceTypeItem.php
@@ -259,20 +259,24 @@ class ResourceTypeItem extends Model
      * type grouped by resource
      *
      * @param int $resource_type_id
+     * @param boolean $include_unpublished
      *
      * @return array
      */
-    public function resourcesSummary(int $resource_type_id): array
+    public function resourcesSummary(int $resource_type_id, bool $include_unpublished): array
     {
-        return $this->selectRaw('resource.id AS id, resource.name AS `name`, SUM(item.actualised_total) AS total')->
+        $collection = $this->selectRaw('
+                resource.id AS id, 
+                resource.name AS `name`, 
+                SUM(item.actualised_total) AS total'
+            )->
             join('resource', 'item.resource_id', 'resource.id')->
             join('resource_type', 'resource.resource_type_id', 'resource_type.id')->
-            where('resource_type.id', '=', $resource_type_id)->
-            where(function ($sql) {
-                $sql->whereNull('item.publish_after')->
-                    orWhereRaw('item.publish_after < NOW()');
-            })->
-            groupBy('resource.id')->
+            where('resource_type.id', '=', $resource_type_id);
+
+        $collection = $this->includeUnpublished($collection, $include_unpublished);
+
+        return $collection->groupBy('resource.id')->
             orderBy('name')->
             get()->
             toArray();
@@ -309,23 +313,26 @@ class ResourceTypeItem extends Model
      * Return the summary for all items for the resources in the requested resource
      * type grouped by month for the requested year
      *
-     * @param integer $year
      * @param integer $resource_type_id
-
+     * @param integer $year
+     * @param boolean $include_unpublished
+     *
      * @return array
      */
-    public function monthsSummary(int $resource_type_id, int $year): array
+    public function monthsSummary(int $resource_type_id, int $year, bool $include_unpublished): array
     {
-        return $this->selectRaw("MONTH(item.effective_date) as month, SUM(item.actualised_total) AS total")->
+        $collection = $this->selectRaw("
+                MONTH(item.effective_date) as month, 
+                SUM(item.actualised_total) AS total"
+            )->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             where("resource_type.id", "=", $resource_type_id)->
-            where(DB::raw('YEAR(item.effective_date)'), '=', $year)->
-            where(function ($sql) {
-                $sql->whereNull('item.publish_after')->
-                    orWhereRaw('item.publish_after < NOW()');
-            })->
-            groupBy("month")->
+            where(DB::raw('YEAR(item.effective_date)'), '=', $year);
+
+        $collection = $this->includeUnpublished($collection, $include_unpublished);
+
+        return $collection->groupBy("month")->
             orderBy("month")->
             get()->
             toArray();
@@ -335,25 +342,33 @@ class ResourceTypeItem extends Model
      * Return the summary for all items for the resources in the requested resource
      * type for a specific year and month
      *
+     * @param integer $resource_type_id
      * @param integer $year
      * @param integer $month
-     * @param int $resource_type_id
-
+     * @param boolean $include_unpublished
+     *
      * @return array
      */
-    public function monthSummary(int $resource_type_id, int $year, int $month): array
+    public function monthSummary(
+        int $resource_type_id,
+        int $year,
+        int $month,
+        bool $include_unpublished
+    ): array
     {
-        return $this->selectRaw("MONTH(item.effective_date) as month, SUM(item.actualised_total) AS total")->
+        $collection = $this->selectRaw("
+                MONTH(item.effective_date) as month, 
+                SUM(item.actualised_total) AS total"
+            )->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             where("resource_type.id", "=", $resource_type_id)->
             where(DB::raw('YEAR(item.effective_date)'), '=', $year)->
-            where(DB::raw('MONTH(item.effective_date)'), '=', $month)->
-            where(function ($sql) {
-                $sql->whereNull('item.publish_after')->
-                    orWhereRaw('item.publish_after < NOW()');
-            })->
-            groupBy("month")->
+            where(DB::raw('MONTH(item.effective_date)'), '=', $month);
+
+        $collection = $this->includeUnpublished($collection, $include_unpublished);
+
+        return $collection->groupBy("month")->
             orderBy("month")->
             get()->
             toArray();
@@ -363,23 +378,26 @@ class ResourceTypeItem extends Model
      * Return the summary for all items for the resources in the requested resource
      * type for a specific year
      *
-     * @param integer $year
      * @param integer $resource_type_id
-
+     * @param integer $year
+     * @param boolean $include_unpublished
+     *
      * @return array
      */
-    public function yearSummary(int $resource_type_id, int $year): array
+    public function yearSummary(int $resource_type_id, int $year, bool $include_unpublished): array
     {
-        return $this->selectRaw("YEAR(item.effective_date) as year, SUM(item.actualised_total) AS total")->
+        $collection = $this->selectRaw("
+                YEAR(item.effective_date) as year, 
+                SUM(item.actualised_total) AS total"
+            )->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
             where("resource_type.id", "=", $resource_type_id)->
-            where(DB::raw('YEAR(item.effective_date)'), '=', $year)->
-            where(function ($sql) {
-                $sql->whereNull('item.publish_after')->
-                    orWhereRaw('item.publish_after < NOW()');
-            })->
-            groupBy("year")->
+            where(DB::raw('YEAR(item.effective_date)'), '=', $year);
+
+        $collection = $this->includeUnpublished($collection, $include_unpublished);
+
+        return $collection->groupBy("year")->
             orderBy("year")->
             get()->
             toArray();
@@ -453,6 +471,50 @@ class ResourceTypeItem extends Model
         return $collection->groupBy("category.id")->
             orderBy("name")->
             get()->
+            toArray();
+    }
+
+    public function filteredSummary(
+        int $resource_type_id,
+        int $category_id = null,
+        int $subcategory_id = null,
+        int $year = null,
+        int $month = null,
+        array $search_parameters = [],
+        bool $include_unpublished = false
+    ): array
+    {
+        $collection = $this->
+            selectRaw('SUM(item.actualised_total) AS total')->
+            join("resource", "resource.id", "item.resource_id")->
+            join("resource_type", "resource_type.id", "resource.resource_type_id")->
+            join("item_category", "item_category.item_id", "item.id")->
+            join("item_sub_category", "item_sub_category.item_category_id", "item_category.id")->
+            join("category", "category.id", "item_category.category_id")->
+            join("sub_category", "sub_category.id", "item_sub_category.sub_category_id")->
+            where("resource_type.id", "=", $resource_type_id);
+
+        if ($category_id !== null) {
+            $collection->where("category.id", "=", $category_id);
+        }
+        if ($subcategory_id !== null) {
+            $collection->where("sub_category.id", "=", $subcategory_id);
+        }
+        if ($year !== null) {
+            $collection->whereRaw(\DB::raw("YEAR(item.effective_date) = {$year}"));
+        }
+        if ($month !== null) {
+            $collection->whereRaw(\DB::raw("MONTH(item.effective_date) = {$month}"));
+        }
+        if (count($search_parameters) > 0) {
+            foreach ($search_parameters as $field => $search_term) {
+                $collection->where('item.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
+        }
+
+        $collection = $this->includeUnpublished($collection, $include_unpublished);
+
+        return $collection->get()->
             toArray();
     }
 
@@ -540,12 +602,12 @@ class ResourceTypeItem extends Model
     /**
      * Work out if we should be hiding unpublished items, by default we don't show them
      *
-     * @param Builder $collection
+     * @param $collection
      * @param boolean $include_unpublished
      *
      * @return Builder
      */
-    private function includeUnpublished(Builder $collection, bool $include_unpublished): Builder
+    private function includeUnpublished($collection, bool $include_unpublished): Builder
     {
         if ($include_unpublished === false) {
             $collection->where(function ($sql) {

--- a/app/Models/SubCategory.php
+++ b/app/Models/SubCategory.php
@@ -3,12 +3,14 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 
 /**
  * Sub category model
  *
+ * @mixin QueryBuilder
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright Dean Blackborough 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
@@ -26,36 +28,54 @@ class SubCategory extends Model
 
     /**
      * @param integer $category_id
+     * @param array $search_parameters
      *
-     * @return array
+     * @return integer
      */
     public function totalCount(
-        int $category_id
+        int $category_id,
+        array $search_parameters = []
     ): int
     {
-        return count(
-            $this->where('category_id', '=', $category_id)->get()
-        );
+        $collection = $this->where('category_id', '=', $category_id);
+
+        if (count($search_parameters) > 0) {
+            foreach ($search_parameters as $field => $search_term) {
+                $collection->where('sub_category.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
+        }
+
+        return count($collection->get());
     }
 
     /**
      * @param integer $category_id
      * @param integer $offset
      * @param integer $limit
+     * @param array $search_parameters
      *
      * @return array
      */
     public function paginatedCollection(
         int $category_id,
         int $offset = 0,
-        int $limit = 10
+        int $limit = 10,
+        array $search_parameters = []
     ): array
     {
-        return $this->where('category_id', '=', $category_id)->
-            orderBy("name")->
+        $collection = $this->where('category_id', '=', $category_id);
+
+        if (count($search_parameters) > 0) {
+            foreach ($search_parameters as $field => $search_term) {
+                $collection->where('sub_category.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
+        }
+
+        $collection->orderBy("name")->
             offset($offset)->
-            limit($limit)->
-            get()->
+            limit($limit);
+
+        return $collection->get()->
             toArray();
     }
 

--- a/app/Models/SubCategory.php
+++ b/app/Models/SubCategory.php
@@ -26,6 +26,20 @@ class SubCategory extends Model
 
     /**
      * @param integer $category_id
+     *
+     * @return array
+     */
+    public function totalCount(
+        int $category_id
+    ): int
+    {
+        return count(
+            $this->where('category_id', '=', $category_id)->get()
+        );
+    }
+
+    /**
+     * @param integer $category_id
      * @param integer $offset
      * @param integer $limit
      *
@@ -39,6 +53,8 @@ class SubCategory extends Model
     {
         return $this->where('category_id', '=', $category_id)->
             orderBy("name")->
+            offset($offset)->
+            limit($limit)->
             get()->
             toArray();
     }

--- a/app/Models/Transformers/Category.php
+++ b/app/Models/Transformers/Category.php
@@ -17,9 +17,7 @@ use App\Models\SubCategory as SubCategoryModel;
  */
 class Category extends Transformer
 {
-    protected $data_to_transform;
-
-    private $parameters = [];
+    private $data_to_transform;
 
     private $subcategories = [];
 
@@ -27,14 +25,14 @@ class Category extends Transformer
      * ResourceType constructor.
      *
      * @param array $data_to_transform
-     * @param array $parameters
+     * @param array $subcategories
      */
-    public function __construct(array $data_to_transform, array $parameters = [])
+    public function __construct(array $data_to_transform, array $subcategories = [])
     {
         parent::__construct();
 
         $this->data_to_transform = $data_to_transform;
-        $this->parameters = $parameters;
+        $this->subcategories = $subcategories;
     }
 
     public function toArray(): array
@@ -47,26 +45,15 @@ class Category extends Transformer
             'resource_type' => [
                 'id' => $this->hash->resourceType()->encode($this->data_to_transform['resource_type_id']),
                 'name' => $this->data_to_transform['resource_type_name'],
-            ],
-            'subcategories_count' => $this->data_to_transform['category_sub_categories']
+            ]
         ];
 
-        if (
-            isset($this->parameters['include-subcategories']) &&
-            $this->parameters['include-subcategories'] === true
-        ) {
-            $subcategories = (new SubCategoryModel())->paginatedCollection(
-                $this->data_to_transform['category_id']
-            );
+        if (array_key_exists('category_subcategories', $this->data_to_transform)) {
+            $result['subcategories']['count'] = $this->data_to_transform['category_subcategories'];
+        }
 
-            array_map(
-                function($subcategory) {
-                    $this->subcategories[] = (new SubCategory($subcategory))->toArray();
-                },
-                $subcategories
-            );
-
-            $result['subcategories'] = $this->subcategories;
+        foreach ($this->subcategories as $subcategory) {
+            $result['subcategories']['collection'][] = (new SubCategory($subcategory))->toArray();
         }
 
         return $result;

--- a/app/Models/Transformers/Resource.php
+++ b/app/Models/Transformers/Resource.php
@@ -12,23 +12,23 @@ namespace App\Models\Transformers;
  */
 class Resource extends Transformer
 {
-    protected $resource;
+    private $data_to_transform;
 
-    public function __construct(\App\Models\Resource $resource)
+    public function __construct(array $data_to_transform)
     {
         parent::__construct();
 
-        $this->resource = $resource;
+        $this->data_to_transform = $data_to_transform;
     }
 
     public function toArray(): array
     {
         return [
-            'id' => $this->hash->resource()->encode($this->resource->id),
-            'name' => $this->resource->name,
-            'description' => $this->resource->description,
-            'effective_date' => $this->resource->effective_date,
-            'created' => $this->resource->created_at->toDateTimeString()
+            'id' => $this->hash->resource()->encode($this->data_to_transform['resource_id']),
+            'name' => $this->data_to_transform['resource_name'],
+            'description' => $this->data_to_transform['resource_description'],
+            'effective_date' => $this->data_to_transform['resource_effective_date'],
+            'created' => $this->data_to_transform['resource_created_at']
         ];
     }
 }

--- a/app/Models/Transformers/ResourceType.php
+++ b/app/Models/Transformers/ResourceType.php
@@ -26,6 +26,8 @@ class ResourceType extends Transformer
      *
      * @param array $data_to_transform
      * @param array $parameters
+     *
+     * @todo Pass in resources data array, let the controller do the work.
      */
     public function __construct(array $data_to_transform, array $parameters = [])
     {

--- a/app/Models/Transformers/ResourceType.php
+++ b/app/Models/Transformers/ResourceType.php
@@ -48,11 +48,11 @@ class ResourceType extends Transformer
         ];
 
         if (array_key_exists('resource_type_resources', $this->data_to_transform)) {
-            $result['resources-count'] = $this->data_to_transform['resource_type_resources'];
+            $result['resources']['count'] = $this->data_to_transform['resource_type_resources'];
         }
 
         foreach ($this->resources as $resource) {
-            $result['resources'][] = (new ResourceTransformer($resource))->toArray();
+            $result['resources']['collection'][] = (new ResourceTransformer($resource))->toArray();
         }
 
         return $result;

--- a/app/Models/Transformers/ResourceType.php
+++ b/app/Models/Transformers/ResourceType.php
@@ -15,7 +15,8 @@ use App\Models\Transformers\Resource as ResourceTransformer;
  */
 class ResourceType extends Transformer
 {
-    private $resource_type;
+    private $data_to_transform;
+
     private $parameters = [];
 
     private $resources = [];
@@ -23,14 +24,14 @@ class ResourceType extends Transformer
     /**
      * ResourceType constructor.
      *
-     * @param ResourceTypeModel $resource_type
+     * @param array $data_to_transform
      * @param array $parameters
      */
-    public function __construct(ResourceTypeModel $resource_type, array $parameters = [])
+    public function __construct(array $data_to_transform, array $parameters = [])
     {
         parent::__construct();
 
-        $this->resource_type = $resource_type;
+        $this->data_to_transform = $data_to_transform;
         $this->parameters = $parameters;
     }
 
@@ -42,15 +43,18 @@ class ResourceType extends Transformer
     public function toArray(): array
     {
         $result = [
-            'id' => $this->hash->resourceType()->encode($this->resource_type->id),
-            'name' => $this->resource_type->name,
-            'description' => $this->resource_type->description,
-            'created' => $this->resource_type->created_at->toDateTimeString(),
-            'public' => !boolval($this->resource_type->private),
-            'resources-count' => $this->resource_type->resources_count()
+            'id' => $this->hash->resourceType()->encode($this->data_to_transform['resource_type_id']),
+            'name' => $this->data_to_transform['resource_type_name'],
+            'description' => $this->data_to_transform['resource_type_description'],
+            'created' => $this->data_to_transform['resource_type_created_at'],
+            'public' => !boolval($this->data_to_transform['resource_type_private']),
         ];
 
-        if (isset($this->parameters['include-resources']) && $this->parameters['include-resources'] === true) {
+        if (array_key_exists('resource_type_resources', $this->data_to_transform)) {
+            $result['resources-count'] = $this->data_to_transform['resource_type_resources'];
+        }
+
+        /*if (isset($this->parameters['include-resources']) && $this->parameters['include-resources'] === true) {
             $resourcesCollection = $this->resource_type->resources;
 
             $resourcesCollection->map(
@@ -60,7 +64,7 @@ class ResourceType extends Transformer
             );
 
             $result['resources'] = $this->resources;
-        }
+        }*/
 
         return $result;
     }

--- a/app/Models/Transformers/ResourceType.php
+++ b/app/Models/Transformers/ResourceType.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace App\Models\Transformers;
 
-use App\Models\ResourceType as ResourceTypeModel;
 use App\Models\Transformers\Resource as ResourceTransformer;
 
 /**
@@ -17,24 +16,20 @@ class ResourceType extends Transformer
 {
     private $data_to_transform;
 
-    private $parameters = [];
-
     private $resources = [];
 
     /**
      * ResourceType constructor.
      *
      * @param array $data_to_transform
-     * @param array $parameters
-     *
-     * @todo Pass in resources data array, let the controller do the work.
+     * @param array $resources
      */
-    public function __construct(array $data_to_transform, array $parameters = [])
+    public function __construct(array $data_to_transform, array $resources = [])
     {
         parent::__construct();
 
         $this->data_to_transform = $data_to_transform;
-        $this->parameters = $parameters;
+        $this->resources = $resources;
     }
 
     /**
@@ -56,17 +51,9 @@ class ResourceType extends Transformer
             $result['resources-count'] = $this->data_to_transform['resource_type_resources'];
         }
 
-        /*if (isset($this->parameters['include-resources']) && $this->parameters['include-resources'] === true) {
-            $resourcesCollection = $this->resource_type->resources;
-
-            $resourcesCollection->map(
-                function ($resource_item) {
-                    $this->resources[] = (new ResourceTransformer($resource_item))->toArray();
-                }
-            );
-
-            $result['resources'] = $this->resources;
-        }*/
+        foreach ($this->resources as $resource) {
+            $result['resources'][] = (new ResourceTransformer($resource))->toArray();
+        }
 
         return $result;
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -27,10 +27,6 @@ class AuthServiceProvider extends ServiceProvider
 
         Passport::routes();
 
-        Passport::tokensExpireIn(now()->addDays(30));
-
-        Passport::refreshTokensExpireIn(now()->addDays(60));
-
         Passport::personalAccessTokensExpireIn(now()->addMonths(3));
     }
 }

--- a/app/Utilities/Response.php
+++ b/app/Utilities/Response.php
@@ -128,14 +128,25 @@ class Response
     }
 
     /**
-     * 404 error, unable to decode the selected value, hasher missing or value
-     * invalid
+     * 204, successful request, no content to return, typically a PATCH
      *
      * @return JsonResponse
      */
     static public function successNoContent(): JsonResponse
     {
         response()->json([],204)->send();
+        exit;
+    }
+
+    /**
+     * 200, successful request, no content to return
+     *
+     * @param boolean $array Return empty array, if false empty object
+     * @return JsonResponse
+     */
+    static public function successEmptyContent(bool $array = false): JsonResponse
+    {
+        response()->json(($array === true ? [] : null),200)->send();
         exit;
     }
 

--- a/app/Validators/Request/Parameters.php
+++ b/app/Validators/Request/Parameters.php
@@ -87,23 +87,7 @@ class Parameters
                     }
                     break;
 
-                case 'months':
-                    if (array_key_exists($key, self::$parameters) === true) {
-                        if (General::isBooleanValue(self::$parameters[$key]) === false) {
-                            unset(self::$parameters[$key]);
-                        }
-                    }
-                    break;
-
                 case 'resource_type':
-                    if (array_key_exists($key, self::$parameters) === true) {
-                        if ((new ResourceType())->
-                            where('id', '=', self::$parameters[$key])->exists() === false) {
-                            unset(self::$parameters[$key]);
-                        }
-                    }
-                    break;
-
                 case 'resource-type':
                     if (array_key_exists($key, self::$parameters) === true) {
                         if ((new ResourceType())->
@@ -114,18 +98,6 @@ class Parameters
                     break;
 
                 case 'subcategory':
-                    if (array_key_exists($key, self::$parameters) === true) {
-                        if (
-                            (new SubCategory())->
-                            where('sub_category.id', '=', self::$parameters[$key])->
-                            where('sub_category.category_id', '=', self::$parameters['category'])->
-                            exists() === false
-                        ) {
-                            unset(self::$parameters[$key]);
-                        }
-                    }
-                    break;
-
                 case 'sub_category':
                     if (array_key_exists($key, self::$parameters) === true) {
                         if (
@@ -139,7 +111,9 @@ class Parameters
                     }
                     break;
 
+                case 'months':
                 case 'subcategories':
+                case 'years':
                     if (array_key_exists($key, self::$parameters) === true) {
                         if (General::isBooleanValue(self::$parameters[$key]) === false) {
                             unset(self::$parameters[$key]);
@@ -150,16 +124,8 @@ class Parameters
                 case 'year':
                     if (array_key_exists($key, self::$parameters) === true) {
                         if (intval(self::$parameters[$key]) < 2013 ||
-                            self::$parameters[$key] > intval(date('Y'))) {
+                            self::$parameters[$key] > intval(date('Y')) + 1) {
 
-                            unset(self::$parameters[$key]);
-                        }
-                    }
-                    break;
-
-                case 'years':
-                    if (array_key_exists($key, self::$parameters) === true) {
-                        if (General::isBooleanValue(self::$parameters[$key]) === false) {
                             unset(self::$parameters[$key]);
                         }
                     }

--- a/config/api/category/parameters.php
+++ b/config/api/category/parameters.php
@@ -3,15 +3,7 @@
 declare(strict_types=1);
 
 return [
-    'collection' => [
-        'include-subcategories' => [
-            'field' => 'include-subcategories',
-            'title' => 'category/parameters.title-include-subcategories',
-            'description' => 'category/parameters.description-include-subcategories',
-            'type' => 'boolean',
-            'required' => false
-        ]
-    ],
+    'collection' => [],
     'item' => [
         'include-subcategories' => [
             'field' => 'include-subcategories',

--- a/config/api/category/searchable.php
+++ b/config/api/category/searchable.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name',
+    'description'
+];

--- a/config/api/resource-type-item/summary-searchable.php
+++ b/config/api/resource-type-item/summary-searchable.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'description'
+];

--- a/config/api/resource-type/parameters.php
+++ b/config/api/resource-type/parameters.php
@@ -3,15 +3,6 @@
 declare(strict_types=1);
 
 return [
-    'collection' => [
-        'include-resources' => [
-            'field' => 'include-resources',
-            'title' => 'resource-type/parameters.title-include-resources',
-            'description' => 'resource-type/parameters.description-include-resources',
-            'type' => 'boolean',
-            'required' => false
-        ]
-    ],
     'item' => [
         'include-resources' => [
             'field' => 'include-resources',

--- a/config/api/resource-type/searchable.php
+++ b/config/api/resource-type/searchable.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name',
+    'description'
+];

--- a/config/api/resource/searchable.php
+++ b/config/api/resource/searchable.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name',
+    'description'
+];

--- a/config/api/subcategory/searchable.php
+++ b/config/api/subcategory/searchable.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name',
+    'description'
+];

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '1.16.5',
+    'version'=> '1.17.5',
     'prefix' => 'v1',
-    'release_date' => '2019-07-29',
+    'release_date' => '2019-08-xx',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '1.17.5',
+    'version'=> '1.17.0',
     'prefix' => 'v1',
-    'release_date' => '2019-08-xx',
+    'release_date' => '2019-08-06',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/routes/api/private-routes.php
+++ b/routes/api/private-routes.php
@@ -24,7 +24,7 @@ Route::group(
 
         Route::post(
             'categories/{category_id}/subcategories',
-            'SubCategoryController@create'
+            'SubcategoryController@create'
         );
 
         Route::post(
@@ -64,7 +64,7 @@ Route::group(
 
         Route::delete(
             'categories/{category_id}/sub_categories/{sub_category_id}',
-            'SubCategoryController@delete'
+            'SubcategoryController@delete'
         );
 
         Route::delete(

--- a/routes/api/public-routes.php
+++ b/routes/api/public-routes.php
@@ -66,22 +66,22 @@ Route::group(
 
         Route::get(
             'categories/{category_id}/subcategories',
-            'SubCategoryController@index'
+            'SubcategoryController@index'
         );
 
         Route::options(
             'categories/{category_id}/subcategories',
-            'SubCategoryController@optionsIndex'
+            'SubcategoryController@optionsIndex'
         );
 
         Route::get(
             'categories/{category_id}/subcategories/{sub_category_id}',
-            'SubCategoryController@show'
+            'SubcategoryController@show'
         );
 
         Route::options(
             'categories/{category_id}/subcategories/{sub_category_id}',
-            'SubCategoryController@optionsShow'
+            'SubcategoryController@optionsShow'
         );
 
         Route::get(


### PR DESCRIPTION
### Added 
- The `v1/summary/resource-types/items` summary supports all the same features as the main `items` summary; you can make a filtered request and even include a search term.
- We have added pagination to the `/v1/categories` GET endpoint.
- We have added pagination to the `/v1/categories/[category]/subcategories` GET endpoint.
- We have added pagination to the `/v1/resource-tyes` GET endpoint.
- We have added pagination to the `/v1/resource-types/[resource-type]/resources` GET endpoint.
- We have added search to the `/v1/categories` GET endpoint; you can search on `name` and `description`.
- We have added search to the `/v1/resource-types` GET endpoint; you can search on `name` and `description`.
- We have added search to the `/v1/categories/[category]/subcategories` GET endpoint; you can search on `name` and `description`.
- We have added search to the `/v1/resource-types/[resource-type]/resources` GET endpoint; you can search on `name` and `description`.

### Changed
- We have modified the year GET parameter to include "next" year, we may have unpublished items for next year and don't want to prohibit summarising the data. (The `year` validation should limit based on the existing data, an issue has been created to find a better solution).
- We have removed unnecessary clauses in the base validation switch statement.
- We have altered the format of the included resources and subcategories when the `include-resources` or `include-subcategories` parameters exist in the request.

### Fixed
- The resource type items summaries are not using the `include-unpublished` parameter.
- The response for a summary request that returns no results returns a 200, not a 404, the endpoint is correct it just no longer returns results because of the GET parameters.
- Transformers should not call models, only transform data, corrected the ResourceType transformer.

### Removed
- Removed the `include-resources` parameter from the resource type collection, not useful at the collection level and causes unnecessary SQL requests, remains an option when requesting a single resource type.
- Removed the `include-subcategories` parameter from the categories collection, not useful at the collection level and causes unnecessary SQL requests, remains an option when requesting a single category.