### PR TITLE
v1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.19.1] - 2019-08-09
+### Added
+- We have added a `collection` parameter which is available to some collections. When the `collection` parameter is defined and `true`, it overrides the pagination limits, and we return the entire collection.
+
+### Changed
+- We have updated the pagination helper class to check to ensure that the `collection` parameter is allowable for the request.
+
 ## [v1.19.0] - 2019-08-08
 ### Added
 - We have added an `X-Sort` header to responses, displays the valid sort options, the applied sort options may differ to the requested sort options.

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -16,7 +16,6 @@ use App\Validators\Request\SortParameters;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 
 /**
@@ -28,6 +27,8 @@ use Illuminate\Support\Facades\Config;
  */
 class CategoryController extends Controller
 {
+    protected $allow_entire_collection = true;
+
     /**
      * Return the categories collection
      *
@@ -49,7 +50,12 @@ class CategoryController extends Controller
             Config::get('api.category.sortable')
         );
 
-        $pagination = UtilityPagination::init(request()->path(), $total)->
+        $pagination = UtilityPagination::init(
+                request()->path(),
+                $total,
+                10,
+                $this->allow_entire_collection
+            )->
             setSearchParameters($search_parameters)->
             setSortParameters($sort_parameters)->
             paging();
@@ -149,7 +155,7 @@ class CategoryController extends Controller
                 'sortable_config' => 'api.category.sortable',
                 'searchable_config' => 'api.category.searchable',
                 'enable_pagination' => true,
-                'allow_entire_collection' => true,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -149,6 +149,7 @@ class CategoryController extends Controller
                 'sortable_config' => 'api.category.sortable',
                 'searchable_config' => 'api.category.searchable',
                 'enable_pagination' => true,
+                'allow_entire_collection' => true,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -104,6 +104,7 @@ class Controller extends BaseController
             'sortable_config' => null,
             'searchable_config' => null,
             'enable_pagination' => true,
+            'allow_entire_collection' => false,
             'authentication_required' => false
         ],
         array $post = [
@@ -121,7 +122,14 @@ class Controller extends BaseController
         if ($get['parameters_config_string'] !== null) {
             foreach (
                 array_merge_recursive(
-                    ($get['enable_pagination'] === true ? Config::get('api.pagination.parameters') : []),
+                    ($get['enable_pagination'] === true ?
+                        (
+                            $get['allow_entire_collection'] === false ?
+                                Config::get('api.pagination.parameters') :
+                                Config::get('api.pagination.parameters-including-collection')
+                        ) :
+                        []
+                    ),
                     ($get['sortable_config'] !== null ? Config::get('api.sortable.parameters') : []),
                     ($get['searchable_config'] !== null ? Config::get('api.searchable.parameters') : []),
                     Config::get($get['parameters_config_string']),

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -27,6 +27,11 @@ class Controller extends BaseController
      */
     protected $include_private;
 
+    /**
+     * @var boolean Allow the entire collection to be returned ignoring pagination
+     */
+    protected $allow_entire_collection = false;
+
     public function __construct()
     {
         $this->hash = new Hash();

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -126,6 +126,7 @@ class ItemCategoryController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
+                'allow_entire_collection' => false,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -126,7 +126,7 @@ class ItemCategoryController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
-                'allow_entire_collection' => false,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -175,6 +175,7 @@ class ItemController extends Controller
                 'sortable_config' => 'api.item.sortable',
                 'searchable_config' => 'api.item.searchable',
                 'enable_pagination' => true,
+                'allow_entire_collection' => false,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -175,7 +175,7 @@ class ItemController extends Controller
                 'sortable_config' => 'api.item.sortable',
                 'searchable_config' => 'api.item.searchable',
                 'enable_pagination' => true,
-                'allow_entire_collection' => false,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -158,6 +158,7 @@ class ItemSubCategoryController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
+                'allow_entire_collection' => false,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -158,7 +158,7 @@ class ItemSubCategoryController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
-                'allow_entire_collection' => false,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ItemTransferController.php
+++ b/app/Http/Controllers/ItemTransferController.php
@@ -79,7 +79,7 @@ class ItemTransferController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
-                'allow_entire_collection' => false,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ItemTransferController.php
+++ b/app/Http/Controllers/ItemTransferController.php
@@ -79,6 +79,7 @@ class ItemTransferController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
+                'allow_entire_collection' => false,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -122,7 +122,7 @@ class RequestController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => true,
-                'allow_entire_collection' => false,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ]
         );
