### PR TITLE
v1.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ## [v1.22.1] - 2019-09-01
 ### Changed
 - We have updated the domain for Mailgun, now mail.costs-to-expect.com rather than the temp domain.
-- We have updated the OPTIONS requestion, they now show additional validation data if necessary.
+- We have updated the OPTIONS requests, they now show additional validation data if necessary.
 - We have continued to unify information names in the OPTIONS requests; we use dashes instead of underscores.
 - We have updated the from setting for emails so 'on behalf of' doesn't show for sent emails.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.23.0] - 2019-09-xx
+
+
 ## [v1.22.1] - 2019-09-01
 ### Changed
 - We have updated the domain for Mailgun, now mail.costs-to-expect.com rather than the temp domain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
 ## [v1.23.0] - 2019-09-xx
-
+## Changed
+- We have added string length validation for hashed id values; all should be ten characters.
 
 ## [v1.22.1] - 2019-09-01
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
-## [v1.23.0] - 2019-09-xx
-## Changed
+## [v1.22.2] - 2019-09-03
+### Added
+- We have added an error log database table, initially, for capturing 500 errors.
+- We have added an `InternalError` event and listener. After writing the error to the database, we send an email with the error.
+
+### Changed
 - We have added string length validation for hashed id values; all should be ten characters.
+- We have reduced the `request/access-log` limit to 25, from 50.
+- We have renamed the `CaptureAndSend` listener; it is specific to request errors so the name should be `CaptureAndSendRequestError`.
 
 ## [v1.22.1] - 2019-09-01
 ### Changed

--- a/app/Events/InternalError.php
+++ b/app/Events/InternalError.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class InternalError
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $internal_error = [];
+
+    /**
+     * Create a new event instance.
+     *
+     * @param array $internal_error
+     *
+     * @return void
+     */
+    public function __construct(array $internal_error)
+    {
+        $this->internal_error = $internal_error;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,6 +2,7 @@
 
 namespace App\Exceptions;
 
+use App\Events\InternalError;
 use App\Models\ErrorLog;
 use App\Utilities\Response;
 use Exception;
@@ -77,13 +78,17 @@ class Handler extends ExceptionHandler
                     ];
                 } else {
                     try {
-                        $error = new ErrorLog([
+                        $error_data = [
                             'message' => $exception->getMessage(),
                             'file' => $exception->getFile(),
                             'line' => $exception->getLine(),
                             'trace' => $exception->getTraceAsString()
-                        ]);
+                        ];
+
+                        $error = new ErrorLog($error_data);
                         $error->save();
+
+                        event(new InternalError($error_data));
                     } catch (Exception $e) {
                         // Don't worry for now, we just want to try and log some errors
                     }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,6 +2,7 @@
 
 namespace App\Exceptions;
 
+use App\Models\ErrorLog;
 use App\Utilities\Response;
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
@@ -75,6 +76,18 @@ class Handler extends ExceptionHandler
                         'trace' => $exception->getTraceAsString()
                     ];
                 } else {
+                    try {
+                        $error = new ErrorLog([
+                            'message' => $exception->getMessage(),
+                            'file' => $exception->getFile(),
+                            'line' => $exception->getLine(),
+                            'trace' => $exception->getTraceAsString()
+                        ]);
+                        $error->save();
+                    } catch (Exception $e) {
+                        // Don't worry for now, we just want to try and log some errors
+                    }
+
                     $response = [
                         'message' => 'Sorry, there has been an error, please try again later'
                     ];

--- a/app/Listeners/CaptureAndSendInternalError.php
+++ b/app/Listeners/CaptureAndSendInternalError.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\InternalError;
+use App\Mail\InternalError as InternalErrorMail;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Mail;
+
+class CaptureAndSendInternalError
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  InternalError  $event
+     * @return void
+     */
+    public function handle(InternalError $event)
+    {
+        if (isset($event->internal_error) && count($event->internal_error) > 0) {
+            Mail::to(Config::get('api.mail.internal-error.to'))->
+                send(
+                    new InternalErrorMail($event->internal_error)
+                );
+        }
+    }
+}

--- a/app/Listeners/CaptureAndSendRequestError.php
+++ b/app/Listeners/CaptureAndSendRequestError.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Mail;
 
-class CaptureAndSend
+class CaptureAndSendRequestError
 {
     /**
      * Create the event listener.

--- a/app/Mail/InternalError.php
+++ b/app/Mail/InternalError.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Config;
+
+class InternalError extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $api_from_mail;
+    public $api_from_name;
+    public $internal_error;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param array $internal_error
+     *
+     * @return void
+     */
+    public function __construct(array $internal_error)
+    {
+        $this->api_from_mail = Config::get('api.mail.internal-error.from_mail');
+        $this->api_from_name = Config::get('api.mail.internal-error.from_name');
+        $this->internal_error = $internal_error;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->from($this->api_from_mail, $this->api_from_name)->
+            view('mail.internal-error')->
+            subject('Costs to Expect API: Internal error');
+    }
+}

--- a/app/Models/ErrorLog.php
+++ b/app/Models/ErrorLog.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Error log
+ *
+ * @mixin QueryBuilder
+ * @author Dean Blackborough <dean@g3d-development.com>
+ * @copyright G3D Development Limited 2018-2019
+ * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
+ */
+class ErrorLog extends Model
+{
+    protected $table = 'error_log';
+
+    protected $guarded = ['id'];
+}

