### PR TITLE
Summary routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.23.0] - 2019-09-xx
+### Changed
+- We have added `X-Count` headers to several endpoints from which they were missing.
+
 ## [v1.22.2] - 2019-09-03
 ### Added
 - We have added an error log database table, initially, for capturing 500 errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
-## [v1.23.0] - 2019-09-xx
+## [v1.23.0] - 2019-09-05
+### Added 
+- We have added a new summary route, `/summary/categories`.
+- We have added a new summary route, `/summary/categories/{category_id}/subcategories`.
+
 ### Changed
 - We have added `X-Count` headers to several endpoints from which they were missing.
+- Content corrections in the README.
+
+### Fixed 
+- Minor corrections after the creation of additional Postman monitors.
 
 ## [v1.22.2] - 2019-09-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,12 +117,15 @@ X-Link-Previous and X-Link-Next can be null.
 
 ## Summary routes
 
-Eventually there will be a summary route for every API route, till that point the summary routes 
-are details below, some use GET parameters to breakdown the data, one example being items 
-which allows you to provide year, month, category and subcategory.
+Eventually there will be a summary route for every API route, until that point, the summary routes 
+are detailed below. Some use GET parameters to breakdown the data, one example being items 
+which allows you to provide year, month, category and subcategory. A summary route should have the same 
+GET parameters as the non summary route.
 
 | HTTP Verb(s) | Route |
 | :--- | :--- |
+| GET/HEAD | v1/summary/categories |
+| OPTIONS  | v1/summary/categories |
 | GET/HEAD | v1/summary/request/access-log |
 | OPTIONS  | v1/summary/request/access-log |
 | GET/HEAD | v1/summary/resource-types |

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ GET parameters as the non summary route.
 | :--- | :--- |
 | GET/HEAD | v1/summary/categories |
 | OPTIONS  | v1/summary/categories |
+| GET/HEAD | v1/summary/categories/{category_id}/subcategories |
+| OPTIONS  | v1/summary/categories/{category_id}/subcategories |
 | GET/HEAD | v1/summary/request/access-log |
 | OPTIONS  | v1/summary/request/access-log |
 | GET/HEAD | v1/summary/resource-types |

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -140,7 +140,8 @@ class CategoryController extends Controller
             (new CategoryTransformer($category, $subcategories))->toArray(),
             200,
             [
-                'X-Total-Count' => 1
+                'X-Total-Count' => 1,
+                'X-Count' => 1
             ]
         );
     }

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -145,7 +145,8 @@ class ItemController extends Controller
             (new ItemTransformer($item))->toArray(),
             200,
             [
-                'X-Total-Count' => 1
+                'X-Total-Count' => 1,
+                'X-Count' => 1
             ]
         );
     }

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -132,7 +132,8 @@ class SubcategoryController extends Controller
             (new SubCategoryTransformer($subcategory))->toArray(),
             200,
             [
-                'X-Total-Count' => 1
+                'X-Total-Count' => 1,
+                'X-Count' => 1
             ]
         );
     }

--- a/app/Http/Controllers/SummaryCategoryController.php
+++ b/app/Http/Controllers/SummaryCategoryController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Models\Category;
 use App\Option\Get;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 
 /**
  * Summary controller for the categories routes
@@ -17,7 +16,7 @@ use Illuminate\Http\Request;
 class SummaryCategoryController extends Controller
 {
     /**
-     * Return a summary of the resource types
+     * Return a summary of the categories
      *
      * @return JsonResponse
      */

