### PR TITLE
v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ## [v1.18.0] - 2019-08-07
 ### Added
 - We have added sorting to the `/v1/resource-types` collection; you can sort on `name`, `description` and date created.
-- We have added sorting to the `/v1/resource-types/[resource-type]/resources` collection; you can sort on `name`, `descrption`, `effective date` and date created.
+- We have added sorting to the `/v1/resource-types/[resource-type]/resources` collection; you can sort on `name`, `description`, `effective date` and date created.
 - We have added sorting to the `/v1/categories` collection; you can sort on `name`, `description` and date created. 
 - We have added sorting to the `/v1/categories/[category]/subcategories` collection; you can sort on `name`, `description` and date created.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.18.0] - 2019-08-07
+### Added
+- We have added sorting to the `/v1/resource-types` collection; you can sort on `name`, `description` and date created.
+- We have added sorting to the `/v1/resource-types/[resource-type]/resources` collection; you can sort on `name`, `descrption`, `effective date` and date created.
+- We have added sorting to the `/v1/categories` collection; you can sort on `name`, `description` and date created. 
+- We have added sorting to the `/v1/categories/[category]/subcategories` collection; you can sort on `name`, `description` and date created.
+
+### Changed
+- We have been busy refactoring again, mainly in the models this time.
+- We have increased the Postman test coverage; we are not yet at full coverage; however, we are approaching full coverage with every release.
+
+### Fixed
+- We have removed a redundant query after the create category request.
+
 ## [v1.17.0] - 2019-08-06
 ### Added 
 - The `v1/summary/resource-types/items` summary supports all the same features as the main `items` summary; you can make a filtered request and even include a search term.

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -12,6 +12,7 @@ use App\Models\Transformers\Category as CategoryTransformer;
 use App\Utilities\Response as UtilityResponse;
 use App\Validators\Request\Fields\Category as CategoryValidator;
 use App\Validators\Request\SearchParameters;
+use App\Validators\Request\SortParameters;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -44,8 +45,15 @@ class CategoryController extends Controller
             $search_parameters
         );
 
+        $sort_parameters = SortParameters::fetch([
+            'name',
+            'description',
+            'created'
+        ]);
+
         $pagination = UtilityPagination::init(request()->path(), $total)->
             setSearchParameters($search_parameters)->