--- a/app/Models/RequestLog.php
+++ b/app/Models/RequestLog.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Facades\DB;
 
 /**
  * Request log
  *
+ * @mixin QueryBuilder
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright G3D Development Limited 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
@@ -37,7 +39,7 @@ class RequestLog extends Model
         array $collection_parameters = []
     )
     {
-        $collection = $this->orderByDesc('created_at');
+        $collection = $this->orderByDesc('id');
 
         if (array_key_exists('source', $collection_parameters) === true) {
             $collection->where('source', '=', $collection_parameters['source']);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -20,9 +20,9 @@ class EventServiceProvider extends ServiceProvider
         'App\Events\RequestError' => [
             'App\Listeners\CaptureAndSendRequestError'
         ],
-        /*'App\Events\InternalError' => [
+        'App\Events\InternalError' => [
             'App\Listeners\CaptureAndSendInternalError'
-        ]*/
+        ]
     ];
 
     /**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -18,8 +18,11 @@ class EventServiceProvider extends ServiceProvider
             'App\Listeners\PruneTokens'
         ],
         'App\Events\RequestError' => [
-            'App\Listeners\CaptureAndSend'
-        ]
+            'App\Listeners\CaptureAndSendRequestError'
+        ],
+        /*'App\Events\InternalError' => [
+            'App\Listeners\CaptureAndSendInternalError'
+        ]*/
     ];
 
     /**

--- a/config/api/category/fields.php
+++ b/config/api/category/fields.php
@@ -29,6 +29,9 @@ return [
         'title' => 'category/fields.title-resource_type_id',
         'description' => 'category/fields.description-resource_type_id',
         'type' => 'string',
+        'validation' => [
+            'length' => 10
+        ],
         'required' => true
     ]
 ];

--- a/config/api/item-category/fields.php
+++ b/config/api/item-category/fields.php
@@ -8,6 +8,9 @@ return [
         'title' => 'item-category/fields.title-category_id',
         'description' => 'item-category/fields.description-category_id',
         'type' => 'string',
+        'validation' => [
+            'length' => 10
+        ],
         'required' => true
     ]
 ];

--- a/config/api/item-subcategory/fields.php
+++ b/config/api/item-subcategory/fields.php
@@ -8,6 +8,9 @@ return [
         'title' => 'item-subcategory/fields.title-sub_category_id',
         'description' => 'item-subcategory/fields.description-sub_category_id',
         'type' => 'string',
+        'validation' => [
+            'length' => 10
+        ],
         'required' => true
     ]
 ];

--- a/config/api/item-transfer/fields.php
+++ b/config/api/item-transfer/fields.php
@@ -8,6 +8,9 @@ return [
         'title' => 'item-transfer/fields.title-resource_id',
         'description' => 'item-transfer/fields.description-resource_id',
         'type' => 'string',
+        'validation' => [
+            'length' => 10
+        ],
         'required' => true
     ]
 ];

--- a/config/api/mail/internal-error.php
+++ b/config/api/mail/internal-error.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'from_mail' => env('MAIL_FROM_ADDRESS'),
+    'from_name' => env('MAIL_FROM_NAME'),
+    'to' => env('MAIL_TO_ADDRESS'),
+];

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '1.23.0',
+    'version'=> '1.22.2',
     'prefix' => 'v1',
-    'release_date' => '2019-09-xx',
+    'release_date' => '2019-09-03',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '1.22.1',
+    'version'=> '1.23.0',
     'prefix' => 'v1',
-    'release_date' => '2019-09-01',
+    'release_date' => '2019-09-xx',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/database/migrations/2019_09_02_221133_create_error_log.php
+++ b/database/migrations/2019_09_02_221133_create_error_log.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateErrorLog extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('error_log', function (Blueprint $table) {
+            $table->charset = 'utf8mb4';
+            $table->collation = 'utf8mb4_unicode_ci';
+
+            $table->bigIncrements('id');
+            $table->text('message');
+            $table->string('file');
+            $table->string('line');
+            $table->text('trace');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('error_log');
+    }
+}

--- a/resources/views/mail/internal-error.blade.php
+++ b/resources/views/mail/internal-error.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Costs to Expect API: Internal error</title>
+    <style type="text/css">
+    body {
+        font-family: Arial, Helvetica, sans-serif;
+    }
+</style>
+</head>
+
+<body>
+    <h2>Captured Costs to Expect API Internal Error</h2>
+
+    <table>
+        <tr>
+            <td style="padding-right: 50px;">Message:</td>
+            <td>{{ $internal_error['message'] }}</td>
+        </tr>
+        <tr>
+            <td>File:</td>
+            <td>{{ $internal_error['file'] }}</td>
+        </tr>
+        <tr>
+            <td>Line:</td>
+            <td>{{ $internal_error['line'] }}</td>
+        </tr>
+        <tr>
+            <td>Trace:</td>
+            <td>{{ $internal_error['trace'] }}</td>
+        </tr>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
### Added
- We have added an error log database table, initially, for capturing 500 errors.
- We have added an `InternalError` event and listener. After writing the error to the database, we send an email with the error.

### Changed
- We have added string length validation for hashed id values; all should be ten characters.
- We have reduced the `request/access-log` limit to 25, from 50.
- We have renamed the `CaptureAndSend` listener; it is specific to request errors so the name should be `CaptureAndSendRequestError`.