--- a/app/Http/Controllers/SummaryCategoryController.php
+++ b/app/Http/Controllers/SummaryCategoryController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Category;
+use App\Option\Get;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Summary controller for the categories routes
+ *
+ * @author Dean Blackborough <dean@g3d-development.com>
+ * @copyright G3D Development Limited 2018-2019
+ * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
+ */
+class SummaryCategoryController extends Controller
+{
+    /**
+     * Return a summary of the resource types
+     *
+     * @return JsonResponse
+     */
+    public function index(): JsonResponse
+    {
+        $summary = (new Category())->totalCount($this->include_private);
+
+        return response()->json(
+            [
+                'categories' => $summary
+            ],
+            200,
+            [
+                'X-Total-Count' => $summary,
+                'X-Count' => $summary
+            ]
+        );
+    }
+
+
+    /**
+     * Generate the OPTIONS request for the categories summary
+     *
+     * @return JsonResponse
+     */
+    public function optionsIndex(): JsonResponse
+    {
+        $get = Get::init()->
+            setDescription('route-descriptions.summary_category_GET_index')->
+            option();
+
+        return $this->optionsResponse($get, 200);
+    }
+}

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -153,7 +153,10 @@ class SummaryItemController extends Controller
                 'total' => number_format($summary[0]['actualised_total'], 2, '.', '')
             ],
             200,
-            ['X-Total-Count' => 1]
+            [
+                'X-Total-Count' => count($summary),
+                'X-Count' => count($summary)
+            ]
         );
     }
 
@@ -182,7 +185,10 @@ class SummaryItemController extends Controller
                 $summary
             ),
             200,
-            ['X-Total-Count' => count($summary)]
+            [
+                'X-Total-Count' => count($summary),
+                'X-Count' => count($summary)
+            ]
         );
     }
 
@@ -209,7 +215,10 @@ class SummaryItemController extends Controller
         return response()->json(
             (new ItemYearSummaryTransformer($summary[0]))->toArray(),
             200,
-            ['X-Total-Count' => 1]
+            [
+                'X-Total-Count' => count($summary),
+                'X-Count' => count($summary)
+            ]
         );
     }
 
@@ -241,7 +250,10 @@ class SummaryItemController extends Controller
                 $summary
             ),
             200,
-            [ 'X-Total-Count' => count($summary) ]
+            [
+                'X-Total-Count' => count($summary),
+                'X-Count' => count($summary)
+            ]
         );
     }
 
@@ -270,7 +282,10 @@ class SummaryItemController extends Controller
         return response()->json(
             (new ItemMonthSummaryTransformer($summary[0]))->toArray(),
             200,
-            [ 'X-Total-Count' => 1 ]
+            [
+                'X-Total-Count' => count($summary),
+                'X-Count' => count($summary)
+            ]
         );
     }
 
@@ -299,7 +314,10 @@ class SummaryItemController extends Controller
                 $summary
             ),
             200,
-            [ 'X-Total-Count' => count($summary) ]
+            [
+                'X-Total-Count' => count($summary),
+                'X-Count' => count($summary)
+            ]
         );
     }
 
@@ -342,7 +360,10 @@ class SummaryItemController extends Controller
                 'total' => number_format($summary[0]['total'], 2, '.', '')
             ],
             200,
-            ['X-Total-Count' => 1]
+            [
+                'X-Total-Count' => count($summary),
+                'X-Count' => count($summary)
+            ]
         );
     }
 
@@ -371,7 +392,10 @@ class SummaryItemController extends Controller
         return response()->json(
             (new ItemCategorySummaryTransformer($summary[0]))->toArray(),
             200,
-            [ 'X-Total-Count' => 1 ]
+            [
+                'X-Total-Count' => count($summary),
+                'X-Count' => count($summary)
+            ]
         );
     }
 
@@ -405,7 +429,10 @@ class SummaryItemController extends Controller
                 $summary
             ),
             200,
-            [ 'X-Total-Count' => count($summary) ]
+            [
+                'X-Total-Count' => count($summary),
+                'X-Count' => count($summary)
+            ]
         );
     }
 
@@ -436,7 +463,10 @@ class SummaryItemController extends Controller
         return response()->json(
             (new ItemSubCategorySummaryTransformer($summary[0]))->toArray(),
             200,
-            [ 'X-Total-Count' => 1 ]
+            [
+                'X-Total-Count' => count($summary),
+                'X-Count' => count($summary)
+            ]
         );
     }
 