+            setSortParameters($sort_parameters)->
             paging();
 
         $categories = (new Category())->paginatedCollection(
@@ -53,7 +61,8 @@ class CategoryController extends Controller
             $pagination['offset'],
             $pagination['limit'],
             [],
-            $search_parameters
+            $search_parameters,
+            $sort_parameters
         );
 
         $headers = [
@@ -120,18 +129,16 @@ class CategoryController extends Controller
     /**
      * Generate the OPTIONS request for the category list
      *
-     * @param Request $request
-     *
      * @return JsonResponse
      */
-    public function optionsIndex(Request $request): JsonResponse
+    public function optionsIndex(): JsonResponse
     {
         return $this->generateOptionsForIndex(
             [
                 'description_localisation_string' => 'route-descriptions.category_GET_index',
                 'parameters_config_string' => 'api.category.parameters.collection',
                 'conditionals_config' => [],
-                'sortable_config' => null,
+                'sortable_config' => 'api.category.sortable',
                 'searchable_config' => 'api.category.searchable',
                 'enable_pagination' => true,
                 'authentication_required' => false
@@ -148,12 +155,11 @@ class CategoryController extends Controller
     /**
      * Generate the OPTIONS request for a specific category
      *
-     * @param Request $request
      * @param string $category_id
      *
      * @return JsonResponse
      */
-    public function optionsShow(Request $request, string $category_id): JsonResponse
+    public function optionsShow(string $category_id): JsonResponse
     {
         Route::categoryRoute($category_id);
 
@@ -210,13 +216,11 @@ class CategoryController extends Controller
     /**
      * Delete the requested category
      *
-     * @param Request $request,
      * @param string $category_id
      *
      * @return JsonResponse
      */
     public function delete(
-        Request $request,
         string $category_id
     ): JsonResponse
     {

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -174,11 +174,9 @@ class CategoryController extends Controller
     /**
      * Create a new category
      *
-     * @param Request $request
-     *
      * @return JsonResponse
      */
-    public function create(Request $request): JsonResponse
+    public function create(): JsonResponse
     {
         $validator = (new CategoryValidator)->create();
 
@@ -187,15 +185,15 @@ class CategoryController extends Controller
         }
 
         try {
-            $resource_type_id = $this->hash->decode('resource_type', $request->input('resource_type_id'));
+            $resource_type_id = $this->hash->decode('resource_type', request()->input('resource_type_id'));
 
             if ($resource_type_id === false) {
                 UtilityResponse::unableToDecode();
             }
 
             $category = new Category([
-                'name' => $request->input('name'),
-                'description' => $request->input('description'),
+                'name' => request()->input('name'),
+                'description' => request()->input('description'),
                 'resource_type_id' => $resource_type_id
             ]);
             $category->save();
@@ -204,7 +202,7 @@ class CategoryController extends Controller
         }
 
         return response()->json(
-            (new CategoryTransformer((new Category)->single($category->id)))->toArray(),
+            (new CategoryTransformer((new Category)->instanceToArray($category)))->toArray(),
             201
         );
     }

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -248,7 +248,7 @@ class ItemCategoryController extends Controller
 
         $conditional_post_parameters = ['category_id' => []];
         foreach ($categories as $category) {
-            $id = $this->hash->encode('category', $category->category_id);
+            $id = $this->hash->encode('category', $category['category_id']);
 
             if ($id === false) {
                 UtilityResponse::unableToDecode();
@@ -256,8 +256,8 @@ class ItemCategoryController extends Controller
 
             $conditional_post_parameters['category_id']['allowed_values'][$id] = [
                 'value' => $id,
-                'name' => $category->category_name,
-                'description' => $category->category_description
+                'name' => $category['category_name'],
+                'description' => $category['category_description']
             ];
         }
 

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -45,7 +45,7 @@ class ItemSubCategoryController extends Controller
         Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill') {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
         $item_sub_category = (new ItemSubCategory())->paginatedCollection(
@@ -56,7 +56,7 @@ class ItemSubCategoryController extends Controller
         );
 
         if ($item_sub_category === null) {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
         $headers = [
@@ -94,7 +94,7 @@ class ItemSubCategoryController extends Controller
         Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill' || $item_sub_category_id === 'nill') {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
         $item_sub_category = (new ItemSubCategory())->single(
@@ -106,7 +106,7 @@ class ItemSubCategoryController extends Controller
         );
 
         if ($item_sub_category === null) {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
         $headers = [
@@ -142,7 +142,7 @@ class ItemSubCategoryController extends Controller
         Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill') {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
         $item_category = (new ItemCategory())->find($item_category_id);
@@ -193,7 +193,7 @@ class ItemSubCategoryController extends Controller
         Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill' || $item_sub_category_id === 'nill') {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
         $item_sub_category = (new ItemSubCategory())->single(
@@ -205,7 +205,7 @@ class ItemSubCategoryController extends Controller
         );
 
         if ($item_sub_category === null) {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
         return $this->generateOptionsForShow(
@@ -244,7 +244,7 @@ class ItemSubCategoryController extends Controller
         Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill') {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
         $item_category = (new ItemCategory())
@@ -337,7 +337,7 @@ class ItemSubCategoryController extends Controller
         Route::itemRoute($resource_type_id, $resource_id, $item_id);
 
         if ($item_category_id === 'nill' || $item_sub_category_id === 'nill') {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
         $item_sub_category = (new ItemSubCategory())->single(
@@ -349,7 +349,7 @@ class ItemSubCategoryController extends Controller
         );
 
         if ($item_sub_category === null) {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
         try {
@@ -359,7 +359,7 @@ class ItemSubCategoryController extends Controller
         } catch (QueryException $e) {
             UtilityResponse::foreignKeyConstraintError();
         } catch (Exception $e) {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
     }
 }

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -9,6 +9,7 @@ use App\Models\Transformers\Resource as ResourceTransformer;
 use App\Utilities\Response as UtilityResponse;
 use App\Validators\Request\Fields\Resource as ResourceValidator;
 use App\Validators\Request\SearchParameters;
+use App\Validators\Request\SortParameters;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -44,15 +45,24 @@ class ResourceController extends Controller
             $search_parameters
         );
 
+        $sort_parameters = SortParameters::fetch([
+            'name',
+            'description',
+            'effective_date',
+            'created'
+        ]);
+
         $pagination = UtilityPagination::init(request()->path(), $total)->
             setSearchParameters($search_parameters)->
+            setSortParameters($sort_parameters)->
             paging();
 
         $resources = (new Resource)->paginatedCollection(
             $resource_type_id,
             $pagination['offset'],
             $pagination['limit'],
-            $search_parameters
+            $search_parameters,
+            $sort_parameters
         );
 
         $headers = [
@@ -122,8 +132,8 @@ class ResourceController extends Controller
                 'description_localisation_string' => 'route-descriptions.resource_GET_index',
                 'parameters_config_string' => 'api.resource.parameters.collection',
                 'conditionals_config' => [],
-                'sortable_config' => null,
-                'searchable_config' => 'api.resources.searchable',
+                'sortable_config' => 'api.resource.sortable',
+                'searchable_config' => 'api.resource.searchable',
                 'enable_pagination' => true,
                 'authentication_required' => false
             ],

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -93,7 +93,7 @@ class ResourceController extends Controller
 
         $resource = (new Resource)->single($resource_type_id, $resource_id);
 
-        if ($resource === 1) {
+        if ($resource === null) {
             UtilityResponse::notFound(trans('entities.resource'));
         }
 

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -11,6 +11,7 @@ use App\Models\Transformers\ResourceType as ResourceTypeTransformer;
 use App\Utilities\Response as UtilityResponse;
 use App\Validators\Request\Fields\ResourceType as ResourceTypeValidator;
 use App\Validators\Request\SearchParameters;
+use App\Validators\Request\SortParameters;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -41,14 +42,23 @@ class ResourceTypeController extends Controller
             $search_parameters
         );
 
-        $pagination = UtilityPagination::init(request()->path(), $total)
-            ->paging();
+        $sort_parameters = SortParameters::fetch([
+            'name',
+            'description',
+            'created'
+        ]);
+
+        $pagination = UtilityPagination::init(request()->path(), $total)->
+            setSearchParameters($search_parameters)->
+            setSortParameters($sort_parameters)->
+            paging();
 
         $resource_types = (new ResourceType())->paginatedCollection(
             $this->include_private,
             $pagination['offset'],
             $pagination['limit'],
-            $search_parameters
+            $search_parameters,
+            $sort_parameters
         );
 
         $headers = [
@@ -125,7 +135,7 @@ class ResourceTypeController extends Controller
                 'description_localisation_string' => 'route-descriptions.resource_type_GET_index',
                 'parameters_config_string' => [],
                 'conditionals_config' => [],
-                'sortable_config' => null,
+                'sortable_config' => 'api.resource-type.sortable',
                 'searchable_config' => 'api.resource-type.searchable',
                 'enable_pagination' => true,
                 'authentication_required' => false

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -79,14 +79,12 @@ class SubcategoryController extends Controller
     /**
      * Return a single sub category
      *
-     * @param Request $request
      * @param string $category_id
      * @param string $sub_category_id
      *
      * @return JsonResponse
      */
     public function show(
-        Request $request,
         string $category_id,
         string $sub_category_id
     ): JsonResponse
@@ -144,14 +142,12 @@ class SubcategoryController extends Controller
     /**
      * Generate the OPTIONS request for the specific sub category
      *
-     * @param Request $request
      * @param string $category_id
      * @param string $sub_category_id
      *
      * @return JsonResponse
      */
     public function optionsShow(
-        Request $request,
         string $category_id,
         string $sub_category_id
     ): JsonResponse
@@ -175,12 +171,11 @@ class SubcategoryController extends Controller
     /**
      * Create a new sub category
      *
-     * @param Request $request
      * @param string $category_id
      *
      * @return JsonResponse
      */
-    public function create(Request $request, string $category_id): JsonResponse
+    public function create(string $category_id): JsonResponse
     {
         Route::categoryRoute($category_id);
 
@@ -202,7 +197,7 @@ class SubcategoryController extends Controller
         }
 
         return response()->json(
-            (new SubCategoryTransformer((new SubCategory())->single($category_id, $sub_category->id)))->toArray(),
+            (new SubCategoryTransformer((new SubCategory())->instanceToArray($sub_category)))->toArray(),
             201
         );
     }
@@ -210,14 +205,12 @@ class SubcategoryController extends Controller
     /**
      * Delete the requested sub category
      *
-     * @param Request $request,
-     * @param string $category_id,
+     * @param string $category_id
      * @param string $sub_category_id
      *
      * @return JsonResponse
      */
     public function delete(
-        Request $request,
         string $category_id,
         string $sub_category_id
     ): JsonResponse
@@ -230,7 +223,7 @@ class SubcategoryController extends Controller
         );
 
         if ($sub_category === null) {
-            UtilityResponse::notFound(trans('entities.sub-category'));
+            UtilityResponse::notFound(trans('entities.subcategory'));
         }
 
         try {
@@ -240,7 +233,7 @@ class SubcategoryController extends Controller
         } catch (QueryException $e) {
             UtilityResponse::foreignKeyConstraintError();
         } catch (Exception $e) {
-            UtilityResponse::notFound(trans('entities.sub-category'));
+            UtilityResponse::notFound(trans('entities.subcategory'));
         }
     }
 }

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -9,6 +9,7 @@ use App\Models\Transformers\SubCategory as SubCategoryTransformer;
 use App\Utilities\Response as UtilityResponse;
 use App\Validators\Request\Fields\SubCategory as SubCategoryValidator;
 use App\Validators\Request\SearchParameters;
+use App\Validators\Request\SortParameters;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -44,15 +45,23 @@ class SubcategoryController extends Controller
             $search_parameters
         );
 
+        $sort_parameters = SortParameters::fetch([
+            'name',
+            'description',
+            'created'
+        ]);
+
         $pagination = UtilityPagination::init(request()->path(), $total)->
             setSearchParameters($search_parameters)->
+            setSortParameters($sort_parameters)->
             paging();
 
         $subcategories = (new SubCategory())->paginatedCollection(
             $category_id,
             $pagination['offset'],
             $pagination['limit'],
-            $search_parameters
+            $search_parameters,
+            $sort_parameters
         );
 
         $headers = [
@@ -125,7 +134,7 @@ class SubcategoryController extends Controller
                 'description_localisation_string' => 'route-descriptions.sub_category_GET_index',
                 'parameters_config_string' => 'api.subcategory.parameters.collection',
                 'conditionals_config' => [],
-                'sortable_config' => null,
+                'sortable_config' => 'api.subcategory.sortable',
                 'searchable_config' => 'api.subcategory.searchable',
                 'enable_pagination' => true,
                 'authentication_required' => false

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -75,6 +75,7 @@ class Category extends Model
      * @param integer $limit
      * @param array $parameters
      * @param array $search_parameters
+     * @param array $sort_parameters
      *
      * @return array
      */
@@ -83,7 +84,8 @@ class Category extends Model
         int $offset = 0,
         int $limit = 10,
         array $parameters = [],
-        array $search_parameters = []
+        array $search_parameters = [],
+        array $sort_parameters = []
     ): array {
         $collection = $this->select(
             'category.id AS category_id',
@@ -120,6 +122,22 @@ class Category extends Model
             foreach ($search_parameters as $field => $search_term) {
                 $collection->where('category.' . $field, 'LIKE', '%' . $search_term . '%');
             }
+        }
+
+        if (count($sort_parameters) > 0) {
+            foreach ($sort_parameters as $field => $direction) {
+                switch ($field) {
+                    case 'created':
+                        $collection->orderBy('category.created_at', $direction);
+                        break;
+
+                    default:
+                        $collection->orderBy('category.' . $field, $direction);
+                        break;
+                }
+            }
+        } else {
+            $collection->orderBy('category.name', 'asc');
         }
 
         $collection->offset($offset);

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -133,11 +133,11 @@ class Category extends Model
      *
      * @param integer $category_id
      *
-     * @return array
+     * @return array|null
      */
-    public function single(int $category_id): array
+    public function single(int $category_id): ?array
     {
-        return $this->join('resource_type', $this->table . '.resource_type_id', '=', 'resource_type.id')
+        $result = $this->join('resource_type', $this->table . '.resource_type_id', '=', 'resource_type.id')
             ->where('category.id', '=', intval($category_id))
             ->orderBy('category.name')
             ->select(
@@ -150,8 +150,13 @@ class Category extends Model
                 'resource_type.id AS resource_type_id',
                 'resource_type.name AS resource_type_name'
             )
-            ->first()
-            ->toArray();
+            ->first();
+
+        if ($result === null) {
+            return null;
+        } else {
+            return $result->toArray();
+        }
     }
 
     /**
@@ -172,5 +177,23 @@ class Category extends Model
                 'category.description AS category_description'
             )
             ->get();
+    }
+
+    /**
+     * Convert the model instance to an array for use with the transformer
+     *
+     * @param Category $category
+     *
+     * @return array
+     */
+    public function instanceToArray(Category $category): array
+    {
+        return [
+            'category_id' => $category->id,
+            'category_name' => $category->name,
+            'category_description' => $category->description,
+            'category_created_at' => $category->created_at->toDateTimeString(),
+            'resource_type_id' => $category->resource_type_id
+        ];
     }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -164,19 +164,20 @@ class Category extends Model
      *
      * @param integer $resource_type_id
      *
-     * @return \Illuminate\Support\Collection
+     * @return array
      */
-    public function categoriesByResourceType(int $resource_type_id)
+    public function categoriesByResourceType(int $resource_type_id): array
     {
-        return $this->join('resource_type', $this->table . '.resource_type_id', '=', 'resource_type.id')
-            ->where('resource_type.id', '=', intval($resource_type_id))
-            ->orderBy('category.name')
-            ->select(
+        return $this->join('resource_type', $this->table . '.resource_type_id', '=', 'resource_type.id')->
+            where('resource_type.id', '=', intval($resource_type_id))->
+            orderBy('category.name')->
+            select(
                 'category.id AS category_id',
                 'category.name AS category_name',
                 'category.description AS category_description'
-            )
-            ->get();
+            )->
+            get()->
+            toArray();
     }
 
     /**

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -91,9 +91,9 @@ class Resource extends Model
             toArray();
     }
 
-    public function single(int $resource_type_id, int $resource_id)
+    public function single(int $resource_type_id, int $resource_id): ?array
     {
-        return $this->select(
+        $result = $this->select(
                 'resource.id AS resource_id',
                 'resource.name AS resource_name',
                 'resource.description AS resource_description',
@@ -101,8 +101,13 @@ class Resource extends Model
                 'resource.created_at AS resource_created_at'
             )->
             where('resource_type_id', '=', $resource_type_id)->
-            find($resource_id)->
-            toArray();
+            find($resource_id);
+
+        if ($result !== null) {
+            return $result->toArray();
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -66,7 +66,8 @@ class Resource extends Model
         int $resource_type_id,
         int $offset = 0,
         int $limit = 10,
-        array $search_parameters = []
+        array $search_parameters = [],
+        array $sort_parameters = []
     ): array
     {
         $collection = $this->select(
@@ -84,8 +85,23 @@ class Resource extends Model
             }
         }
 
-        return $collection->latest()->
-            offset($offset)->
+        if (count($sort_parameters) > 0) {
+            foreach ($sort_parameters as $field => $direction) {
+                switch ($field) {
+                    case 'created':
+                        $collection->orderBy('created_at', $direction);
+                        break;
+
+                    default:
+                        $collection->orderBy($field, $direction);
+                        break;
+                }
+            }
+        } else {
+            $collection->latest();
+        }
+
+        return $collection->offset($offset)->
             limit($limit)->
             get()->
             toArray();

--- a/app/Models/ResourceType.php
+++ b/app/Models/ResourceType.php
@@ -56,11 +56,6 @@ class ResourceType extends Model
         return $this->hasMany(Resource::class, 'resource_type_id', 'id');
     }
 
-    public function resources_count()
-    {
-        return $this->hasMany(Resource::class, 'resource_type_id', 'id')->count();
-    }
-
     /**
      * Return the paginated collection
      *
@@ -126,7 +121,7 @@ class ResourceType extends Model
         bool $include_private = false
     ): array
     {
-        $collection = $this->select(
+        $result = $this->select(
                 'resource_type.id AS resource_type_id',
                 'resource_type.name AS resource_type_name',
                 'resource_type.description AS resource_type_description',
@@ -145,13 +140,11 @@ class ResourceType extends Model
             leftJoin("resource", "resource_type.id", "resource.id");
 
         if ($include_private === false) {
-            return $collection->where('resource_type.private', '=', 0)->
-                find($resource_type_id)->
-                toArray();
-        } else {
-            return $collection->find($resource_type_id)->
-                toArray();
+            $result->where('resource_type.private', '=', 0);
         }
+
+        return $result->find($resource_type_id)->
+            toArray();
     }
 
     /**

--- a/app/Models/SubCategory.php
+++ b/app/Models/SubCategory.php
@@ -53,6 +53,7 @@ class SubCategory extends Model
      * @param integer $offset
      * @param integer $limit
      * @param array $search_parameters
+     * @param array $sort_parameters
      *
      * @return array
      */
@@ -60,7 +61,8 @@ class SubCategory extends Model
         int $category_id,
         int $offset = 0,
         int $limit = 10,
-        array $search_parameters = []
+        array $search_parameters = [],
+        array $sort_parameters = []
     ): array
     {
         $collection = $this->select(
@@ -77,8 +79,23 @@ class SubCategory extends Model
             }
         }
 
-        $collection->orderBy("name")->
-            offset($offset)->
+        if (count($sort_parameters) > 0) {
+            foreach ($sort_parameters as $field => $direction) {
+                switch ($field) {
+                    case 'created':
+                        $collection->orderBy('sub_category.created_at', $direction);
+                        break;
+
+                    default:
+                        $collection->orderBy('sub_category.' . $field, $direction);
+                        break;
+                }
+            }
+        } else {
+            $collection->orderBy('sub_category.name', 'asc');
+        }
+
+        $collection->offset($offset)->
             limit($limit);
 
         return $collection->get()->

--- a/app/Models/Transformers/Category.php
+++ b/app/Models/Transformers/Category.php
@@ -43,10 +43,13 @@ class Category extends Transformer
             'description' => $this->data_to_transform['category_description'],
             'created' => $this->data_to_transform['category_created_at'],
             'resource_type' => [
-                'id' => $this->hash->resourceType()->encode($this->data_to_transform['resource_type_id']),
-                'name' => $this->data_to_transform['resource_type_name'],
+                'id' => $this->hash->resourceType()->encode($this->data_to_transform['resource_type_id'])
             ]
         ];
+
+        if (array_key_exists('resource_type_name', $this->data_to_transform) === true) {
+           $result['resource_type']['name'] = $this->data_to_transform['resource_type_name'];
+        }
 
         if (array_key_exists('category_subcategories', $this->data_to_transform)) {
             $result['subcategories']['count'] = $this->data_to_transform['category_subcategories'];

--- a/app/Models/Transformers/SubCategory.php
+++ b/app/Models/Transformers/SubCategory.php
@@ -24,10 +24,10 @@ class SubCategory extends Transformer
     public function toArray(): array
     {
         return [
-            'id' => $this->hash->subCategory()->encode($this->data_to_transform['id']),
-            'name' => $this->data_to_transform['name'],
-            'description' => $this->data_to_transform['description'],
-            'created' => $this->data_to_transform['created_at']
+            'id' => $this->hash->subCategory()->encode($this->data_to_transform['subcategory_id']),
+            'name' => $this->data_to_transform['subcategory_name'],
+            'description' => $this->data_to_transform['subcategory_description'],
+            'created' => $this->data_to_transform['subcategory_created_at']
         ];
     }
 }

--- a/app/Validators/Request/Route.php
+++ b/app/Validators/Request/Route.php
@@ -31,7 +31,7 @@ class Route
     static public function subCategoryRoute($category_id, $sub_category_id)
     {
         if (SubCategory::validate($category_id, $sub_category_id) === false) {
-            UtilityResponse::notFound(trans('entities.sub-category'));
+            UtilityResponse::notFound(trans('entities.subcategory'));
         }
     }
 
@@ -88,7 +88,7 @@ class Route
                 $item_sub_category_id
             ) === false
         ) {
-            UtilityResponse::notFound(trans('entities.item-sub-category'));
+            UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
     }
 }

--- a/config/api/category/sortable.php
+++ b/config/api/category/sortable.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name',
+    'description',
+    'created'
+];

--- a/config/api/resource-type/sortable.php
+++ b/config/api/resource-type/sortable.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name',
+    'description',
+    'created'
+];

--- a/config/api/resource/sortable.php
+++ b/config/api/resource/sortable.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name',
+    'description',
+    'effective_date',
+    'created'
+];

--- a/config/api/subcategory/sortable.php
+++ b/config/api/subcategory/sortable.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'name',
+    'description',
+    'created'
+];

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '1.17.0',
+    'version'=> '1.18.0',
     'prefix' => 'v1',
