### PR TITLE
v1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.19.0] - 2019-08-xx
+### Added
+- We have added an `X-Sort` header to responses, displays the valid sort options, the applied sort options may differ to the requested sort options.
+- We have added an `X-Search` header to responses, displays the valid search options, the applied search options may differ to the requested search options.
+
+### Changed
+- We have eliminated some code duplication around allowable search and sort options.
+
+### Fixed
+- Sorting the `/v1/resource-type/[resource-type]/resources/[resource]/items` collection by description generates an error, table name missing from sort field causing ambiguity.
+
 ## [v1.18.0] - 2019-08-07
 ### Added
 - We have added sorting to the `/v1/resource-types` collection; you can sort on `name`, `description` and date created.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
-## [v1.19.0] - 2019-08-xx
+## [v1.19.0] - 2019-08-08
 ### Added
 - We have added an `X-Sort` header to responses, displays the valid sort options, the applied sort options may differ to the requested sort options.
 - We have added an `X-Search` header to responses, displays the valid search options, the applied search options may differ to the requested search options.
 
 ### Changed
 - We have eliminated some code duplication around allowable search and sort options.
+- We have eliminated some code duplication in the models relating to the way search parameters get added to the queries.
 
 ### Fixed
 - Sorting the `/v1/resource-type/[resource-type]/resources/[resource]/items` collection by description generates an error, table name missing from sort field causing ambiguity.

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -17,6 +17,7 @@ use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 
 /**
  * Manage categories
@@ -34,10 +35,9 @@ class CategoryController extends Controller
      */
     public function index(): JsonResponse
     {
-        $search_parameters = SearchParameters::fetch([
-            'name',
-            'description'
-        ]);
+        $search_parameters = SearchParameters::fetch(
+            Config::get('api.category.searchable')
+        );
 
         $total = (new Category())->totalCount(
             $this->include_private,
@@ -45,11 +45,9 @@ class CategoryController extends Controller
             $search_parameters
         );
 
-        $sort_parameters = SortParameters::fetch([
-            'name',
-            'description',
-            'created'
-        ]);
+        $sort_parameters = SortParameters::fetch(
+            Config::get('api.category.sortable')
+        );
 
         $pagination = UtilityPagination::init(request()->path(), $total)->
             setSearchParameters($search_parameters)->
@@ -73,6 +71,16 @@ class CategoryController extends Controller
             'X-Link-Previous' => $pagination['links']['previous'],
             'X-Link-Next' => $pagination['links']['next']
         ];
