### PR TITLE
v1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.21.1] - 2019-08-xx
+### Changed
+
+
 ## [v1.21.0] - 2019-08-19
 ### Added
 - We have added an `OptionPatch` class to help generate the PATCH data array for the OPTIONS requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
-## [v1.21.1] - 2019-08-xx
-### Changed
-
+## [v1.21.1] - 2019-08-20
+### Added
+- We have added a `debug` field to the request error log; you can optionally provide information that may be useful in tracking down the error.
 
 ## [v1.21.0] - 2019-08-19
 ### Added

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -174,6 +174,7 @@ class RequestController extends Controller
                 'expected_status_code' => $request->input('expected_status_code'),
                 'returned_status_code' => $request->input('returned_status_code'),
                 'request_uri' => $request->input('request_uri'),
+                'debug' => $request->input('debug')
             ]);
             $request_error_log->save();
 
@@ -183,7 +184,8 @@ class RequestController extends Controller
                 'expected_status_code' => $request->input('expected_status_code'),
                 'returned_status_code' => $request->input('returned_status_code'),
                 'request_uri' => $request->input('request_uri'),
-                'referer' => $request->server('HTTP_REFERER', 'NOT SET!')
+                'referer' => $request->server('HTTP_REFERER', 'NOT SET!'),
+                'debug' => $request->input('debug')
             ]));
 
         } catch (Exception $e) {

--- a/app/Models/RequestErrorLog.php
+++ b/app/Models/RequestErrorLog.php
@@ -36,7 +36,8 @@ class RequestErrorLog extends Model
                 'request_error_log.returned_status_code AS request_error_log_returned_status_code',
                 'request_error_log.request_uri AS request_error_log_request_uri',
                 'request_error_log.source AS request_error_log_source',
-                'request_error_log.created_at AS request_error_log_created_at'
+                'request_error_log.created_at AS request_error_log_created_at',
+                'request_error_log.debug AS request_error_log_debug'
             )->
             orderByDesc('created_at')->
             offset($offset)->

--- a/app/Models/Transformers/RequestErrorLog.php
+++ b/app/Models/Transformers/RequestErrorLog.php
@@ -29,7 +29,8 @@ class RequestErrorLog extends Transformer
             'returned_status_code' => $this->data_to_transform['request_error_log_returned_status_code'],
             'request_uri' => $this->data_to_transform['request_error_log_request_uri'],
             'source' => $this->data_to_transform['request_error_log_source'],
-            'created' => $this->data_to_transform['request_error_log_created_at']
+            'created' => $this->data_to_transform['request_error_log_created_at'],
+            'debug' => $this->data_to_transform['request_error_log_debug']
         ];
     }
 }

--- a/config/api/request-error-log/fields.php
+++ b/config/api/request-error-log/fields.php
@@ -37,5 +37,12 @@ return [
         'description' => 'request-error-log/fields.description-source',
         'type' => 'string',
         'required' => true
+    ],
+    'debug' => [
+        'field' => 'debug',
+        'title' => 'request-error-log/fields.title-debug',
+        'description' => 'request-error-log/fields.description-debug',
+        'type' => 'string',
+        'required' => false
     ]
 ];

--- a/config/api/request-error-log/validation.php
+++ b/config/api/request-error-log/validation.php
@@ -9,7 +9,8 @@ return [
             'expected_status_code' => 'required|integer|between:100,530',
             'returned_status_code' => 'required|integer|between:100,530',
             'request_uri' => 'required|string',
-            'source' => 'required|string|in:website,api,legacy,postman'
+            'source' => 'required|string|in:website,api,legacy,postman',
+            'debug' => 'sometimes|string'
         ],
         'messages' => []
     ]

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -3,7 +3,7 @@
 return [
     'version'=> '1.21.1',
     'prefix' => 'v1',
-    'release_date' => '2019-08-19',
+    'release_date' => '2019-08-20',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'version'=> '1.21.0',
+    'version'=> '1.21.1',
     'prefix' => 'v1',
     'release_date' => '2019-08-19',
     'changelog' => [

--- a/database/migrations/2019_08_20_212839_debug_field_error_log.php
+++ b/database/migrations/2019_08_20_212839_debug_field_error_log.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DebugFieldErrorLog extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('request_error_log', function (Blueprint $table) {
+            $table->string('debug', 255)
+                ->after('source')
+                ->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('request_error_log', function (Blueprint $table) {
+            $table->dropColumn('debug');
+        });
+    }
+}

--- a/resources/lang/en/request-error-log/fields.php
+++ b/resources/lang/en/request-error-log/fields.php
@@ -17,4 +17,7 @@ return [
 
     'title-source' => 'Source',
     'description-source' => 'Source of the error (website,api,legacy,postman)',
+
+    'title-debug' => 'Debug',
+    'description-debug' => 'Additional debug data (optional)',
 ];

--- a/resources/views/mail/request-error.blade.php
+++ b/resources/views/mail/request-error.blade.php
@@ -37,6 +37,10 @@
             <td>Referer (if set):</td>
             <td>{{ $request_error['referer'] }}</td>
         </tr>
+        <tr>
+            <td>Debug information (if set):</td>
+            <td>{{ $request_error['debug'] }}</td>
+        </tr>
     </table>
 </body>
 </html>


### PR DESCRIPTION
### Added
- We have added a `debug` field to the request error log; you can optionally provide information that may be useful in tracking down the error.