-    'release_date' => '2019-08-06',
+    'release_date' => '2019-08-07',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/resources/lang/en/entities.php
+++ b/resources/lang/en/entities.php
@@ -6,8 +6,8 @@ return [
     'resource-type' => 'Resource Type',
     'resource' => 'Resource',
     'category' => 'Category',
-    'sub-category' => 'Sub Category',
+    'subcategory' => 'Subcategory',
     'item' => 'Item (Expense)',
     'item-category' => 'Assigned Category',
-    'item-sub-category' => 'Assigned Sub Category'
+    'item-sub-category' => 'Assigned Subcategory'
 ];


### PR DESCRIPTION
### Added
- We have added sorting to the `/v1/resource-types` collection; you can sort on `name`, `description` and date created.
- We have added sorting to the `/v1/resource-types/[resource-type]/resources` collection; you can sort on `name`, `description`, `effective date` and date created.
- We have added sorting to the `/v1/categories` collection; you can sort on `name`, `description` and date created. 
- We have added sorting to the `/v1/categories/[category]/subcategories` collection; you can sort on `name`, `description` and date created.

### Changed
- We have been busy refactoring again, mainly in the models this time.
- We have increased the Postman test coverage; we are not yet at full coverage; however, we are approaching full coverage with every release.

### Fixed
- We have removed a redundant query after the create category request.