+
+        $sort_header = SortParameters::xHeader();
+        if ($sort_header !== null) {
+            $headers['X-Sort'] = $sort_header;
+        }
+
+        $search_header = SearchParameters::xHeader();
+        if ($search_header !== null) {
+            $headers['X-Search'] = $search_header;
+        }
 
         return response()->json(
             array_map(

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -13,6 +13,7 @@ use App\Validators\Request\SortParameters;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Config;
 
 /**
  * Manage resources
@@ -34,10 +35,9 @@ class ResourceController extends Controller
     {
         Route::resourceTypeRoute($resource_type_id);
 
-        $search_parameters = SearchParameters::fetch([
-            'name',
-            'description'
-        ]);
+        $search_parameters = SearchParameters::fetch(
+            Config::get('api.resource.searchable')
+        );
 
         $total = (new Resource())->totalCount(
             $resource_type_id,
@@ -45,12 +45,9 @@ class ResourceController extends Controller
             $search_parameters
         );
 
-        $sort_parameters = SortParameters::fetch([
-            'name',
-            'description',
-            'effective_date',
-            'created'
-        ]);
+        $sort_parameters = SortParameters::fetch(
+            Config::get('api.resource.sortable')
+        );
 
         $pagination = UtilityPagination::init(request()->path(), $total)->
             setSearchParameters($search_parameters)->
@@ -73,6 +70,16 @@ class ResourceController extends Controller
             'X-Link-Previous' => $pagination['links']['previous'],
             'X-Link-Next' => $pagination['links']['next']
         ];
+
+        $sort_header = SortParameters::xHeader();
+        if ($sort_header !== null) {
+            $headers['X-Sort'] = $sort_header;
+        }
+
+        $search_header = SearchParameters::xHeader();
+        if ($search_header !== null) {
+            $headers['X-Search'] = $search_header;
+        }
 
         return response()->json(
             array_map(

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -14,6 +14,7 @@ use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 
 /**
  * Manage category sub categories
@@ -35,21 +36,18 @@ class SubcategoryController extends Controller
     {
         Route::categoryRoute($category_id);
 
-        $search_parameters = SearchParameters::fetch([
-            'name',
-            'description'
-        ]);
+        $search_parameters = SearchParameters::fetch(
+            Config::get('api.subcategory.searchable')
+        );
 
         $total = (new SubCategory())->totalCount(
             $category_id,
             $search_parameters
         );
 
-        $sort_parameters = SortParameters::fetch([
-            'name',
-            'description',
-            'created'
-        ]);
+        $sort_parameters = SortParameters::fetch(
+            Config::get('api.subcategory.sortable')
+        );
 
         $pagination = UtilityPagination::init(request()->path(), $total)->
             setSearchParameters($search_parameters)->
@@ -72,6 +70,16 @@ class SubcategoryController extends Controller
             'X-Link-Previous' => $pagination['links']['previous'],
             'X-Link-Next' => $pagination['links']['next']
         ];
+
+        $sort_header = SortParameters::xHeader();
+        if ($sort_header !== null) {
+            $headers['X-Sort'] = $sort_header;
+        }
+
+        $search_header = SearchParameters::xHeader();
+        if ($search_header !== null) {
+            $headers['X-Search'] = $search_header;
+        }
 
         return response()->json(
             array_map(

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Utilities\Model as ModelUtility;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
@@ -58,11 +59,7 @@ class Category extends Model
             $collection->where('resource_type.private', '=', 0);
         }
 
-        if (count($search_parameters) > 0) {
-            foreach ($search_parameters as $field => $search_term) {
-                $collection->where('category.' . $field, 'LIKE', '%' . $search_term . '%');
-            }
-        }
+        $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 
         return count($collection->get());
     }
@@ -118,11 +115,7 @@ class Category extends Model
             $collection->where('resource_type.private', '=', 0);
         }
 
-        if (count($search_parameters) > 0) {
-            foreach ($search_parameters as $field => $search_term) {
-                $collection->where('category.' . $field, 'LIKE', '%' . $search_term . '%');
-            }
-        }
+        $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 
         if (count($sort_parameters) > 0) {
             foreach ($sort_parameters as $field => $direction) {

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -242,11 +242,11 @@ class Item extends Model
             foreach ($sort_parameters as $field => $direction) {
                 switch ($field) {
                     case 'created':
-                        $collection->orderBy('created_at', $direction);
+                        $collection->orderBy('item.created_at', $direction);
                         break;
 
                     default:
-                        $collection->orderBy($field, $direction);
+                        $collection->orderBy('item.' . $field, $direction);
                         break;
                 }
             }

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Utilities\General;
+use App\Utilities\Model as ModelUtility;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
@@ -97,11 +98,7 @@ class Item extends Model
             $collection->where('item_sub_category.sub_category_id', '=', $parameters['subcategory']);
         }
 
-        if (count($search_parameters) > 0) {
-            foreach ($search_parameters as $field => $search_term) {
-                $collection->where('item.' . $field, 'LIKE', '%' . $search_term . '%');
-            }
-        }
+        $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 
         if (
             array_key_exists('include-unpublished', $parameters) === false ||
@@ -223,11 +220,7 @@ class Item extends Model
             $collection->where('item_sub_category.sub_category_id', '=', $parameters['subcategory']);
         }
 
-        if (count($search_parameters) > 0) {
-            foreach ($search_parameters as $field => $search_term) {
-                $collection->where('item.' . $field, 'LIKE', '%' . $search_term . '%');
-            }
-        }
+        $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 
         if (
             array_key_exists('include-unpublished', $parameters) === false ||

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Utilities\Model as ModelUtility;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
@@ -43,11 +44,7 @@ class Resource extends Model
             $collection->where('resource_type.private', '=', 0);
         }
 
-        if (count($search_parameters) > 0) {
-            foreach ($search_parameters as $field => $search_term) {
-                $collection->where('resource.' . $field, 'LIKE', '%' . $search_term . '%');
-            }
-        }
+        $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 
         return count($collection->get());
     }
@@ -79,11 +76,7 @@ class Resource extends Model
             )->
             where('resource_type_id', '=', $resource_type_id);
 
-        if (count($search_parameters) > 0) {
-            foreach ($search_parameters as $field => $search_term) {
-                $collection->where('resource.' . $field, 'LIKE', '%' . $search_term . '%');
-            }
-        }
+        $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 
         if (count($sort_parameters) > 0) {
             foreach ($sort_parameters as $field => $direction) {

--- a/app/Models/ResourceType.php
+++ b/app/Models/ResourceType.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Utilities\Model as ModelUtility;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
@@ -42,11 +43,7 @@ class ResourceType extends Model
             $collection->where('resource_type.private', '=', 0);
         }
 
-        if (count($search_parameters) > 0) {
-            foreach ($search_parameters as $field => $search_term) {
-                $collection->where('resource_type.' . $field, 'LIKE', '%' . $search_term . '%');
-            }
-        }
+        $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 
         return count($collection->get());
     }
@@ -97,11 +94,7 @@ class ResourceType extends Model
             $collection->where('private', '=', 0);
         }
 
-        if (count($search_parameters) > 0) {
-            foreach ($search_parameters as $field => $search_term) {
-                $collection->where('resource_type.' . $field, 'LIKE', '%' . $search_term . '%');
-            }
-        }
+        $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 
         if (count($sort_parameters) > 0) {
             foreach ($sort_parameters as $field => $direction) {

--- a/app/Models/SubCategory.php
+++ b/app/Models/SubCategory.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Utilities\Model as ModelUtility;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
@@ -39,11 +40,7 @@ class SubCategory extends Model
     {
         $collection = $this->where('category_id', '=', $category_id);
 
-        if (count($search_parameters) > 0) {
-            foreach ($search_parameters as $field => $search_term) {
-                $collection->where('sub_category.' . $field, 'LIKE', '%' . $search_term . '%');
-            }
-        }
+        $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 
         return count($collection->get());
     }
@@ -73,11 +70,7 @@ class SubCategory extends Model
             )->
             where('category_id', '=', $category_id);
 
-        if (count($search_parameters) > 0) {
-            foreach ($search_parameters as $field => $search_term) {
-                $collection->where('sub_category.' . $field, 'LIKE', '%' . $search_term . '%');
-            }
-        }
+        $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 
         if (count($sort_parameters) > 0) {
             foreach ($sort_parameters as $field => $direction) {

--- a/app/Utilities/Model.php
+++ b/app/Utilities/Model.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Utilities;
+
+/**
+ * Model helper class
+ *
+ * @author Dean Blackborough <dean@g3d-development.com>
+ * @copyright Dean Blackborough 2018-2019
+ * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
+ */
+class Model
+{
+    public static function applySearch($collection, string $table, array $search_parameters = [])
+    {
+        if (count($search_parameters) > 0) {
+            foreach ($search_parameters as $field => $search_term) {
+                $collection->where($table . '.' . $field, 'LIKE', '%' . $search_term . '%');
+            }
+        }
+
+        return $collection;
+    }
+}

--- a/app/Validators/Request/SearchParameters.php
+++ b/app/Validators/Request/SearchParameters.php
@@ -68,4 +68,24 @@ class SearchParameters
 
         return self::$searchable_fields;
     }
+
+    /**
+     * Generate the X-Search header string for the valid sort options
+     *
+     * @return string|null
+     */
+    public static function xHeader(): ?string
+    {
+        $header = '';
+
+        foreach (self::$searchable_fields as $key => $value) {
+            $header .= '|' . $key . ':' . urlencode($value);
+        }
+
+        if (strlen($header) > 0) {
+            return ltrim($header, '|');
+        } else {
+            return null;
+        }
+    }
 }