@@ -143,7 +143,7 @@ class RequestController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
-                'allow_entire_collection' => false,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -122,6 +122,7 @@ class RequestController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => true,
+                'allow_entire_collection' => false,
                 'authentication_required' => false
             ]
         );
@@ -142,6 +143,7 @@ class RequestController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
+                'allow_entire_collection' => false,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -142,6 +142,7 @@ class ResourceController extends Controller
                 'sortable_config' => 'api.resource.sortable',
                 'searchable_config' => 'api.resource.searchable',
                 'enable_pagination' => true,
+                'allow_entire_collection' => true,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -24,6 +24,8 @@ use Illuminate\Support\Facades\Config;
  */
 class ResourceController extends Controller
 {
+    protected $allow_entire_collection = true;
+
     /**
      * Return all the resources
      *
@@ -49,7 +51,12 @@ class ResourceController extends Controller
             Config::get('api.resource.sortable')
         );
 
-        $pagination = UtilityPagination::init(request()->path(), $total)->
+        $pagination = UtilityPagination::init(
+                request()->path(),
+                $total,
+                10,
+                $this->allow_entire_collection
+            )->
             setSearchParameters($search_parameters)->
             setSortParameters($sort_parameters)->
             paging();
@@ -142,7 +149,7 @@ class ResourceController extends Controller
                 'sortable_config' => 'api.resource.sortable',
                 'searchable_config' => 'api.resource.searchable',
                 'enable_pagination' => true,
-                'allow_entire_collection' => true,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -146,6 +146,7 @@ class ResourceTypeController extends Controller
                 'sortable_config' => 'api.resource-type.sortable',
                 'searchable_config' => 'api.resource-type.searchable',
                 'enable_pagination' => true,
+                'allow_entire_collection' => true,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -26,6 +26,8 @@ use Illuminate\Support\Facades\Config;
  */
 class ResourceTypeController extends Controller
 {
+    protected $allow_entire_collection = true;
+
     /**
      * Return all the resource types
      *
@@ -46,7 +48,12 @@ class ResourceTypeController extends Controller
             Config::get('api.resource-type.sortable')
         );
 
-        $pagination = UtilityPagination::init(request()->path(), $total)->
+        $pagination = UtilityPagination::init(
+                request()->path(),
+                $total,
+                10,
+                $this->allow_entire_collection
+            )->
             setSearchParameters($search_parameters)->
             setSortParameters($sort_parameters)->
             paging();
@@ -146,7 +153,7 @@ class ResourceTypeController extends Controller
                 'sortable_config' => 'api.resource-type.sortable',
                 'searchable_config' => 'api.resource-type.searchable',
                 'enable_pagination' => true,
-                'allow_entire_collection' => true,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -126,6 +126,7 @@ class ResourceTypeItemController extends Controller
                 'sortable_config' => 'api.resource-type-item.sortable',
                 'searchable_config' => 'api.resource-type-item.searchable',
                 'enable_pagination' => true,
+                'allow_entire_collection' => true,
                 'authentication_required' => false
             ]
         );

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -126,7 +126,7 @@ class ResourceTypeItemController extends Controller
                 'sortable_config' => 'api.resource-type-item.sortable',
                 'searchable_config' => 'api.resource-type-item.searchable',
                 'enable_pagination' => true,
-                'allow_entire_collection' => true,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ]
         );

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -13,7 +13,6 @@ use App\Validators\Request\SortParameters;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 
 /**
@@ -25,6 +24,8 @@ use Illuminate\Support\Facades\Config;
  */
 class SubcategoryController extends Controller
 {
+    protected $allow_entire_collection = true;
+
     /**
      * Return all the sub categories assigned to the given category
      *
@@ -49,7 +50,12 @@ class SubcategoryController extends Controller
             Config::get('api.subcategory.sortable')
         );
 
-        $pagination = UtilityPagination::init(request()->path(), $total)->
+        $pagination = UtilityPagination::init(
+                request()->path(),
+                $total,
+                10,
+                $this->allow_entire_collection
+            )->
             setSearchParameters($search_parameters)->
             setSortParameters($sort_parameters)->
             paging();
@@ -145,7 +151,7 @@ class SubcategoryController extends Controller
                 'sortable_config' => 'api.subcategory.sortable',
                 'searchable_config' => 'api.subcategory.searchable',
                 'enable_pagination' => true,
-                'allow_entire_collection' => true,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -145,6 +145,7 @@ class SubcategoryController extends Controller
                 'sortable_config' => 'api.subcategory.sortable',
                 'searchable_config' => 'api.subcategory.searchable',
                 'enable_pagination' => true,
+                'allow_entire_collection' => true,
                 'authentication_required' => false
             ],
             [

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -457,7 +457,7 @@ class SummaryItemController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => 'api.item.searchable',
                 'enable_pagination' => false,
-                'allow_entire_collection' => false,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ]
         );

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -457,6 +457,7 @@ class SummaryItemController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => 'api.item.searchable',
                 'enable_pagination' => false,
+                'allow_entire_collection' => false,
                 'authentication_required' => false
             ]
         );

--- a/app/Http/Controllers/SummaryRequestController.php
+++ b/app/Http/Controllers/SummaryRequestController.php
@@ -57,6 +57,7 @@ class SummaryRequestController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
+                'allow_entire_collection' => false,
                 'authentication_required' => false
             ]
         );

--- a/app/Http/Controllers/SummaryRequestController.php
+++ b/app/Http/Controllers/SummaryRequestController.php
@@ -57,7 +57,7 @@ class SummaryRequestController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
-                'allow_entire_collection' => false,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ]
         );

--- a/app/Http/Controllers/SummaryResourceController.php
+++ b/app/Http/Controllers/SummaryResourceController.php
@@ -60,7 +60,7 @@ class SummaryResourceController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
-                'allow_entire_collection' => false,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ]
         );

--- a/app/Http/Controllers/SummaryResourceController.php
+++ b/app/Http/Controllers/SummaryResourceController.php
@@ -60,6 +60,7 @@ class SummaryResourceController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
+                'allow_entire_collection' => false,
                 'authentication_required' => false
             ]
         );

--- a/app/Http/Controllers/SummaryResourceTypeController.php
+++ b/app/Http/Controllers/SummaryResourceTypeController.php
@@ -53,7 +53,7 @@ class SummaryResourceTypeController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
-                'allow_entire_collection' => false,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ]
         );

--- a/app/Http/Controllers/SummaryResourceTypeController.php
+++ b/app/Http/Controllers/SummaryResourceTypeController.php
@@ -53,6 +53,7 @@ class SummaryResourceTypeController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => null,
                 'enable_pagination' => false,
+                'allow_entire_collection' => false,
                 'authentication_required' => false
             ]
         );

--- a/app/Http/Controllers/SummaryResourceTypeItemController.php
+++ b/app/Http/Controllers/SummaryResourceTypeItemController.php
@@ -498,6 +498,7 @@ class SummaryResourceTypeItemController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => 'api.resource-type-item.searchable',
                 'enable_pagination' => false,
+                'allow_entire_collection' => false,
                 'authentication_required' => false
             ]
         );

--- a/app/Http/Controllers/SummaryResourceTypeItemController.php
+++ b/app/Http/Controllers/SummaryResourceTypeItemController.php
@@ -498,7 +498,7 @@ class SummaryResourceTypeItemController extends Controller
                 'sortable_config' => null,
                 'searchable_config' => 'api.resource-type-item.searchable',
                 'enable_pagination' => false,
-                'allow_entire_collection' => false,
+                'allow_entire_collection' => $this->allow_entire_collection,
                 'authentication_required' => false
             ]
         );

--- a/app/Utilities/Pagination.php
+++ b/app/Utilities/Pagination.php
@@ -41,6 +41,10 @@ class Pagination
      */
     private static $collection;
     /**
+     * @var boolean
+     */
+    private static $allow_override;
+    /**
      * @var int
      */
     private static $total;
@@ -59,10 +63,16 @@ class Pagination
      * @param string $uri Set the pagination uri
      * @param int $total Set the total number of items in collection
      * @param int $limit Set the 'per page' limit
+     * @param boolean $allow_override Allow the pagination to be overridden via the collection parameter
      *
      * @return Pagination
      */
-    public static function init(string $uri, int $total, int $limit = 10): Pagination
+    public static function init(
+        string $uri,
+        int $total,
+        int $limit = 10,
+        bool $allow_override = false
+    ): Pagination
     {
         if (self::$instance === null) {
             self::$instance = new Pagination;
@@ -76,6 +86,8 @@ class Pagination
         self::$uri = $uri;
         self::$hash = new Hash();
         self::$offset = 0;
+        self::$allow_override = $allow_override;
+        self::$collection = false;
 
         return self::$instance;
     }
@@ -230,7 +242,9 @@ class Pagination
     {
         self::$offset = intval(request()->query('offset', 0));
         self::$limit = intval(request()->query('limit', self::$limit));
-        self::$collection = General::booleanValue(request()->query('collection', false));
+        if (self::$allow_override === true) {
+            self::$collection = General::booleanValue(request()->query('collection', false));
+        }
 
         $uris = [
             'next' => null,

--- a/config/api/pagination/parameters-including-collection.php
+++ b/config/api/pagination/parameters-including-collection.php
@@ -18,5 +18,13 @@ return [
         'default' => 10,
         'type' => 'integer',
         'required' => false
+    ],
+    'collection' => [
+        'parameter' => 'collection',
+        'title' => 'pagination/parameters.title-collection',
+        'description' => 'pagination/parameters.description-collection',
+        'default' => false,
+        'type' => 'boolean',
+        'required' => false
     ]
 ];

--- a/config/api/pagination/parameters.php
+++ b/config/api/pagination/parameters.php
@@ -18,5 +18,13 @@ return [
         'default' => 10,
         'type' => 'integer',
         'required' => false
+    ],
+    'collection' => [
+        'parameter' => 'collection',
+        'title' => 'pagination/parameters.title-collection',
+        'description' => 'pagination/parameters.description-collection',
+        'default' => false,
+        'type' => 'boolean',
+        'required' => false
     ]
 ];

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '1.19.0',
+    'version'=> '1.19.1',
     'prefix' => 'v1',
-    'release_date' => '2019-08-08',
+    'release_date' => '2019-08-09',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/resources/lang/en/pagination/parameters.php
+++ b/resources/lang/en/pagination/parameters.php
@@ -10,5 +10,5 @@ return [
     'description-limit' => 'Number of results to return',
 
     'title-collection' => 'Collection',
-    'description-collection' => 'Override pagination limits and return the entire collection [!USE WITH CARE!]'
+    'description-collection' => 'Override pagination limits and return the entire collection [!USE WITH CARE!]',
 ];

--- a/resources/lang/en/pagination/parameters.php
+++ b/resources/lang/en/pagination/parameters.php
@@ -7,5 +7,8 @@ return [
     'description-offset' => 'Start result for pagination',
 
     'title-limit' => 'Limit',
-    'description-limit' => 'Number of results to return'
+    'description-limit' => 'Number of results to return',
+
+    'title-collection' => 'Collection',
+    'description-collection' => 'Override pagination limits and return the entire collection [!USE WITH CARE!]'
 ];


### PR DESCRIPTION
### Added
- We have added a `collection` parameter which is available to some collections. When the `collection` parameter is defined and `true`, it overrides the pagination limits, and we return the entire collection.

### Changed
- We have updated the pagination helper class to check to ensure that the `collection` parameter is allowable for the request.