--- a/app/Http/Controllers/SummarySubcategoryController.php
+++ b/app/Http/Controllers/SummarySubcategoryController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Category;
+use App\Models\SubCategory;
+use App\Option\Get;
+use App\Validators\Request\Route;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Summary controller for the subcategories routes
+ *
+ * @author Dean Blackborough <dean@g3d-development.com>
+ * @copyright G3D Development Limited 2018-2019
+ * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
+ */
+class SummarySubcategoryController extends Controller
+{
+    /**
+     * Return a summary of the subcategories
+     *
+     * @param string $category_id
+     *
+     * @return JsonResponse
+     */
+    public function index(string $category_id): JsonResponse
+    {
+        Route::categoryRoute($category_id);
+
+        $summary = (new SubCategory())->totalCount($category_id);
+
+        return response()->json(
+            [
+                'subcategories' => $summary
+            ],
+            200,
+            [
+                'X-Total-Count' => $summary,
+                'X-Count' => $summary
+            ]
+        );
+    }
+
+
+    /**
+     * Generate the OPTIONS request for the subcategories summary
+     *
+     * @param string $category_id
+     *
+     * @return JsonResponse
+     */
+    public function optionsIndex(string $category_id): JsonResponse
+    {
+        Route::categoryRoute($category_id);
+
+        $get = Get::init()->
+            setDescription('route-descriptions.summary_subcategory_GET_index')->
+            option();
+
+        return $this->optionsResponse($get, 200);
+    }
+}

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '1.22.2',
+    'version'=> '1.23.0',
     'prefix' => 'v1',
-    'release_date' => '2019-09-03',
+    'release_date' => '2019-09-xx',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -3,7 +3,7 @@
 return [
     'version'=> '1.23.0',
     'prefix' => 'v1',
-    'release_date' => '2019-09-xx',
+    'release_date' => '2019-09-05',
     'changelog' => [
         'api' => '/v1/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/resources/lang/en/route-descriptions.php
+++ b/resources/lang/en/route-descriptions.php
@@ -57,6 +57,7 @@ return [
     'request_POST' => 'Create an error log report',
 
     'summary_category_GET_index' => 'Return a summary of the categories',
+    'summary_subcategory_GET_index' => 'Return a summary of the subcategories',
 
     'summary_GET_request_access-log' => 'Return a summary of the access log, all read requests, grouped by year and month',
 

--- a/resources/lang/en/route-descriptions.php
+++ b/resources/lang/en/route-descriptions.php
@@ -56,6 +56,8 @@ return [
     'request_GET_error_log' => 'Return the error log',
     'request_POST' => 'Create an error log report',
 
+    'summary_category_GET_index' => 'Return a summary of the categories',
+
     'summary_GET_request_access-log' => 'Return a summary of the access log, all read requests, grouped by year and month',
 
     'summary-resource-type-GET-index' => 'Return a summary of the resource types',

--- a/routes/api/public-summary-routes.php
+++ b/routes/api/public-summary-routes.php
@@ -14,6 +14,16 @@ Route::group(
     ],
     function () {
         Route::get(
+            'summary/categories',
+            'SummaryCategoryController@index'
+        );
+
+        Route::options(
+            'summary/categories',
+            'SummaryCategoryController@optionsIndex'
+        );
+
+        Route::get(
             'summary/resource-types',
             'SummaryResourceTypeController@index'
         );

--- a/routes/api/public-summary-routes.php
+++ b/routes/api/public-summary-routes.php
@@ -24,6 +24,16 @@ Route::group(
         );
 
         Route::get(
+            'summary/categories/{category_id}/subcategories',
+            'SummarySubcategoryController@index'
+        );
+
+        Route::options(
+            'summary/categories/{category_id}/subcategories',
+            'SummarySubcategoryController@optionsIndex'
+        );
+
+        Route::get(
             'summary/resource-types',
             'SummaryResourceTypeController@index'
         );


### PR DESCRIPTION
### Added 
- We have added a new summary route, `/summary/categories`.
- We have added a new summary route, `/summary/categories/{category_id}/subcategories`.

### Changed
- We have added `X-Count` headers to several endpoints from which they were missing.
- Content corrections in the README.

### Fixed 
- Minor corrections after the creation of additional Postman monitors.