--- a/app/Validators/Request/SortParameters.php
+++ b/app/Validators/Request/SortParameters.php
@@ -69,4 +69,24 @@ class SortParameters
 
         return self::$sortable_fields;
     }
+
+    /**
+     * Generate the X-Sort header string for the valid sort options
+     *
+     * @return string|null
+     */
+    public static function xHeader(): ?string
+    {
+        $header = '';
+
+        foreach (self::$sortable_fields as $key => $value) {
+            $header .= '|' . $key . ':' . urlencode($value);
+        }
+
+        if (strlen($header) > 0) {
+            return ltrim($header, '|');
+        } else {
+            return null;
+        }
+    }
 }

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -3,7 +3,7 @@
 return [
     'version'=> '1.19.0',
     'prefix' => 'v1',
-    'release_date' => '2019-08-xx',
+    'release_date' => '2019-08-08',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '1.18.0',
+    'version'=> '1.19.0',
     'prefix' => 'v1',
-    'release_date' => '2019-08-07',
+    'release_date' => '2019-08-xx',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'


### PR DESCRIPTION
### Added
- We have added an `X-Sort` header to responses, displays the valid sort options, the applied sort options may differ to the requested sort options.
- We have added an `X-Search` header to responses, displays the valid search options, the applied search options may differ to the requested search options.

### Changed
- We have eliminated some code duplication around allowable search and sort options.
- We have eliminated some code duplication in the models relating to the way search parameters get added to the queries.

### Fixed
- Sorting the `/v1/resource-type/[resource-type]/resources/[resource]/items` collection by description generates an error, table name missing from sort field causing ambiguity.