### PR TITLE
v2.01.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - We have removed the category routes; they are now available below resource types.
 - We have removed the category summary routes; they are now available below the resource types summary.
 - We have removed the subcategory routes; they are now available below resource types.
+- We have removed the subcategory summary routes; they are now available below the resource types summary.
 
 ## [v2.00.1] - 2019-09-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 ### Fixed
 - We have fixed the item subcategory route; the field name for POST was incorrect, still had the underscore.
 - We have corrected the query for the request/access-log, rather than return the entire collection and count the results, probably easier to let MySQL count the results, doh!
+- Unable to delete a subcategory because an instance was not being returned from the model.
 
 ### Removed
 - We have removed the category routes; they are now available below resource types.
 - We have removed the category summary routes; they are now available below the resource types summary.
+- We have removed the subcategory routes; they are now available below resource types.
 
 ## [v2.00.1] - 2019-09-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 - We have fixed the item subcategory route; the field name for POST was incorrect, still had the underscore.
 - We have corrected the query for the request/access-log, rather than return the entire collection and count the results, probably easier to let MySQL count the results, doh!
 
+### Removed
+- We have removed the category routes; they are now available below resource types.
+
 ## [v2.00.1] - 2019-09-17
 ### Fixed
 - Links on welcome page incorrect.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The complete changelog for the Costs to Expect REST API, follows the format defi
 
 ### Removed
 - We have removed the category routes; they are now available below resource types.
+- We have removed the category summary routes; they are now available below the resource types summary.
 
 ## [v2.00.1] - 2019-09-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v2.01.0] - 2019-09-xx
+### Added
+- We have added a `Header` utility class that can be used to generate the expected headers for collection and item requests.
+- We have added a `RoutePermission` class which returns the view and manage permission for each route.
+
+### Changed
+- We have updated all routes to use the new `Header`, utility class.
+- We have updated all the `Options` requests to use the new `RoutePermissions` class.
+
+### Fixed
+- We have fixed the item subcategory route; the field name for POST was incorrect, still had the underscore.
+- We have corrected the query for the request/access-log, rather than return the entire collection and count the results, probably easier to let MySQL count the results, doh!
+
 ## [v2.00.1] - 2019-09-17
 ### Fixed
 - Links on welcome page incorrect.

--- a/README.md
+++ b/README.md
@@ -83,18 +83,18 @@ X-Link-Previous and X-Link-Next can be null.
 | OPTIONS  | v2/ | 
 | POST     | v2/auth/login |
 | POST     | v2/auth/register (Removed in production) |
-| GET/HEAD | v2/categories/{category_id} |
-| OPTIONS  | v2/categories/{category_id} |
-| GET/HEAD | v2/categories/{category_id}/subcategories |
-| OPTIONS  | v2/categories/{category_id}/subcategories |
-| GET/HEAD | v2/categories/{category_id}/subcategories/{subcategory_id} |
-| OPTIONS  | v2/categories/{category_id}/subcategories/{subcategory_id} |
 | GET/HEAD | v2/resource-types |
 | OPTIONS  | v2/resource-types |
 | GET/HEAD | v2/resource-types/{resource_type_id} |
 | OPTIONS  | v2/resource-types/{resource_type_id} |
 | GET/HEAD | v2/resource-types/{resource_type_id}/categories |
 | OPTIONS  | v2/resource-types/{resource_type_id}/categories |
+| GET/HEAD | v2/resource-types/{resource_type_id}/categories/{category_id} |
+| OPTIONS  | v2/resource-types/{resource_type_id}/categories/{category_id} |
+| GET/HEAD | v2/resource-types/{resource_type_id}/categories/{category_id}/subcategories |
+| OPTIONS  | v2/resource-types/{resource_type_id}/categories/{category_id}/subcategories |
+| GET/HEAD | v2/resource-types/{resource_type_id}/categories/{category_id}/subcategories/{subcategory_id} |
+| OPTIONS  | v2/resource-types/{resource_type_id}/categories/{category_id}/subcategories/{subcategory_id} |
 | GET/HEAD | v2/resource-types/{resource_type_id}/items |
 | OPTIONS  | v2/resource-types/{resource_type_id}/items |
 | GET/HEAD | v2/resource-types/{resource_type_id}/resources |
@@ -124,14 +124,14 @@ GET parameters as the non summary route.
 
 | HTTP Verb(s) | Route |
 | :--- | :--- |
-| GET/HEAD | v2/summary/categories/{category_id}/subcategories |
-| OPTIONS  | v2/summary/categories/{category_id}/subcategories |
 | GET/HEAD | v2/summary/request/access-log |
 | OPTIONS  | v2/summary/request/access-log |
 | GET/HEAD | v2/summary/resource-types |
 | OPTIONS  | v2/summary/resource-types |
 | GET/HEAD | v2/summary/resource-types/{resource_type_id}/categories |
 | OPTIONS  | v2/summary/resource-types/{resource_type_id}/categories |
+| GET/HEAD | v2/summary/resource-types/{resource_type_id}/categories/{category_id}/subcategories |
+| OPTIONS  | v2/summary/resource-types/{resource_type_id}/categories/{category_id}/subcategories |
 | GET/HEAD | v2/summary/resource-types/{resource_type_id}/items |
 | OPTIONS  | v2/summary/resource-types/{resource_type_id}/items |
 | GET/HEAD | v2/summary/resource-types/{resource_type_id}/resources |

--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ GET parameters as the non summary route.
 
 | HTTP Verb(s) | Route |
 | :--- | :--- |
-| GET/HEAD | v2/summary/categories |
-| OPTIONS  | v2/summary/categories |
 | GET/HEAD | v2/summary/categories/{category_id}/subcategories |
 | OPTIONS  | v2/summary/categories/{category_id}/subcategories |
 | GET/HEAD | v2/summary/request/access-log |
 | OPTIONS  | v2/summary/request/access-log |
 | GET/HEAD | v2/summary/resource-types |
 | OPTIONS  | v2/summary/resource-types |
+| GET/HEAD | v2/summary/resource-types/{resource_type_id}/categories |
+| OPTIONS  | v2/summary/resource-types/{resource_type_id}/categories |
 | GET/HEAD | v2/summary/resource-types/{resource_type_id}/items |
 | OPTIONS  | v2/summary/resource-types/{resource_type_id}/items |
 | GET/HEAD | v2/summary/resource-types/{resource_type_id}/resources |

--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ X-Link-Previous and X-Link-Next can be null.
 | OPTIONS  | v2/ | 
 | POST     | v2/auth/login |
 | POST     | v2/auth/register (Removed in production) |
-| GET/HEAD | v2/categories |
-| OPTIONS  | v2/categories |
 | GET/HEAD | v2/categories/{category_id} |
 | OPTIONS  | v2/categories/{category_id} |
 | GET/HEAD | v2/categories/{category_id}/subcategories |
@@ -94,7 +92,9 @@ X-Link-Previous and X-Link-Next can be null.
 | GET/HEAD | v2/resource-types |
 | OPTIONS  | v2/resource-types |
 | GET/HEAD | v2/resource-types/{resource_type_id} |
-| OPTIONS  | v2/resource-types/{resource_type_id} | 
+| OPTIONS  | v2/resource-types/{resource_type_id} |
+| GET/HEAD | v2/resource-types/{resource_type_id}/categories |
+| OPTIONS  | v2/resource-types/{resource_type_id}/categories |
 | GET/HEAD | v2/resource-types/{resource_type_id}/items |
 | OPTIONS  | v2/resource-types/{resource_type_id}/items |
 | GET/HEAD | v2/resource-types/{resource_type_id}/resources |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ X-Link-Previous and X-Link-Next can be null.
 
 ## Summary routes
 
-Eventually there will be a summary route for every API route, until that point, the summary routes 
+Eventually there will be a summary route for every API GET endpoint, until that point, the summary routes 
 are detailed below. Some use GET parameters to breakdown the data, one example being items 
 which allows you to provide year, month, category and subcategory. A summary route should have the same 
 GET parameters as the non summary route.

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -136,13 +136,13 @@ class CategoryController extends Controller
             );
         }
 
+        $headers = new Header();
+        $headers->item();
+
         return response()->json(
             (new CategoryTransformer($category, $subcategories))->toArray(),
             200,
-            [
-                'X-Total-Count' => 1,
-                'X-Count' => 1
-            ]
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -7,6 +7,7 @@ use App\Option\Delete;
 use App\Option\Get;
 use App\Option\Patch;
 use App\Option\Post;
+use App\Utilities\Header;
 use App\Utilities\Pagination as UtilityPagination;
 use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
@@ -76,23 +77,17 @@ class CategoryController extends Controller
             $sort_parameters
         );
 
-        $headers = [
-            'X-Count' => count($categories),
-            'X-Total-Count' => $total,
-            'X-Offset' => $pagination['offset'],
-            'X-Limit' => $pagination['limit'],
-            'X-Link-Previous' => $pagination['links']['previous'],
-            'X-Link-Next' => $pagination['links']['next']
-        ];
+        $headers = new Header();
+        $headers->collection($pagination, count($categories), $total);
 
         $sort_header = SortParameters::xHeader();
         if ($sort_header !== null) {
-            $headers['X-Sort'] = $sort_header;
+            $headers->addSort($sort_header);
         }
 
         $search_header = SearchParameters::xHeader();
         if ($search_header !== null) {
-            $headers['X-Search'] = $search_header;
+            $headers->addSearch($search_header);
         }
 
         return response()->json(
@@ -103,7 +98,7 @@ class CategoryController extends Controller
                 $categories
             ),
             200,
-            $headers
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -9,6 +9,7 @@ use App\Option\Patch;
 use App\Option\Post;
 use App\Utilities\Header;
 use App\Utilities\Pagination as UtilityPagination;
+use App\Utilities\RoutePermission;
 use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\Category;
@@ -185,27 +186,31 @@ class CategoryController extends Controller
      */
     public function optionsShow(string $category_id): JsonResponse
     {
-        $authenticated = Route::category(
+        Route::category(
+            $category_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::category(
             $category_id,
             $this->permitted_resource_types
         );
 
         $get = Get::init()->
             setParameters('api.category.parameters.item')->
-            setAuthenticationStatus($authenticated)->
             setDescription('route-descriptions.category_GET_show')->
             option();
 
         $delete = Delete::init()->
             setAuthenticationRequired(true)->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             setDescription('route-descriptions.category_DELETE')->
             option();
 
         $patch = Patch::init()->
             setFields('api.category.fields-patch')->
             setDescription('route-descriptions.category_PATCH')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             setAuthenticationRequired(true)->
             option();
 

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Option\Delete;
 use App\Option\Get;
 use App\Option\Post;
+use App\Utilities\Header;
 use App\Validators\Request\Route;
 use App\Models\Category;
 use App\Models\ItemCategory;
@@ -55,14 +56,14 @@ class ItemCategoryController extends Controller
             UtilityResponse::notFound(trans('entities.item-category'));
         }
 
-        $headers = [
-            'X-Total-Count' => 1
-        ];
+        $headers = new Header();
+        $headers->add('X-Total-Count', 1);
+        $headers->add('X-Count', 1);
 
         return response()->json(
             [(new ItemCategoryTransformer($item_category[0]))->toArray()],
             200,
-            $headers
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -6,6 +6,7 @@ use App\Option\Delete;
 use App\Option\Get;
 use App\Option\Post;
 use App\Utilities\Header;
+use App\Utilities\RoutePermission;
 use App\Validators\Request\Route;
 use App\Models\Category;
 use App\Models\ItemCategory;
@@ -130,7 +131,14 @@ class ItemCategoryController extends Controller
      */
     public function optionsIndex(Request $request, string $resource_type_id, string $resource_id, string $item_id): JsonResponse
     {
-        $authenticated = Route::item(
+        Route::item(
+            $resource_type_id,
+            $resource_id,
+            $item_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::item(
             $resource_type_id,
             $resource_id,
             $item_id,
@@ -139,7 +147,7 @@ class ItemCategoryController extends Controller
 
         $get = Get::init()->
             setParameters('api.item-category.parameters.collection')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['view'])->
             setDescription('route-descriptions.item_category_GET_index')->
             option();
 
@@ -147,7 +155,7 @@ class ItemCategoryController extends Controller
             setFields('api.item-category.fields')->
             setConditionalFields($this->conditionalPostParameters($resource_type_id))->
             setDescription('route-descriptions.item_category_POST')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             setAuthenticationRequired(true)->
             option();
 
@@ -176,7 +184,14 @@ class ItemCategoryController extends Controller
         string $item_category_id
     ): JsonResponse
     {
-        $authenticated = Route::item(
+        Route::item(
+            $resource_type_id,
+            $resource_id,
+            $item_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::item(
             $resource_type_id,
             $resource_id,
             $item_id,
@@ -200,13 +215,13 @@ class ItemCategoryController extends Controller
 
         $get = Get::init()->
             setParameters('api.item-category.parameters.item')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['view'])->
             setDescription('route-descriptions.item_category_GET_show')->
             option();
 
         $delete = Delete::init()->
             setDescription('route-descriptions.item_category_DELETE')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             setAuthenticationRequired(true)->
             option();
 

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -108,14 +108,13 @@ class ItemCategoryController extends Controller
             UtilityResponse::notFound(trans('entities.item-category'));
         }
 
-        $headers = [
-            'X-Total-Count' => 1
-        ];
+        $headers = new Header();
+        $headers->item();
 
         return response()->json(
             (new ItemCategoryTransformer($item_category))->toArray(),
             200,
-            $headers
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -478,11 +478,11 @@ class ItemController extends Controller
         }
 
         $categories = (new Category())->paginatedCollection(
+            $resource_type_id,
             $this->permitted_resource_types,
             $this->include_public,
             0,
-            100,
-            ['resource_type'=>$resource_type_id]
+            100
         );
 
         foreach ($categories as $category) {

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -7,6 +7,7 @@ use App\Option\Delete;
 use App\Option\Get;
 use App\Option\Patch;
 use App\Option\Post;
+use App\Utilities\Header;
 use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\Category;
@@ -92,23 +93,17 @@ class ItemController extends Controller
             $search_parameters
         );
 
-        $headers = [
-            'X-Count' => count($items),
-            'X-Total-Count' => $total,
-            'X-Offset' => $pagination['offset'],
-            'X-Limit' => $pagination['limit'],
-            'X-Link-Previous' => $pagination['links']['previous'],
-            'X-Link-Next' => $pagination['links']['next']
-        ];
+        $headers = new Header();
+        $headers->collection($pagination, count($items), $total);
 
         $sort_header = SortParameters::xHeader();
         if ($sort_header !== null) {
-            $headers['X-Sort'] = $sort_header;
+            $headers->addSort($sort_header);
         }
 
         $search_header = SearchParameters::xHeader();
         if ($search_header !== null) {
-            $headers['X-Search'] = $search_header;
+            $headers->addSearch($search_header);
         }
 
         return response()->json(
@@ -119,7 +114,7 @@ class ItemController extends Controller
                 $items
             ),
             200,
-            $headers
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -146,13 +146,13 @@ class ItemController extends Controller
             UtilityResponse::notFound(trans('entities.item'));
         }
 
+        $headers = new Header();
+        $headers->item();
+
         return response()->json(
             (new ItemTransformer($item))->toArray(),
             200,
-            [
-                'X-Total-Count' => 1,
-                'X-Count' => 1
-            ]
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -301,7 +301,7 @@ class ItemSubCategoryController extends Controller
 
             $item_sub_category = new ItemSubCategory([
                 'item_category_id' => $item_category_id,
-                'subcategory_id' => $subcategory_id
+                'sub_category_id' => $subcategory_id
             ]);
             $item_sub_category->save();
         } catch (Exception $e) {

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -124,14 +124,13 @@ class ItemSubCategoryController extends Controller
             UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
-        $headers = [
-            'X-Total-Count' => 1
-        ];
+        $headers = new Header();
+        $headers->item();
 
         return response()->json(
             (new ItemSubCategoryTransformer($item_sub_category))->toArray(),
             200,
-            $headers
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -6,6 +6,7 @@ use App\Option\Delete;
 use App\Option\Get;
 use App\Option\Post;
 use App\Utilities\Header;
+use App\Utilities\RoutePermission;
 use App\Validators\Request\Route;
 use App\Models\ItemCategory;
 use App\Models\ItemSubCategory;
@@ -137,7 +138,6 @@ class ItemSubCategoryController extends Controller
     /**
      * Generate the OPTIONS request for the item list
      *
-     * @param Request $request
      * @param string $resource_type_id
      * @param string $resource_id
      * @param string $item_id
@@ -146,14 +146,20 @@ class ItemSubCategoryController extends Controller
      * @return JsonResponse
      */
     public function optionsIndex(
-        Request $request,
         string $resource_type_id,
         string $resource_id,
         string $item_id,
         string $item_category_id
     ): JsonResponse
     {
-        $authenticated = Route::item(
+        Route::item(
+            $resource_type_id,
+            $resource_id,
+            $item_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::item(
             $resource_type_id,
             $resource_id,
             $item_id,
@@ -171,7 +177,7 @@ class ItemSubCategoryController extends Controller
 
         $get = Get::init()->
             setParameters('api.item-subcategory.parameters.collection')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['view'])->
             setDescription('route-descriptions.item_sub_category_GET_index')->
             option();
 
@@ -179,7 +185,7 @@ class ItemSubCategoryController extends Controller
             setFields('api.item-subcategory.fields')->
             setConditionalFields($this->conditionalPostParameters($item_category->category_id))->
             setDescription('route-descriptions.item_sub_category_POST')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             setAuthenticationRequired(true)->
             option();
 
@@ -192,7 +198,6 @@ class ItemSubCategoryController extends Controller
     /**
      * Generate the OPTIONS request for a specific item
      *
-     * @param Request $request
      * @param string $resource_id
      * @param string $resource_type_id
      * @param string $item_id
@@ -202,7 +207,6 @@ class ItemSubCategoryController extends Controller
      * @return JsonResponse
      */
     public function optionsShow(
-        Request $request,
         string $resource_type_id,
         string $resource_id,
         string $item_id,
@@ -210,7 +214,14 @@ class ItemSubCategoryController extends Controller
         string $item_subcategory_id
     ): JsonResponse
     {
-        $authenticated = Route::item(
+        Route::item(
+            $resource_type_id,
+            $resource_id,
+            $item_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::item(
             $resource_type_id,
             $resource_id,
             $item_id,
@@ -235,13 +246,13 @@ class ItemSubCategoryController extends Controller
 
         $get = Get::init()->
             setParameters('api.item-subcategory.parameters.item')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['view'])->
             setDescription('route-descriptions.item_sub_category_GET_show')->
             option();
 
         $delete = Delete::init()->
             setDescription('route-descriptions.item_sub_category_DELETE')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             setAuthenticationRequired(true)->
             option();
 

--- a/app/Http/Controllers/ItemSubCategoryController.php
+++ b/app/Http/Controllers/ItemSubCategoryController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Option\Delete;
 use App\Option\Get;
 use App\Option\Post;
+use App\Utilities\Header;
 use App\Validators\Request\Route;
 use App\Models\ItemCategory;
 use App\Models\ItemSubCategory;
@@ -68,14 +69,14 @@ class ItemSubCategoryController extends Controller
             UtilityResponse::notFound(trans('entities.item-subcategory'));
         }
 
-        $headers = [
-            'X-Total-Count' => 1
-        ];
+        $headers = new Header();
+        $headers->add('X-Total-Count', 1);
+        $headers->add('X-Count', 1);
 
         return response()->json(
             [(new ItemSubCategoryTransformer($item_sub_category[0]))->toArray()],
             200,
-            $headers
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/ItemTransferController.php
+++ b/app/Http/Controllers/ItemTransferController.php
@@ -22,8 +22,6 @@ use Illuminate\Http\Request;
  */
 class ItemTransferController extends Controller
 {
-    protected $collection_parameters = [];
-    protected $get_parameters = [];
     protected $pagination = [];
 
     public function transfer(

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Events\RequestError;
 use App\Option\Get;
 use App\Option\Post;
+use App\Utilities\Header;
 use App\Utilities\Request as UtilityRequest;
 use App\Utilities\Response;
 use App\Validators\Request\Parameters;
@@ -89,21 +90,15 @@ class RequestController extends Controller
             $this->collection_parameters
         );
 
-        $headers = [
-            'X-Total-Count' => $total,
-            'X-Total' => count($log),
-            'X-Offset' => $pagination['offset'],
-            'X-Limit' => $pagination['limit'],
-            'X-Link-Previous' => $pagination['links']['previous'],
-            'X-Link-Next' => $pagination['links']['next'],
-        ];
+        $headers = new Header();
+        $headers->collection($pagination, count($log), $total);
 
         $json = [];
         foreach ($log as $log_item) {
             $json[] = (new RequestLogTransformer($log_item))->toArray();
         }
 
-        return response()->json($json, 200, $headers);
+        return response()->json($json, 200, $headers->headers());
     }
 
     /**

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -78,7 +78,7 @@ class RequestController extends Controller
      */
     public function accessLog(): JsonResponse
     {
-        $total = (new RequestLog())->totalCount();
+        $total = (new RequestLog())->totalCount()[0]['total'];
 
         $this->collection_parameters = Parameters::fetch(['source']);
 

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -9,6 +9,7 @@ use App\Option\Post;
 use App\Utilities\Header;
 use App\Utilities\Pagination as UtilityPagination;
 use App\Utilities\Request as UtilityRequest;
+use App\Utilities\RoutePermission;
 use App\Validators\Request\Route;
 use App\Models\Resource;
 use App\Models\Transformers\Resource as ResourceTransformer;
@@ -148,7 +149,12 @@ class ResourceController extends Controller
      */
     public function optionsIndex(string $resource_type_id): JsonResponse
     {
-        $authenticated = Route::resourceType(
+        Route::resourceType(
+            $resource_type_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::resourceType(
             $resource_type_id,
             $this->permitted_resource_types
         );
@@ -158,14 +164,14 @@ class ResourceController extends Controller
             setSearchable('api.resource.searchable')->
             setPaginationOverride(true)->
             setParameters('api.resource.parameters.collection')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['view'])->
             setDescription('route-descriptions.resource_GET_index')->
             option();
 
         $post = Post::init()->
             setFields('api.resource.fields')->
             setDescription('route-descriptions.resource_POST')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             setAuthenticationRequired(true)->
             option();
 
@@ -185,7 +191,13 @@ class ResourceController extends Controller
      */
     public function optionsShow(string $resource_type_id, string $resource_id): JsonResponse
     {
-        $authenticated = Route::resource(
+        Route::resource(
+            $resource_type_id,
+            $resource_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::resource(
             $resource_type_id,
             $resource_id,
             $this->permitted_resource_types
@@ -202,21 +214,21 @@ class ResourceController extends Controller
 
         $get = Get::init()->
             setParameters('api.resource.parameters.item')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['view'])->
             setDescription('route-descriptions.resource_GET_show')->
             option();
 
         $delete = Delete::init()->
             setDescription('route-descriptions.resource_DELETE')->
             setAuthenticationRequired(true)->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             option();
 
         $patch = Patch::init()->
             setFields('api.resource.fields')->
             setDescription('route-descriptions.resource_PATCH')->
             setAuthenticationRequired(true)->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             option();
 
         return $this->optionsResponse(

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -6,6 +6,7 @@ use App\Option\Delete;
 use App\Option\Get;
 use App\Option\Patch;
 use App\Option\Post;
+use App\Utilities\Header;
 use App\Utilities\Pagination as UtilityPagination;
 use App\Utilities\Request as UtilityRequest;
 use App\Validators\Request\Route;
@@ -78,23 +79,17 @@ class ResourceController extends Controller
             $sort_parameters
         );
 
-        $headers = [
-            'X-Count' => count($resources),
-            'X-Total-Count' => $total,
-            'X-Offset' => $pagination['offset'],
-            'X-Limit' => $pagination['limit'],
-            'X-Link-Previous' => $pagination['links']['previous'],
-            'X-Link-Next' => $pagination['links']['next']
-        ];
+        $headers = new Header();
+        $headers->collection($pagination, count($resources), $total);
 
         $sort_header = SortParameters::xHeader();
         if ($sort_header !== null) {
-            $headers['X-Sort'] = $sort_header;
+            $headers->addSort($sort_header);
         }
 
         $search_header = SearchParameters::xHeader();
         if ($search_header !== null) {
-            $headers['X-Search'] = $search_header;
+            $headers->addSearch($search_header);
         }
 
         return response()->json(
@@ -105,7 +100,7 @@ class ResourceController extends Controller
                 $resources
             ),
             200,
-            $headers
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -129,12 +129,13 @@ class ResourceController extends Controller
             UtilityResponse::notFound(trans('entities.resource'));
         }
 
+        $headers = new Header();
+        $headers->item();
+
         return response()->json(
             (new ResourceTransformer($resource))->toArray(),
             200,
-            [
-                'X-Total-Count' => 1
-            ]
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -8,6 +8,7 @@ use App\Option\Delete;
 use App\Option\Get;
 use App\Option\Patch;
 use App\Option\Post;
+use App\Utilities\Header;
 use App\Utilities\Pagination as UtilityPagination;
 use App\Utilities\Request as UtilityRequest;
 use App\Validators\Request\Parameters;
@@ -75,23 +76,17 @@ class ResourceTypeController extends Controller
             $sort_parameters
         );
 
-        $headers = [
-            'X-Count' => count($resource_types),
-            'X-Total-Count' => $total,
-            'X-Offset' => $pagination['offset'],
-            'X-Limit' => $pagination['limit'],
-            'X-Link-Previous' => $pagination['links']['previous'],
-            'X-Link-Next' => $pagination['links']['next']
-        ];
+        $headers = new Header();
+        $headers->collection($pagination, count($resource_types), $total);
 
         $sort_header = SortParameters::xHeader();
         if ($sort_header !== null) {
-            $headers['X-Sort'] = $sort_header;
+            $headers->addSort($sort_header);
         }
 
         $search_header = SearchParameters::xHeader();
         if ($search_header !== null) {
-            $headers['X-Search'] = $search_header;
+            $headers->addSearch($search_header);
         }
 
         return response()->json(
@@ -102,7 +97,7 @@ class ResourceTypeController extends Controller
                 $resource_types
             ),
             200,
-            $headers
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -11,6 +11,7 @@ use App\Option\Post;
 use App\Utilities\Header;
 use App\Utilities\Pagination as UtilityPagination;
 use App\Utilities\Request as UtilityRequest;
+use App\Utilities\RoutePermission;
 use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\ResourceType;
@@ -184,7 +185,12 @@ class ResourceTypeController extends Controller
      */
     public function optionsShow(string $resource_type_id): JsonResponse
     {
-        $authenticated = Route::resourceType(
+        Route::resourceType(
+            $resource_type_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::resourceType(
             $resource_type_id,
             $this->permitted_resource_types
         );
@@ -192,20 +198,20 @@ class ResourceTypeController extends Controller
         $get = Get::init()->
             setParameters('api.resource-type.parameters.item')->
             setDescription('route-descriptions.resource_type_GET_show')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['view'])->
             option();
 
         $delete = Delete::init()->
             setDescription('route-descriptions.resource_type_DELETE')->
             setAuthenticationRequired(true)->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             option();
 
         $patch = Patch::init()->
             setFields('api.resource-type.fields')->
             setDescription('route-descriptions.resource_type_PATCH')->
             setAuthenticationRequired(true)->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             option();
 
         return $this->optionsResponse(

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -137,12 +137,13 @@ class ResourceTypeController extends Controller
             );
         }
 
+        $headers = new Header();
+        $headers->item();
+
         return response()->json(
             (new ResourceTypeTransformer($resource_type, $resources))->toArray(),
             200,
-            [
-                'X-Total-Count' => 1
-            ]
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Option\Get;
 use App\Utilities\Header;
+use App\Utilities\RoutePermission;
 use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\Category;
@@ -111,14 +112,18 @@ class ResourceTypeItemController extends Controller
     /**
      * Generate the OPTIONS request for the items list
      *
-     * @param Request $request
      * @param string $resource_type_id
      *
      * @return JsonResponse
      */
-    public function optionsIndex(Request $request, string $resource_type_id): JsonResponse
+    public function optionsIndex(string $resource_type_id): JsonResponse
     {
-        $authenticated = Route::resourceType(
+        Route::resourceType(
+            $resource_type_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::resourceType(
             $resource_type_id,
             $this->permitted_resource_types
         );
@@ -137,7 +142,7 @@ class ResourceTypeItemController extends Controller
             setParameters('api.resource-type-item.parameters.collection')->
             setConditionalParameters($this->conditional_get_parameters)->
             setDescription('route-descriptions.resource_type_item_GET_index')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['view'])->
             option();
 
         return $this->optionsResponse($get, 200);

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -191,11 +191,11 @@ class ResourceTypeItemController extends Controller
         }
 
         $categories = (new Category())->paginatedCollection(
+            (int) $resource_type_id,
             $this->permitted_resource_types,
             $this->include_public,
             0,
-            100,
-            ['resource_type'=>$resource_type_id]
+            100
         );
         array_map(
             function($category) {

--- a/app/Http/Controllers/ResourceTypeItemController.php
+++ b/app/Http/Controllers/ResourceTypeItemController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Option\Get;
+use App\Utilities\Header;
 use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\Category;
@@ -82,23 +83,17 @@ class ResourceTypeItemController extends Controller
             $search_conditions
         );
 
-        $headers = [
-            'X-Count' => count($items),
-            'X-Total-Count' => $total,
-            'X-Offset' => $pagination['offset'],
-            'X-Limit' => $pagination['limit'],
-            'X-Link-Previous' => $pagination['links']['previous'],
-            'X-Link-Next' => $pagination['links']['next']
-        ];
+        $headers = new Header();
+        $headers->collection($pagination, count($items), $total);
 
         $sort_header = SortParameters::xHeader();
         if ($sort_header !== null) {
-            $headers['X-Sort'] = $sort_header;
+            $headers->addSort($sort_header);
         }
 
         $search_header = SearchParameters::xHeader();
         if ($search_header !== null) {
-            $headers['X-Search'] = $search_header;
+            $headers->addSearch($search_header);
         }
 
         return response()->json(
@@ -109,7 +104,7 @@ class ResourceTypeItemController extends Controller
                 $items
             ),
             200,
-            $headers
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -9,6 +9,7 @@ use App\Option\Post;
 use App\Utilities\Header;
 use App\Utilities\Pagination as UtilityPagination;
 use App\Utilities\Request as UtilityRequest;
+use App\Utilities\RoutePermission;
 use App\Validators\Request\Route;
 use App\Models\SubCategory;
 use App\Models\Transformers\SubCategory as SubCategoryTransformer;
@@ -149,7 +150,12 @@ class SubcategoryController extends Controller
      */
     public function optionsIndex(string $category_id): JsonResponse
     {
-        $authenticated = Route::category(
+        Route::category(
+            $category_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::category(
             $category_id,
             $this->permitted_resource_types
         );
@@ -160,14 +166,14 @@ class SubcategoryController extends Controller
             setPaginationOverride(true)->
             setParameters('api.subcategory.parameters.collection')->
             setDescription('route-descriptions.sub_category_GET_index')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['view'])->
             option();
 
         $post = Post::init()->
             setFields('api.subcategory.fields')->
             setDescription('route-descriptions.sub_category_POST')->
             setAuthenticationRequired(true)->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             option();
 
         return $this->optionsResponse(
@@ -189,7 +195,13 @@ class SubcategoryController extends Controller
         string $subcategory_id
     ): JsonResponse
     {
-        $authenticated = Route::subcategory(
+        Route::subcategory(
+            $category_id,
+            $subcategory_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::subcategory(
             $category_id,
             $subcategory_id,
             $this->permitted_resource_types
@@ -198,20 +210,20 @@ class SubcategoryController extends Controller
         $get = Get::init()->
             setParameters('api.subcategory.parameters.item')->
             setDescription('route-descriptions.sub_category_GET_show')->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['view'])->
             option();
 
         $delete = Delete::init()->
             setDescription('route-descriptions.sub_category_DELETE')->
             setAuthenticationRequired(true)->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             option();
 
         $patch = Patch::init()->
             setFields('api.subcategory.fields')->
             setDescription('route-descriptions.sub_category_PATCH')->
             setAuthenticationRequired(true)->
-            setAuthenticationStatus($authenticated)->
+            setAuthenticationStatus($permissions['manage'])->
             option();
 
         return $this->optionsResponse(

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -130,13 +130,13 @@ class SubcategoryController extends Controller
             UtilityResponse::notFound();
         }
 
+        $headers = new Header();
+        $headers->item();
+
         return response()->json(
             (new SubCategoryTransformer($subcategory))->toArray(),
             200,
-            [
-                'X-Total-Count' => 1,
-                'X-Count' => 1
-            ]
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -6,6 +6,7 @@ use App\Option\Delete;
 use App\Option\Get;
 use App\Option\Patch;
 use App\Option\Post;
+use App\Utilities\Header;
 use App\Utilities\Pagination as UtilityPagination;
 use App\Utilities\Request as UtilityRequest;
 use App\Validators\Request\Route;
@@ -76,23 +77,17 @@ class SubcategoryController extends Controller
             $sort_parameters
         );
 
-        $headers = [
-            'X-Count' => count($subcategories),
-            'X-Total-Count' => $total,
-            'X-Offset' => $pagination['offset'],
-            'X-Limit' => $pagination['limit'],
-            'X-Link-Previous' => $pagination['links']['previous'],
-            'X-Link-Next' => $pagination['links']['next']
-        ];
+        $headers = new Header();
+        $headers->collection($pagination, count($subcategories), $total);
 
         $sort_header = SortParameters::xHeader();
         if ($sort_header !== null) {
-            $headers['X-Sort'] = $sort_header;
+            $headers->addSort($sort_header);
         }
 
         $search_header = SearchParameters::xHeader();
         if ($search_header !== null) {
-            $headers['X-Search'] = $search_header;
+            $headers->addSearch($search_header);
         }
 
         return response()->json(
@@ -103,7 +98,7 @@ class SubcategoryController extends Controller
                 $subcategories
             ),
             200,
-            $headers
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -36,14 +36,16 @@ class SubcategoryController extends Controller
     /**
      * Return all the sub categories assigned to the given category
      *
-     * @param string $category_id
+     * @param $resource_type_id
+     * @param $category_id
      *
      * @return JsonResponse
      */
-    public function index(string $category_id): JsonResponse
+    public function index($resource_type_id, $category_id): JsonResponse
     {
         Route::category(
-            $category_id,
+            (int) $resource_type_id,
+            (int) $category_id,
             $this->permitted_resource_types
         );
 
@@ -52,7 +54,8 @@ class SubcategoryController extends Controller
         );
 
         $total = (new SubCategory())->totalCount(
-            $category_id,
+            (int) $resource_type_id,
+            (int) $category_id,
             $search_parameters
         );
 
@@ -61,17 +64,18 @@ class SubcategoryController extends Controller
         );
 
         $pagination = UtilityPagination::init(
-                request()->path(),
-                $total,
-                10,
-                $this->allow_entire_collection
-            )->
-            setSearchParameters($search_parameters)->
-            setSortParameters($sort_parameters)->
-            paging();
+            request()->path(),
+            $total,
+            10,
+            $this->allow_entire_collection
+        )->
+        setSearchParameters($search_parameters)->
+        setSortParameters($sort_parameters)->
+        paging();
 
         $subcategories = (new SubCategory())->paginatedCollection(
-            $category_id,
+            (int) $resource_type_id,
+            (int) $category_id,
             $pagination['offset'],
             $pagination['limit'],
             $search_parameters,
@@ -106,19 +110,22 @@ class SubcategoryController extends Controller
     /**
      * Return a single sub category
      *
-     * @param string $category_id
-     * @param string $subcategory_id
+     * @param $resource_type_id
+     * @param $category_id
+     * @param $subcategory_id
      *
      * @return JsonResponse
      */
     public function show(
-        string $category_id,
-        string $subcategory_id
+        $resource_type_id,
+        $category_id,
+        $subcategory_id
     ): JsonResponse
     {
         Route::subcategory(
-            $category_id,
-            $subcategory_id,
+            (int) $resource_type_id,
+            (int) $category_id,
+            (int) $subcategory_id,
             $this->permitted_resource_types
         );
 
@@ -144,19 +151,22 @@ class SubcategoryController extends Controller
     /**
      * Generate the OPTIONS request for the sub categories list
      *
-     * @param string $category_id
+     * @param $resource_type_id
+     * @param $category_id
      *
      * @return JsonResponse
      */
-    public function optionsIndex(string $category_id): JsonResponse
+    public function optionsIndex($resource_type_id, $category_id): JsonResponse
     {
         Route::category(
-            $category_id,
+            (int) $resource_type_id,
+            (int) $category_id,
             $this->permitted_resource_types
         );
 
         $permissions = RoutePermission::category(
-            $category_id,
+            (int) $resource_type_id,
+            (int) $category_id,
             $this->permitted_resource_types
         );
 
@@ -185,25 +195,29 @@ class SubcategoryController extends Controller
     /**
      * Generate the OPTIONS request for the specific sub category
      *
-     * @param string $category_id
-     * @param string $subcategory_id
+     * @param $resource_type_id
+     * @param $category_id
+     * @param $subcategory_id
      *
      * @return JsonResponse
      */
     public function optionsShow(
-        string $category_id,
-        string $subcategory_id
+        $resource_type_id,
+        $category_id,
+        $subcategory_id
     ): JsonResponse
     {
         Route::subcategory(
-            $category_id,
-            $subcategory_id,
+            (int) $resource_type_id,
+            (int) $category_id,
+            (int) $subcategory_id,
             $this->permitted_resource_types
         );
 
         $permissions = RoutePermission::subcategory(
-            $category_id,
-            $subcategory_id,
+            (int) $resource_type_id,
+            (int) $category_id,
+            (int) $subcategory_id,
             $this->permitted_resource_types
         );
 
@@ -235,14 +249,16 @@ class SubcategoryController extends Controller
     /**
      * Create a new sub category
      *
-     * @param string $category_id
+     * @param $resource_type_id
+     * @param $category_id
      *
      * @return JsonResponse
      */
-    public function create(string $category_id): JsonResponse
+    public function create($resource_type_id, $category_id): JsonResponse
     {
         Route::category(
-            $category_id,
+            (int) $resource_type_id,
+            (int) $category_id,
             $this->permitted_resource_types,
             true
         );
@@ -270,24 +286,27 @@ class SubcategoryController extends Controller
     /**
      * Delete the requested sub category
      *
-     * @param string $category_id
-     * @param string $subcategory_id
+     * @param $resource_type_id
+     * @param $category_id
+     * @param $subcategory_id
      *
      * @return JsonResponse
      */
     public function delete(
-        string $category_id,
-        string $subcategory_id
+        $resource_type_id,
+        $category_id,
+        $subcategory_id
     ): JsonResponse
     {
         Route::subcategory(
-            $category_id,
-            $subcategory_id,
+            (int) $resource_type_id,
+            (int) $category_id,
+            (int) $subcategory_id,
             $this->permitted_resource_types,
             true
         );
 
-        $sub_category = (new SubCategory())->single(
+        $sub_category = (new SubCategory())->instance(
             $category_id,
             $subcategory_id
         );
@@ -310,19 +329,22 @@ class SubcategoryController extends Controller
     /**
      * Update the selected subcategory
      *
-     * @param string $category_id
-     * @param string $subcategory_id
+     * @param $resource_type_id
+     * @param $category_id
+     * @param $subcategory_id
      *
      * @return JsonResponse
      */
     public function update(
-        string $category_id,
-        string $subcategory_id
+        $resource_type_id,
+        $category_id,
+        $subcategory_id
     ): JsonResponse
     {
         Route::subcategory(
-            $category_id,
-            $subcategory_id,
+            (int) $resource_type_id,
+            (int) $category_id,
+            (int) $subcategory_id,
             $this->permitted_resource_types,
             true
         );

--- a/app/Http/Controllers/SummaryCategoryController.php
+++ b/app/Http/Controllers/SummaryCategoryController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Category;
 use App\Option\Get;
 use App\Utilities\Header;
+use App\Utilities\RoutePermission;
+use App\Validators\Request\Route;
 use Illuminate\Http\JsonResponse;
 
 /**
@@ -19,11 +21,19 @@ class SummaryCategoryController extends Controller
     /**
      * Return a summary of the categories
      *
+     * @param $resource_type_id
+     *
      * @return JsonResponse
      */
-    public function index(): JsonResponse
+    public function index($resource_type_id): JsonResponse
     {
+        Route::resourceType(
+            $resource_type_id,
+            $this->permitted_resource_types
+        );
+
         $summary = (new Category())->totalCount(
+            $resource_type_id,
             $this->permitted_resource_types,
             $this->include_public
         );
@@ -45,13 +55,25 @@ class SummaryCategoryController extends Controller
     /**
      * Generate the OPTIONS request for the categories summary
      *
+     * @param $resource_type_id
+     *
      * @return JsonResponse
      */
-    public function optionsIndex(): JsonResponse
+    public function optionsIndex($resource_type_id): JsonResponse
     {
+        Route::resourceType(
+            $resource_type_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::resourceType(
+            $resource_type_id,
+            $this->permitted_resource_types
+        );
+
         $get = Get::init()->
             setDescription('route-descriptions.summary_category_GET_index')->
-            setAuthenticationStatus(($this->user_id !== null) ? true : false)->
+            setAuthenticationStatus($permissions['view'])->
             option();
 
         return $this->optionsResponse($get, 200);

--- a/app/Http/Controllers/SummaryCategoryController.php
+++ b/app/Http/Controllers/SummaryCategoryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Category;
 use App\Option\Get;
+use App\Utilities\Header;
 use Illuminate\Http\JsonResponse;
 
 /**
@@ -27,15 +28,16 @@ class SummaryCategoryController extends Controller
             $this->include_public
         );
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', $summary);
+        $headers->add('X-Count', $summary);
+
         return response()->json(
             [
                 'categories' => $summary
             ],
             200,
-            [
-                'X-Total-Count' => $summary,
-                'X-Count' => $summary
-            ]
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Option\Get;
 use App\Utilities\Header;
 use App\Utilities\Response;
+use App\Utilities\RoutePermission;
 use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\ItemSummary;
@@ -512,11 +513,17 @@ class SummaryItemController extends Controller
             $this->permitted_resource_types
         );
 
+        $permissions = RoutePermission::resource(
+            $resource_type_id,
+            $resource_id,
+            $this->permitted_resource_types
+        );
+
         $get = Get::init()->
             setParameters('api.item.summary-parameters.collection')->
             setSearchable('api.item.searchable')->
             setDescription('route-descriptions.summary_GET_resource-type_resource_items')->
-            setAuthenticationStatus(($this->user_id !== null) ? true : false)->
+            setAuthenticationStatus($permissions['view'])->
             option();
 
         return $this->optionsResponse($get, 200);

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -34,13 +34,12 @@ class SummaryItemController extends Controller
     /**
      * Return the TCO for the resource
      *
-     * @param Request $request
      * @param string $resource_type_id
      * @param string $resource_id
      *
      * @return JsonResponse
      */
-    public function index(Request $request, string $resource_type_id, string $resource_id): JsonResponse
+    public function index(string $resource_type_id, string $resource_id): JsonResponse
     {
         Route::resource(
             $resource_type_id,
@@ -107,14 +106,21 @@ class SummaryItemController extends Controller
         ) {
             if (array_key_exists('subcategories', $collection_parameters) === true &&
                 General::booleanValue($collection_parameters['subcategories']) === true) {
-                return $this->subcategoriesSummary($collection_parameters['category']);
+                return $this->subcategoriesSummary(
+                    $resource_type_id,
+                    $collection_parameters['category']
+                );
             } else if (array_key_exists('subcategory', $collection_parameters) === true) {
                 return $this->subcategorySummary(
+                    $resource_type_id,
                     $collection_parameters['category'],
                     $collection_parameters['subcategory']
                 );
             } else {
-                return $this->categorySummary($collection_parameters['category']);
+                return $this->categorySummary(
+                    $resource_type_id,
+                    $collection_parameters['category']
+                );
             }
         }
 
@@ -383,13 +389,15 @@ class SummaryItemController extends Controller
     /**
      * Return the category summary for a resource
      *
+     * @param integer $resource_type_id
      * @param integer $category_id
      *
      * @return JsonResponse
      */
-    private function categorySummary(int $category_id): JsonResponse
+    private function categorySummary(int $resource_type_id, int $category_id): JsonResponse
     {
         Route::category(
+            $resource_type_id,
             $category_id,
             $this->permitted_resource_types
         );
@@ -419,13 +427,15 @@ class SummaryItemController extends Controller
     /**
      * Return the subcategories summary for a category
      *
+     * @param integer $resource_type_id
      * @param integer $category_id
      *
      * @return JsonResponse
      */
-    private function subcategoriesSummary(int $category_id): JsonResponse
+    private function subcategoriesSummary(int $resource_type_id, int $category_id): JsonResponse
     {
         Route::category(
+            $resource_type_id,
             $category_id,
             $this->permitted_resource_types
         );
@@ -460,14 +470,20 @@ class SummaryItemController extends Controller
     /**
      * Return the subcategories summary for a category
      *
+     * @param integer $resource_type_id
      * @param integer $category_id
      * @param integer $subcategory_id
      *
      * @return JsonResponse
      */
-    private function subcategorySummary(int $category_id, int $subcategory_id): JsonResponse
+    private function subcategorySummary(
+        int $resource_type_id,
+        int $category_id,
+        int $subcategory_id
+    ): JsonResponse
     {
         Route::subcategory(
+            $resource_type_id,
             $category_id,
             $subcategory_id,
             $this->permitted_resource_types

--- a/app/Http/Controllers/SummaryItemController.php
+++ b/app/Http/Controllers/SummaryItemController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Option\Get;
+use App\Utilities\Header;
 use App\Utilities\Response;
 use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
@@ -152,15 +153,16 @@ class SummaryItemController extends Controller
             Response::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', 1);
+        $headers->add('X-Count', 1);
+
         return response()->json(
             [
                 'total' => number_format($summary[0]['actualised_total'], 2, '.', '')
             ],
             200,
-            [
-                'X-Total-Count' => count($summary),
-                'X-Count' => count($summary)
-            ]
+            $headers->headers()
         );
     }
 
@@ -181,6 +183,10 @@ class SummaryItemController extends Controller
             Response::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             array_map(
                 function($year) {
@@ -189,10 +195,7 @@ class SummaryItemController extends Controller
                 $summary
             ),
             200,
-            [
-                'X-Total-Count' => count($summary),
-                'X-Count' => count($summary)
-            ]
+            $headers->headers()
         );
     }
 
@@ -216,13 +219,14 @@ class SummaryItemController extends Controller
             Response::successEmptyContent();
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             (new ItemYearSummaryTransformer($summary[0]))->toArray(),
             200,
-            [
-                'X-Total-Count' => count($summary),
-                'X-Count' => count($summary)
-            ]
+            $headers->headers()
         );
     }
 
@@ -246,6 +250,10 @@ class SummaryItemController extends Controller
             Response::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             array_map(
                 function($month) {
@@ -254,10 +262,7 @@ class SummaryItemController extends Controller
                 $summary
             ),
             200,
-            [
-                'X-Total-Count' => count($summary),
-                'X-Count' => count($summary)
-            ]
+            $headers->headers()
         );
     }
 
@@ -283,13 +288,14 @@ class SummaryItemController extends Controller
             Response::successEmptyContent();
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             (new ItemMonthSummaryTransformer($summary[0]))->toArray(),
             200,
-            [
-                'X-Total-Count' => count($summary),
-                'X-Count' => count($summary)
-            ]
+            $headers->headers()
         );
     }
 
@@ -310,6 +316,10 @@ class SummaryItemController extends Controller
             Response::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             array_map(
                 function($category) {
@@ -318,10 +328,7 @@ class SummaryItemController extends Controller
                 $summary
             ),
             200,
-            [
-                'X-Total-Count' => count($summary),
-                'X-Count' => count($summary)
-            ]
+            $headers->headers()
         );
     }
 
@@ -359,15 +366,16 @@ class SummaryItemController extends Controller
             Response::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             [
                 'total' => number_format($summary[0]['total'], 2, '.', '')
             ],
             200,
-            [
-                'X-Total-Count' => count($summary),
-                'X-Count' => count($summary)
-            ]
+            $headers->headers()
         );
     }
 
@@ -396,13 +404,14 @@ class SummaryItemController extends Controller
             Response::successEmptyContent();
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             (new ItemCategorySummaryTransformer($summary[0]))->toArray(),
             200,
-            [
-                'X-Total-Count' => count($summary),
-                'X-Count' => count($summary)
-            ]
+            $headers->headers()
         );
     }
 
@@ -431,6 +440,10 @@ class SummaryItemController extends Controller
             Response::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             array_map(
                 function($subcategory) {
@@ -439,10 +452,7 @@ class SummaryItemController extends Controller
                 $summary
             ),
             200,
-            [
-                'X-Total-Count' => count($summary),
-                'X-Count' => count($summary)
-            ]
+            $headers->headers()
         );
     }
 
@@ -474,13 +484,14 @@ class SummaryItemController extends Controller
             Response::successEmptyContent();
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             (new ItemSubCategorySummaryTransformer($summary[0]))->toArray(),
             200,
-            [
-                'X-Total-Count' => count($summary),
-                'X-Count' => count($summary)
-            ]
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/SummaryRequestController.php
+++ b/app/Http/Controllers/SummaryRequestController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Option\Get;
+use App\Utilities\Header;
 use App\Validators\Request\Parameters;
 use App\Models\RequestLog;
 use Illuminate\Http\JsonResponse;
@@ -37,9 +38,14 @@ class SummaryRequestController extends Controller
             $summary[$month['year']][] = ['month' => $month['month'], 'requests' => $month['requests']];
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             $summary,
-            200
+            200,
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/SummaryResourceController.php
+++ b/app/Http/Controllers/SummaryResourceController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Option\Get;
+use App\Utilities\Header;
 use App\Validators\Request\Route;
 use App\Models\Resource;
 use Illuminate\Http\JsonResponse;
@@ -38,12 +39,16 @@ class SummaryResourceController extends Controller
             $this->include_public
         );
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', $summary);
+        $headers->add('X-Count', $summary);
+
         return response()->json(
             [
                 'resources' => $summary
             ],
             200,
-            ['X-Total-Count' => $summary]
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/SummaryResourceController.php
+++ b/app/Http/Controllers/SummaryResourceController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Option\Get;
 use App\Utilities\Header;
+use App\Utilities\RoutePermission;
 use App\Validators\Request\Route;
 use App\Models\Resource;
 use Illuminate\Http\JsonResponse;
@@ -68,10 +69,15 @@ class SummaryResourceController extends Controller
             $this->permitted_resource_types
         );
 
+        $permissions = RoutePermission::resourceType(
+            $resource_type_id,
+            $this->permitted_resource_types
+        );
+
         $get = Get::init()->
             setParameters('api.resource.summary-parameters.collection')->
             setDescription('route-descriptions.summary-resource-GET-index')->
-            setAuthenticationStatus(($this->user_id !== null) ? true : false)->
+            setAuthenticationStatus($permissions['view'])->
             option();
 
         return $this->optionsResponse($get, 200);

--- a/app/Http/Controllers/SummaryResourceTypeController.php
+++ b/app/Http/Controllers/SummaryResourceTypeController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\ResourceType;
 use App\Option\Get;
+use App\Utilities\Header;
 use Illuminate\Http\JsonResponse;
 
 /**
@@ -27,12 +28,16 @@ class SummaryResourceTypeController extends Controller
             $this->include_public
         );
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', $summary);
+        $headers->add('X-Count', $summary);
+
         return response()->json(
             [
                 'resource_types' => $summary
             ],
             200,
-            ['X-Total-Count' => $summary]
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/SummaryResourceTypeItemController.php
+++ b/app/Http/Controllers/SummaryResourceTypeItemController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Option\Get;
 use App\Utilities\Header;
+use App\Utilities\RoutePermission;
 use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\ResourceTypeItem;
@@ -529,15 +530,19 @@ class SummaryResourceTypeItemController extends Controller
     /**
      * Generate the OPTIONS request for items summary route
      *
-     * @param Request $request
      * @param string $resource_type_id
      *
      * @return JsonResponse
      *
      */
-    public function optionsIndex(Request $request, string $resource_type_id): JsonResponse
+    public function optionsIndex(string $resource_type_id): JsonResponse
     {
         Route::resourceType(
+            $resource_type_id,
+            $this->permitted_resource_types
+        );
+
+        $permissions = RoutePermission::resourceType(
             $resource_type_id,
             $this->permitted_resource_types
         );
@@ -546,7 +551,7 @@ class SummaryResourceTypeItemController extends Controller
             setSearchable('api.resource-type-item.searchable')->
             setParameters('api.resource-type-item.summary-parameters.collection')->
             setDescription('route-descriptions.summary-resource-type-item-GET-index')->
-            setAuthenticationStatus(($this->user_id !== null) ? true : false)->
+            setAuthenticationStatus($permissions['view'])->
             option();
 
         return $this->optionsResponse($get, 200);

--- a/app/Http/Controllers/SummaryResourceTypeItemController.php
+++ b/app/Http/Controllers/SummaryResourceTypeItemController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Option\Get;
+use App\Utilities\Header;
 use App\Validators\Request\Parameters;
 use App\Validators\Request\Route;
 use App\Models\ResourceTypeItem;
@@ -162,6 +163,10 @@ class SummaryResourceTypeItemController extends Controller
             UtilityResponse::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             [
                 'total' => number_format(
@@ -172,7 +177,7 @@ class SummaryResourceTypeItemController extends Controller
                 )
             ],
             200,
-            ['X-Total-Count' => 1]
+            $headers->headers()
         );
     }
 
@@ -193,6 +198,10 @@ class SummaryResourceTypeItemController extends Controller
             UtilityResponse::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             array_map(
                 function ($resource) {
@@ -201,7 +210,7 @@ class SummaryResourceTypeItemController extends Controller
                 $summary
             ),
             200,
-            ['X-Total-Count' => count($summary)]
+            $headers->headers()
         );
     }
 
@@ -222,6 +231,10 @@ class SummaryResourceTypeItemController extends Controller
             UtilityResponse::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             array_map(
                 function ($year) {
@@ -230,7 +243,7 @@ class SummaryResourceTypeItemController extends Controller
                 $summary
             ),
             200,
-            ['X-Total-Count' => count($summary)]
+            $headers->headers()
         );
     }
 
@@ -253,10 +266,14 @@ class SummaryResourceTypeItemController extends Controller
             UtilityResponse::successEmptyContent();
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             (new ResourceTypeItemYearSummaryTransformer($summary[0]))->toArray(),
             200,
-            ['X-Total-Count' => count($summary)]
+            $headers->headers()
         );
     }
 
@@ -280,6 +297,10 @@ class SummaryResourceTypeItemController extends Controller
             UtilityResponse::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             array_map(
                 function ($month) {
@@ -288,7 +309,7 @@ class SummaryResourceTypeItemController extends Controller
                 $summary
             ),
             200,
-            ['X-Total-Count' => count($summary)]
+            $headers->headers()
         );
     }
 
@@ -314,10 +335,14 @@ class SummaryResourceTypeItemController extends Controller
             UtilityResponse::successEmptyContent();
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             (new ResourceTypeItemMonthSummaryTransformer($summary[0]))->toArray(),
             200,
-            ['X-Total-Count' => 1]
+            $headers->headers()
         );
     }
 
@@ -338,6 +363,10 @@ class SummaryResourceTypeItemController extends Controller
             UtilityResponse::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             array_map(
                 function ($category) {
@@ -346,7 +375,7 @@ class SummaryResourceTypeItemController extends Controller
                 $summary
             ),
             200,
-            ['X-Total-Count' => count($summary)]
+            $headers->headers()
         );
     }
 
@@ -370,10 +399,14 @@ class SummaryResourceTypeItemController extends Controller
             UtilityResponse::successEmptyContent();
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             (new ResourceTypeItemCategorySummaryTransformer($summary[0]))->toArray(),
             200,
-            ['X-Total-Count' => 1]
+            $headers->headers()
         );
     }
 
@@ -410,12 +443,16 @@ class SummaryResourceTypeItemController extends Controller
             UtilityResponse::successEmptyContent();
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             [
                 'total' => number_format($summary[0]['total'], 2, '.', '')
             ],
             200,
-            ['X-Total-Count' => 1]
+            $headers->headers()
         );
     }
 
@@ -439,6 +476,10 @@ class SummaryResourceTypeItemController extends Controller
             UtilityResponse::successEmptyContent(true);
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             array_map(
                 function ($category) {
@@ -447,7 +488,7 @@ class SummaryResourceTypeItemController extends Controller
                 $summary
             ),
             200,
-            ['X-Total-Count' => count($summary)]
+            $headers->headers()
         );
     }
 
@@ -473,10 +514,14 @@ class SummaryResourceTypeItemController extends Controller
             UtilityResponse::successEmptyContent();
         }
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Count', count($summary));
+
         return response()->json(
             (new ResourceTypeItemSubcategorySummaryTransformer($summary[0]))->toArray(),
             200,
-            ['X-Total-Count' => 1]
+            $headers->headers()
         );
     }
 

--- a/app/Http/Controllers/SummarySubcategoryController.php
+++ b/app/Http/Controllers/SummarySubcategoryController.php
@@ -23,18 +23,23 @@ class SummarySubcategoryController extends Controller
     /**
      * Return a summary of the subcategories
      *
-     * @param string $category_id
+     * @param $resource_type_id
+     * @param $category_id
      *
      * @return JsonResponse
      */
-    public function index(string $category_id): JsonResponse
+    public function index($resource_type_id, $category_id): JsonResponse
     {
         Route::category(
+            $resource_type_id,
             $category_id,
             $this->permitted_resource_types
         );
 
-        $summary = (new SubCategory())->totalCount($category_id);
+        $summary = (new SubCategory())->totalCount(
+            $resource_type_id,
+            $category_id
+        );
 
         $headers = new Header();
         $headers->add('X-Total-Count', $summary);
@@ -53,18 +58,21 @@ class SummarySubcategoryController extends Controller
     /**
      * Generate the OPTIONS request for the subcategories summary
      *
-     * @param string $category_id
+     * @param $resource_type_id
+     * @param $category_id
      *
      * @return JsonResponse
      */
-    public function optionsIndex(string $category_id): JsonResponse
+    public function optionsIndex($resource_type_id, $category_id): JsonResponse
     {
         Route::category(
+            $resource_type_id,
             $category_id,
             $this->permitted_resource_types
         );
 
         $permissions = RoutePermission::category(
+            $resource_type_id,
             $category_id,
             $this->permitted_resource_types
         );

--- a/app/Http/Controllers/SummarySubcategoryController.php
+++ b/app/Http/Controllers/SummarySubcategoryController.php
@@ -6,6 +6,7 @@ use App\Models\Category;
 use App\Models\SubCategory;
 use App\Option\Get;
 use App\Utilities\Header;
+use App\Utilities\RoutePermission;
 use App\Validators\Request\Route;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -63,9 +64,14 @@ class SummarySubcategoryController extends Controller
             $this->permitted_resource_types
         );
 
+        $permissions = RoutePermission::category(
+            $category_id,
+            $this->permitted_resource_types
+        );
+
         $get = Get::init()->
             setDescription('route-descriptions.summary_subcategory_GET_index')->
-            setAuthenticationStatus(($this->user_id !== null) ? true : false)->
+            setAuthenticationStatus($permissions['view'])->
             option();
 
         return $this->optionsResponse($get, 200);

--- a/app/Http/Controllers/SummarySubcategoryController.php
+++ b/app/Http/Controllers/SummarySubcategoryController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Category;
 use App\Models\SubCategory;
 use App\Option\Get;
+use App\Utilities\Header;
 use App\Validators\Request\Route;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -34,15 +35,16 @@ class SummarySubcategoryController extends Controller
 
         $summary = (new SubCategory())->totalCount($category_id);
 
+        $headers = new Header();
+        $headers->add('X-Total-Count', $summary);
+        $headers->add('X-Count', $summary);
+
         return response()->json(
             [
                 'subcategories' => $summary
             ],
             200,
-            [
-                'X-Total-Count' => $summary,
-                'X-Count' => $summary
-            ]
+            $headers->headers()
         );
     }
 

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -46,29 +46,23 @@ class Category extends Model
     }
 
     /**
+     * @param integer $resource_type_id
      * @param array $permitted_resource_types
      * @param boolean $include_public
-     * @param array $parameters
      * @param array $search_parameters
      *
      * @return integer
      */
     public function totalCount(
+        int $resource_type_id,
         array $permitted_resource_types,
         bool $include_public,
-        array $parameters = [],
         array $search_parameters = []
     ): int
     {
         $collection = $this->select('category.id')->
-            join("resource_type", "category.resource_type_id", "resource_type.id");
-
-        if (
-            array_key_exists('resource_type', $parameters) === true &&
-            $parameters['resource_type'] !== null
-        ) {
-            $collection->where('category.resource_type_id', '=', $parameters['resource_type']);
-        }
+            join("resource_type", "category.resource_type_id", "resource_type.id")->
+            where('category.resource_type_id', '=', $resource_type_id);
 
         $collection = ModelUtility::applyResourceTypeCollectionCondition(
             $collection,
@@ -84,22 +78,22 @@ class Category extends Model
     /**
      * Return the paginated collection
      *
+     * @param integer $resource_type_id
      * @param array $permitted_resource_types
      * @param boolean $include_public Should we include categories assigned to public resources
      * @param integer $offset
      * @param integer $limit
-     * @param array $parameters
      * @param array $search_parameters
      * @param array $sort_parameters
      *
      * @return array
      */
     public function paginatedCollection(
+        int $resource_type_id,
         array $permitted_resource_types,
         bool $include_public,
         int $offset = 0,
         int $limit = 10,
-        array $parameters = [],
         array $search_parameters = [],
         array $sort_parameters = []
     ): array {
@@ -112,7 +106,8 @@ class Category extends Model
             'resource_type.id AS resource_type_id',
             'resource_type.name AS resource_type_name',
             'resource_type.name AS resource_type_name'
-        )->selectRaw('
+        )->
+        selectRaw('
             (
                 SELECT 
                     COUNT(`sub_category`.`id`) 
@@ -121,14 +116,9 @@ class Category extends Model
                 WHERE 
                     `sub_category`.`category_id` = `category`.`id`
             ) AS `category_subcategories`'
-        )->join("resource_type", "category.resource_type_id", "resource_type.id");
-
-        if (
-            array_key_exists('resource_type', $parameters) === true &&
-            $parameters['resource_type'] !== null
-        ) {
-            $collection->where('category.resource_type_id', '=', $parameters['resource_type']);
-        }
+        )->
+        join("resource_type", "category.resource_type_id", "resource_type.id")->
+        where('category.resource_type_id', '=', $resource_type_id);
 
         $collection = ModelUtility::applyResourceTypeCollectionCondition(
             $collection,

--- a/app/Models/RequestLog.php
+++ b/app/Models/RequestLog.php
@@ -23,7 +23,7 @@ class RequestLog extends Model
 
     public function totalCount()
     {
-        return count($this->select('id')->get());
+        return $this->selectRaw('COUNT(id) AS total')->get()->toArray();
     }
 
     /**

--- a/app/Models/SubCategory.php
+++ b/app/Models/SubCategory.php
@@ -56,6 +56,7 @@ class SubCategory extends Model
     }
 
     /**
+     * @param integer $resource_type_id
      * @param integer $category_id
      * @param integer $offset
      * @param integer $limit
@@ -65,6 +66,7 @@ class SubCategory extends Model
      * @return array
      */
     public function paginatedCollection(
+        int $resource_type_id,
         int $category_id,
         int $offset = 0,
         int $limit = 10,
@@ -78,7 +80,9 @@ class SubCategory extends Model
                 'sub_category.description AS subcategory_description',
                 'sub_category.created_at AS subcategory_created_at'
             )->
-            where('category_id', '=', $category_id);
+            join('category', 'sub_category.category_id', 'category.id')->
+            where('sub_category.category_id', '=', $category_id)->
+            where('category.resource_type_id', '=', $resource_type_id);
 
         $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 

--- a/app/Models/SubCategory.php
+++ b/app/Models/SubCategory.php
@@ -38,17 +38,21 @@ class SubCategory extends Model
     }
 
     /**
+     * @param integer $resource_type_id
      * @param integer $category_id
      * @param array $search_parameters
      *
      * @return integer
      */
     public function totalCount(
+        int $resource_type_id,
         int $category_id,
         array $search_parameters = []
     ): int
     {
-        $collection = $this->where('category_id', '=', $category_id);
+        $collection = $this->join('category', 'sub_category.category_id', 'category.id')->
+            where('sub_category.category_id', '=', $category_id)->
+            where('category.resource_type_id', '=', $resource_type_id);
 
         $collection = ModelUtility::applySearch($collection, $this->table, $search_parameters);
 
@@ -165,6 +169,7 @@ class SubCategory extends Model
      * Validate that the subcategory exists and is accessible to the user for
      * viewing, editing based on their permitted resource types
      *
+     * @param integer $resource_type_id
      * @param integer $category_id
      * @param integer $subcategory_id
      * @param array $permitted_resource_types
@@ -174,6 +179,7 @@ class SubCategory extends Model
      * @return boolean
      */
     public function existsToUser(
+        int $resource_type_id,
         int $category_id,
         int $subcategory_id,
         array $permitted_resource_types,
@@ -183,7 +189,8 @@ class SubCategory extends Model
         $collection = $this->where('sub_category.id', '=', $subcategory_id)->
             join('category', 'sub_category.category_id', 'category.id')->
             join('resource_type', 'category.resource_type_id', 'resource_type.id')->
-            where('sub_category.category_id', '=', $category_id);
+            where('sub_category.category_id', '=', $category_id)->
+            where('category.resource_type_id', '=', $resource_type_id);
 
         $collection = ModelUtility::applyResourceTypeCollectionCondition(
             $collection,

--- a/app/Utilities/Hash.php
+++ b/app/Utilities/Hash.php
@@ -9,6 +9,10 @@ use Illuminate\Support\Facades\Config;
 /**
  * Utility hash class to encode and decode strings by type
  *
+ * As with all utility classes, eventually they may be moved into libraries if
+ * they gain more than a few functions and the creation of a library makes
+ * sense.
+ *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright G3D Development Limited 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE

--- a/app/Utilities/Header.php
+++ b/app/Utilities/Header.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace App\Utilities;
 
 /**
- * Header utility functions.
+ * Generate the headers for the request.
  *
  * As with all utility classes, eventually they may be moved into libraries if
  * they gain more than a few functions and the creation of a library makes
@@ -16,5 +16,94 @@ namespace App\Utilities;
  */
 class Header
 {
-    
+    /**
+     * @var array
+     */
+    private $headers;
+
+    public function __construct()
+    {
+        $this->headers = [];
+    }
+
+    /**
+     * Generate the initial headers necessary for a collection
+     *
+     * @param array $pagination Pagination data array, assumed indexes, offset,
+     * limit, links (with previous and next indexes)
+     * @param int $count Results in request
+     * @param int $total_count Results in entire collection
+     *
+     * @return Header
+     */
+    public function collection(
+        array $pagination,
+        int $count,
+        int $total_count
+    ): Header
+    {
+        $this->headers = [
+            'X-Count' => $count,
+            'X-Total-Count' => $total_count,
+            'X-Offset' => $pagination['offset'],
+            'X-Limit' => $pagination['limit'],
+            'X-Link-Previous' => $pagination['links']['previous'],
+            'X-Link-Next' => $pagination['links']['next']
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Add a header to the headers array, does not check to see if the header
+     * already exists, overwrites if previously set
+     *
+     * @param string $name Header name
+     * @param string $value Header value
+     *
+     * @return Header
+     */
+    public function add(
+        string $name,
+        string $value
+    ): Header
+    {
+        $this->headers[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Add the X-Sort header
+     *
+     * @param string $value
+     *
+     * @return Header
+     */
+    public function addSort(string $value): Header
+    {
+        return $this->add('X-Sort', $value);
+    }
+
+    /**
+     * Add the X-Search header
+     *
+     * @param string $value
+     *
+     * @return Header
+     */
+    public function addSearch(string $value): Header
+    {
+        return $this->add('X-Search', $value);
+    }
+
+    /**
+     * Return the headers array
+     *
+     * @return array
+     */
+    public function headers(): array
+    {
+        return $this->headers;
+    }
 }

--- a/app/Utilities/Header.php
+++ b/app/Utilities/Header.php
@@ -55,17 +55,30 @@ class Header
     }
 
     /**
+     * Generate the initial headers necessary for an item
+     *
+     * @return Header
+     */
+    public function item(): Header
+    {
+        $this->add('X-Total-Count', 1);
+        $this->add('X-Count', 1);
+
+        return $this;
+    }
+
+    /**
      * Add a header to the headers array, does not check to see if the header
      * already exists, overwrites if previously set
      *
      * @param string $name Header name
-     * @param string $value Header value
+     * @param mixed $value Header value
      *
      * @return Header
      */
     public function add(
         string $name,
-        string $value
+        $value
     ): Header
     {
         $this->headers[$name] = $value;
@@ -76,11 +89,11 @@ class Header
     /**
      * Add the X-Sort header
      *
-     * @param string $value
+     * @param mixed $value
      *
      * @return Header
      */
-    public function addSort(string $value): Header
+    public function addSort($value): Header
     {
         return $this->add('X-Sort', $value);
     }
@@ -88,11 +101,11 @@ class Header
     /**
      * Add the X-Search header
      *
-     * @param string $value
+     * @param mixed $value
      *
      * @return Header
      */
-    public function addSearch(string $value): Header
+    public function addSearch($value): Header
     {
         return $this->add('X-Search', $value);
     }

--- a/app/Utilities/Header.php
+++ b/app/Utilities/Header.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Utilities;
+
+/**
+ * Header utility functions.
+ *
+ * As with all utility classes, eventually they may be moved into libraries if
+ * they gain more than a few functions and the creation of a library makes
+ * sense.
+ *
+ * @author Dean Blackborough <dean@g3d-development.com>
+ * @copyright G3D Development Limited 2018-2019
+ * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
+ */
+class Header
+{
+    
+}

--- a/app/Utilities/Model.php
+++ b/app/Utilities/Model.php
@@ -6,6 +6,10 @@ namespace App\Utilities;
 /**
  * Model helper class
  *
+ * As with all utility classes, eventually they may be moved into libraries if
+ * they gain more than a few functions and the creation of a library makes
+ * sense.
+ *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright G3D Development Limited 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE

--- a/app/Utilities/Pagination.php
+++ b/app/Utilities/Pagination.php
@@ -8,6 +8,10 @@ use Illuminate\Support\Facades\Config;
 /**
  * Pagination helper
  *
+ * As with all utility classes, eventually they may be moved into libraries if
+ * they gain more than a few functions and the creation of a library makes
+ * sense.
+ *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright G3D Development Limited 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE

--- a/app/Utilities/Request.php
+++ b/app/Utilities/Request.php
@@ -10,6 +10,10 @@ use Illuminate\Http\JsonResponse;
 /**
  * Request utility class, helper methods for PATCH and POST methods
  *
+ * As with all utility classes, eventually they may be moved into libraries if
+ * they gain more than a few functions and the creation of a library makes
+ * sense.
+ *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright G3D Development Limited 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE

--- a/app/Utilities/Response.php
+++ b/app/Utilities/Response.php
@@ -10,6 +10,10 @@ use Illuminate\Http\JsonResponse;
  * through out the API so all non expected responses should be returned via this
  * class
  *
+ * As with all utility classes, eventually they may be moved into libraries if
+ * they gain more than a few functions and the creation of a library makes
+ * sense.
+ *
  * @author Dean Blackborough <dean@g3d-development.com>
  * @copyright G3D Development Limited 2018-2019
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE

--- a/app/Utilities/RoutePermission.php
+++ b/app/Utilities/RoutePermission.php
@@ -27,7 +27,7 @@ class RoutePermission
      * @param $category_id
      * @param array $permitted_resource_types
      *
-     * @return array Two indexes, read and manage, values for both boolean
+     * @return array Two indexes, view and manage, values for both boolean
      */
     static public function category(
         $category_id,
@@ -48,14 +48,14 @@ class RoutePermission
 
 
     /**
-     * Returns the `read` and `manage` permission for the current user, checks
+     * Returns the `view` and `manage` permission for the current user, checks
      * against their permitted resource types
      *
      * @param $category_id
      * @param $subcategory_id
      * @param array $permitted_resource_types
      *
-     * @return array Two indexes, read and manage, values for both boolean
+     * @return array Two indexes, view and manage, values for both boolean
      */
     static public function subcategory(
         $category_id,
@@ -64,7 +64,7 @@ class RoutePermission
     ): array
     {
         return [
-            'read' => SubCategory::existsToUserForViewing(
+            'view' => SubCategory::existsToUserForViewing(
                 (int) $category_id,
                 (int) $subcategory_id,
                 $permitted_resource_types
@@ -78,13 +78,13 @@ class RoutePermission
     }
 
     /**
-     * Returns the `read` and `manage` permission for the current user, checks
+     * Returns the `view` and `manage` permission for the current user, checks
      * against their permitted resource types
      *
      * @param $resource_type_id
      * @param array $permitted_resource_types
      *
-     * @return array Two indexes, read and manage, values for both boolean
+     * @return array Two indexes, view and manage, values for both boolean
      */
     static public function resourceType(
         $resource_type_id,
@@ -104,14 +104,14 @@ class RoutePermission
     }
 
     /**
-     * Returns the `read` and `manage` permission for the current user, checks
+     * Returns the `view` and `manage` permission for the current user, checks
      * against their permitted resource types
      *
      * @param $resource_type_id
      * @param $resource_id
      * @param array $permitted_resource_types
      *
-     * @return array Two indexes, read and manage, values for both boolean
+     * @return array Two indexes, view and manage, values for both boolean
      */
     static public function resource(
         $resource_type_id,
@@ -134,7 +134,7 @@ class RoutePermission
     }
 
     /**
-     * Returns the `read` and `manage` permission for the current user, checks
+     * Returns the `view` and `manage` permission for the current user, checks
      * against their permitted resource types
      *
      * @param $resource_type_id
@@ -142,7 +142,7 @@ class RoutePermission
      * @param $item_id
      * @param array $permitted_resource_types
      *
-     * @return array Two indexes, read and manage, values for both boolean
+     * @return array Two indexes, view and manage, values for both boolean
      */
     static public function item(
         $resource_type_id,
@@ -168,7 +168,7 @@ class RoutePermission
     }
 
     /**
-     * Returns the `read` and `manage` permission for the current user, checks
+     * Returns the `view` and `manage` permission for the current user, checks
      * against their permitted resource types
      *
      * @param $resource_type_id
@@ -177,7 +177,7 @@ class RoutePermission
      * @param $item_category_id,
      * @param array $permitted_resource_types
      *
-     * @return array Two indexes, read and manage, values for both boolean
+     * @return array Two indexes, view and manage, values for both boolean
      */
     static public function itemCategory(
         $resource_type_id,
@@ -206,7 +206,7 @@ class RoutePermission
     }
 
     /**
-     * Returns the `read` and `manage` permission for the current user, checks
+     * Returns the `view` and `manage` permission for the current user, checks
      * against their permitted resource types
      *
      * @param $resource_type_id
@@ -216,7 +216,7 @@ class RoutePermission
      * @param $item_subcategory_id
      * @param array $permitted_resource_types
      *
-     * @return array Two indexes, read and manage, values for both boolean
+     * @return array Two indexes, view and manage, values for both boolean
      */
     static public function itemSubcategory(
         $resource_type_id,

--- a/app/Utilities/RoutePermission.php
+++ b/app/Utilities/RoutePermission.php
@@ -1,0 +1,249 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Validators\Request;
+
+use App\Validators\Request\Routes\Category;
+use App\Validators\Request\Routes\Item;
+use App\Validators\Request\Routes\ItemCategory;
+use App\Validators\Request\Routes\ItemSubCategory;
+use App\Validators\Request\Routes\Resource;
+use App\Validators\Request\Routes\ResourceType;
+use App\Validators\Request\Routes\SubCategory;
+
+/**
+ * Work out the permissions for each route, permissions are read and manage
+ *
+ * @author Dean Blackborough <dean@g3d-development.com>
+ * @copyright G3D Development Limited 2018-2019
+ * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
+ */
+class RoutePermission
+{
+    /**
+     * Returns the `read` and `manage` permission for the current user, checks
+     * against their permitted resource types
+     *
+     * @param $category_id
+     * @param array $permitted_resource_types
+     *
+     * @return array Two indexes, read and manage, values for both boolean
+     */
+    static public function category(
+        $category_id,
+        array $permitted_resource_types
+    ): array
+    {
+        return [
+            'view' => Category::existsToUserForViewing(
+                (int) $category_id,
+                $permitted_resource_types
+            ),
+            'manage' => Category::existsToUserForManagement(
+                (int) $category_id,
+                $permitted_resource_types
+            )
+        ];
+    }
+
+
+    /**
+     * Returns the `read` and `manage` permission for the current user, checks
+     * against their permitted resource types
+     *
+     * @param $category_id
+     * @param $subcategory_id
+     * @param array $permitted_resource_types
+     *
+     * @return array Two indexes, read and manage, values for both boolean
+     */
+    static public function subcategory(
+        $category_id,
+        $subcategory_id,
+        array $permitted_resource_types
+    ): array
+    {
+        return [
+            'read' => SubCategory::existsToUserForViewing(
+                (int) $category_id,
+                (int) $subcategory_id,
+                $permitted_resource_types
+            ),
+            'manage' => SubCategory::existsToUserForManagement(
+                (int) $category_id,
+                (int) $subcategory_id,
+                $permitted_resource_types
+            )
+        ];
+    }
+
+    /**
+     * Returns the `read` and `manage` permission for the current user, checks
+     * against their permitted resource types
+     *
+     * @param $resource_type_id
+     * @param array $permitted_resource_types
+     *
+     * @return array Two indexes, read and manage, values for both boolean
+     */
+    static public function resourceType(
+        $resource_type_id,
+        array $permitted_resource_types
+    ): array
+    {
+        return [
+            'view' => ResourceType::existsToUserForViewing(
+                (int) $resource_type_id,
+                $permitted_resource_types
+            ),
+            'manage' => ResourceType::existsToUserForManagement(
+                (int) $resource_type_id,
+                $permitted_resource_types
+            )
+        ];
+    }
+
+    /**
+     * Returns the `read` and `manage` permission for the current user, checks
+     * against their permitted resource types
+     *
+     * @param $resource_type_id
+     * @param $resource_id
+     * @param array $permitted_resource_types
+     *
+     * @return array Two indexes, read and manage, values for both boolean
+     */
+    static public function resource(
+        $resource_type_id,
+        $resource_id,
+        array $permitted_resource_types
+    ): array
+    {
+        return [
+            'view' => Resource::existsToUserForViewing(
+                (int) $resource_type_id,
+                (int) $resource_id,
+                $permitted_resource_types
+            ),
+            'manage' => Resource::existsToUserForManagement(
+                (int) $resource_type_id,
+                (int) $resource_id,
+                $permitted_resource_types
+            )
+        ];
+    }
+
+    /**
+     * Returns the `read` and `manage` permission for the current user, checks
+     * against their permitted resource types
+     *
+     * @param $resource_type_id
+     * @param $resource_id
+     * @param $item_id
+     * @param array $permitted_resource_types
+     *
+     * @return array Two indexes, read and manage, values for both boolean
+     */
+    static public function item(
+        $resource_type_id,
+        $resource_id,
+        $item_id,
+        array $permitted_resource_types
+    ): array
+    {
+        return [
+            'view' => Item::existsToUserForViewing(
+                (int) $resource_type_id,
+                (int) $resource_id,
+                (int) $item_id,
+                $permitted_resource_types
+            ),
+            'manage' => Item::existsToUserForManagement(
+                (int) $resource_type_id,
+                (int) $resource_id,
+                (int) $item_id,
+                $permitted_resource_types
+            )
+        ];
+    }
+
+    /**
+     * Returns the `read` and `manage` permission for the current user, checks
+     * against their permitted resource types
+     *
+     * @param $resource_type_id
+     * @param $resource_id
+     * @param $item_id
+     * @param $item_category_id,
+     * @param array $permitted_resource_types
+     *
+     * @return array Two indexes, read and manage, values for both boolean
+     */
+    static public function itemCategory(
+        $resource_type_id,
+        $resource_id,
+        $item_id,
+        $item_category_id,
+        array $permitted_resource_types
+    ): array
+    {
+        return [
+            'view' => ItemCategory::existsToUserForViewing(
+                (int) $resource_type_id,
+                (int) $resource_id,
+                (int) $item_id,
+                (int) $item_category_id,
+                $permitted_resource_types
+            ),
+            'manage' => ItemCategory::existsToUserForManagement(
+                (int) $resource_type_id,
+                (int) $resource_id,
+                (int) $item_id,
+                (int) $item_category_id,
+                $permitted_resource_types
+            )
+        ];
+    }
+
+    /**
+     * Returns the `read` and `manage` permission for the current user, checks
+     * against their permitted resource types
+     *
+     * @param $resource_type_id
+     * @param $resource_id
+     * @param $item_id
+     * @param $item_category_id
+     * @param $item_subcategory_id
+     * @param array $permitted_resource_types
+     *
+     * @return array Two indexes, read and manage, values for both boolean
+     */
+    static public function itemSubcategory(
+        $resource_type_id,
+        $resource_id,
+        $item_id,
+        $item_category_id,
+        $item_subcategory_id,
+        array $permitted_resource_types
+    ): array
+    {
+        return [
+        'view' => ItemSubCategory::existsToUserForViewing(
+                (int) $resource_type_id,
+                (int) $resource_id,
+                (int) $item_id,
+                (int) $item_category_id,
+                (int) $item_subcategory_id,
+                $permitted_resource_types
+            ),
+        'manage' => ItemSubCategory::existsToUserForManagement(
+                (int) $resource_type_id,
+                (int) $resource_id,
+                (int) $item_id,
+                (int) $item_category_id,
+                (int) $item_subcategory_id,
+                $permitted_resource_types
+            )
+        ];
+    }
+}

--- a/app/Utilities/RoutePermission.php
+++ b/app/Utilities/RoutePermission.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Validators\Request;
+namespace App\Utilities;
 
 use App\Validators\Request\Routes\Category;
 use App\Validators\Request\Routes\Item;

--- a/app/Utilities/RoutePermission.php
+++ b/app/Utilities/RoutePermission.php
@@ -55,6 +55,7 @@ class RoutePermission
      * Returns the `view` and `manage` permission for the current user, checks
      * against their permitted resource types
      *
+     * @param $resource_type_id
      * @param $category_id
      * @param $subcategory_id
      * @param array $permitted_resource_types
@@ -62,6 +63,7 @@ class RoutePermission
      * @return array Two indexes, view and manage, values for both boolean
      */
     static public function subcategory(
+        $resource_type_id,
         $category_id,
         $subcategory_id,
         array $permitted_resource_types
@@ -69,11 +71,13 @@ class RoutePermission
     {
         return [
             'view' => SubCategory::existsToUserForViewing(
+                (int) $resource_type_id,
                 (int) $category_id,
                 (int) $subcategory_id,
                 $permitted_resource_types
             ),
             'manage' => SubCategory::existsToUserForManagement(
+                (int) $resource_type_id,
                 (int) $category_id,
                 (int) $subcategory_id,
                 $permitted_resource_types

--- a/app/Utilities/RoutePermission.php
+++ b/app/Utilities/RoutePermission.php
@@ -24,22 +24,26 @@ class RoutePermission
      * Returns the `read` and `manage` permission for the current user, checks
      * against their permitted resource types
      *
-     * @param $category_id
+     * @param integer $resource_type_id
+     * @param integer $category_id
      * @param array $permitted_resource_types
      *
      * @return array Two indexes, view and manage, values for both boolean
      */
     static public function category(
+        $resource_type_id,
         $category_id,
         array $permitted_resource_types
     ): array
     {
         return [
             'view' => Category::existsToUserForViewing(
+                (int) $resource_type_id,
                 (int) $category_id,
                 $permitted_resource_types
             ),
             'manage' => Category::existsToUserForManagement(
+                (int) $resource_type_id,
                 (int) $category_id,
                 $permitted_resource_types
             )

--- a/app/Validators/Request/Fields/Category.php
+++ b/app/Validators/Request/Fields/Category.php
@@ -76,20 +76,11 @@ class Category extends BaseValidator
      */
     public function create(array $options = []): Validator
     {
-        $decode = $this->hash->resourceType()->decode(request()->input('resource_type_id'));
-        $resource_type_id = null;
-        if (count($decode) === 1) {
-            $resource_type_id = $decode[0];
-        }
+        $this->requiredIndexes(['resource_type_id'], $options);
 
         return ValidatorFacade::make(
-            array_merge(
-                request()->all(),
-                [
-                    'resource_type_id' => $resource_type_id
-                ]
-            ),
-            $this->createRules(intval($resource_type_id)),
+            request()->all(),
+            $this->createRules(intval($options['resource_type_id'])),
             $this->translateMessages('api.category.validation.POST.messages')
         );
     }

--- a/app/Validators/Request/Fields/ItemSubCategory.php
+++ b/app/Validators/Request/Fields/ItemSubCategory.php
@@ -34,12 +34,7 @@ class ItemSubCategory extends BaseValidator
         return array_merge(
             [
                 'subcategory_id' => [
-                    'required',
-                    Rule::exists('sub_category', 'id')->where(function ($query)
-                    {
-                        $query->where('category_id', '=', $this->category_id);
-                    }),
-
+                    'required'
                 ],
             ],
             Config::get('api.item-subcategory.validation.POST.fields')

--- a/app/Validators/Request/Route.php
+++ b/app/Validators/Request/Route.php
@@ -25,11 +25,13 @@ class Route
      * Validate the route, checks the route parameters based on the users
      * permitted resource types
      *
-     * @param $category_id
+     * @param int $resource_type_id
+     * @param int $category_id
      * @param array $permitted_resource_types
      * @param bool $manage
      */
     static public function category(
+        $resource_type_id,
         $category_id,
         array $permitted_resource_types,
         bool $manage = false
@@ -38,7 +40,8 @@ class Route
         if ($manage === false) {
             if (
                 Category::existsToUserForViewing(
-                    (int) $category_id,
+                    $resource_type_id,
+                    $category_id,
                     $permitted_resource_types
                 ) === false
             ) {
@@ -47,7 +50,8 @@ class Route
         } else {
             if (
                 Category::existsToUserForManagement(
-                    (int) $category_id,
+                    $resource_type_id,
+                    $category_id,
                     $permitted_resource_types
                 ) === false
             ) {

--- a/app/Validators/Request/Route.php
+++ b/app/Validators/Request/Route.php
@@ -25,14 +25,14 @@ class Route
      * Validate the route, checks the route parameters based on the users
      * permitted resource types
      *
-     * @param int $resource_type_id
-     * @param int $category_id
+     * @param integer $resource_type_id
+     * @param integer $category_id
      * @param array $permitted_resource_types
      * @param bool $manage
      */
     static public function category(
-        $resource_type_id,
-        $category_id,
+        int $resource_type_id,
+        int $category_id,
         array $permitted_resource_types,
         bool $manage = false
     )
@@ -65,14 +65,16 @@ class Route
      * Validate the route, checks the route parameters based on the users
      * permitted resource types
      *
-     * @param $category_id
-     * @param $subcategory_id
+     * @param integer $resource_type_id
+     * @param integer $category_id
+     * @param integer $subcategory_id
      * @param array $permitted_resource_types
      * @param bool $manage
      */
     static public function subcategory(
-        $category_id,
-        $subcategory_id,
+        int $resource_type_id,
+        int $category_id,
+        int $subcategory_id,
         array $permitted_resource_types,
         $manage = false
     )
@@ -80,8 +82,9 @@ class Route
         if ($manage === false) {
             if (
                 SubCategory::existsToUserForViewing(
-                    (int) $category_id,
-                    (int) $subcategory_id,
+                    $resource_type_id,
+                    $category_id,
+                    $subcategory_id,
                     $permitted_resource_types
                 ) === false
             ) {
@@ -90,6 +93,7 @@ class Route
         } else {
             if (
                 SubCategory::existsToUserForManagement(
+                    (int) $resource_type_id,
                     (int) $category_id,
                     (int) $subcategory_id,
                     $permitted_resource_types

--- a/app/Validators/Request/Route.php
+++ b/app/Validators/Request/Route.php
@@ -189,6 +189,8 @@ class Route
                 return true;
             }
         }
+
+        return true;
     }
 
     /**

--- a/app/Validators/Request/Route.php
+++ b/app/Validators/Request/Route.php
@@ -189,8 +189,6 @@ class Route
                 return true;
             }
         }
-
-        return false;
     }
 
     /**

--- a/app/Validators/Request/Route.php
+++ b/app/Validators/Request/Route.php
@@ -28,8 +28,6 @@ class Route
      * @param $category_id
      * @param array $permitted_resource_types
      * @param bool $manage
-     *
-     * @return bool
      */
     static public function category(
         $category_id,
@@ -54,13 +52,10 @@ class Route
                 ) === false
             ) {
                 UtilityResponse::notFoundOrNotAccessible(trans('entities.category'));
-            } else {
-                return true;
             }
         }
-
-        return false;
     }
+
 
     /**
      * Validate the route, checks the route parameters based on the users
@@ -70,8 +65,6 @@ class Route
      * @param $subcategory_id
      * @param array $permitted_resource_types
      * @param bool $manage
-     *
-     * @return bool
      */
     static public function subcategory(
         $category_id,
@@ -99,12 +92,8 @@ class Route
                 ) === false
             ) {
                 UtilityResponse::notFoundOrNotAccessible(trans('entities.subcategory'));
-            } else {
-                return true;
             }
         }
-
-        return false;
     }
 
     /**
@@ -114,8 +103,6 @@ class Route
      * @param $resource_type_id
      * @param array $permitted_resource_types
      * @param bool $manage
-     *
-     * @return bool
      */
     static public function resourceType(
         $resource_type_id,
@@ -140,12 +127,8 @@ class Route
                 ) === false
             ) {
                 UtilityResponse::notFoundOrNotAccessible(trans('entities.resource-type'));
-            } else {
-                return true;
             }
         }
-
-        return false;
     }
 
     /**
@@ -156,8 +139,6 @@ class Route
      * @param $resource_id
      * @param array $permitted_resource_types
      * @param bool $manage
-     *
-     * @return bool
      */
     static public function resource(
         $resource_type_id,
@@ -185,12 +166,8 @@ class Route
                 ) === false
             ) {
                 UtilityResponse::notFoundOrNotAccessible(trans('entities.resource'));
-            } else {
-                return true;
             }
         }
-
-        return true;
     }
 
     /**
@@ -202,8 +179,6 @@ class Route
      * @param $item_id
      * @param array $permitted_resource_types
      * @param bool $manage
-     *
-     * @return bool
      */
     static public function item(
         $resource_type_id,
@@ -234,12 +209,8 @@ class Route
                 ) === false
             ) {
                 UtilityResponse::notFoundOrNotAccessible(trans('entities.item'));
-            } else {
-                return true;
             }
         }
-
-        return false;
     }
 
     /**
@@ -252,8 +223,6 @@ class Route
      * @param $item_category_id,
      * @param array $permitted_resource_types
      * @param bool $manage
-     *
-     * @return bool
      */
     static public function itemCategory(
         $resource_type_id,
@@ -286,12 +255,8 @@ class Route
                 ) === false
             ) {
                 UtilityResponse::notFoundOrNotAccessible(trans('entities.item-category'));
-            } else {
-                return true;
             }
         }
-
-        return false;
     }
 
     /**
@@ -305,8 +270,6 @@ class Route
      * @param $item_subcategory_id
      * @param array $permitted_resource_types
      * @param bool $manage
-     *
-     * @return bool
      */
     static public function itemSubcategory(
         $resource_type_id,
@@ -342,11 +305,7 @@ class Route
                 ) === false
             ) {
                 UtilityResponse::notFoundOrNotAccessible(trans('entities.item-subcategory'));
-            } else {
-                return true;
             }
         }
-
-        return false;
     }
 }

--- a/app/Validators/Request/Routes/Category.php
+++ b/app/Validators/Request/Routes/Category.php
@@ -18,12 +18,14 @@ class Category
      * Validate that the user is able to view the requested resource type based
      * on their permitted resource types, needs to be in their group or public
      *
-     * @param string|int $category_id
+     * @param int $resource_type_id
+     * @param int $category_id
      * @param array $permitted_resource_types
      *
      * @return boolean
      */
     static public function existsToUserForViewing(
+        $resource_type_id,
         $category_id,
         array $permitted_resource_types
     ): bool
@@ -31,6 +33,7 @@ class Category
         if (
             $category_id === 'nill' ||
             (new CategoryModel())->existsToUser(
+                $resource_type_id,
                 $category_id,
                 $permitted_resource_types
             ) === false
@@ -45,12 +48,14 @@ class Category
      * Validate that the user is able to manage the requested resource type
      * based on their permitted resource types, needs to be in their group
      *
-     * @param string|int $category_id
+     * @param int $resource_type_id
+     * @param int $category_id
      * @param array $permitted_resource_types
      *
      * @return boolean
      */
     static public function existsToUserForManagement(
+        $resource_type_id,
         $category_id,
         array $permitted_resource_types
     ): bool
@@ -58,6 +63,7 @@ class Category
         if (
             $category_id === 'nill' ||
             (new CategoryModel())->existsToUser(
+                $resource_type_id,
                 $category_id,
                 $permitted_resource_types,
                 true

--- a/app/Validators/Request/Routes/SubCategory.php
+++ b/app/Validators/Request/Routes/SubCategory.php
@@ -18,22 +18,26 @@ class SubCategory
      * Validate that the user is able to view the requested subcategory based
      * on their permitted resource types, needs to be in their group or public
      *
-     * @param string|int $category_id
-     * @param string|int $subcategory_id
+     * @param integer $resource_type_id
+     * @param integer $category_id
+     * @param integer $subcategory_id
      * @param array $permitted_resource_types
      *
      * @return boolean
      */
     static public function existsToUserForViewing(
-        $category_id,
-        $subcategory_id,
+        int $resource_type_id,
+        int $category_id,
+        int $subcategory_id,
         array $permitted_resource_types
     ): bool
     {
         if (
+            $resource_type_id === 'nill' ||
             $category_id === 'nill' ||
             $subcategory_id === 'nill' ||
             (new SubCategoryModel())->existsToUser(
+                $resource_type_id,
                 $category_id,
                 $subcategory_id,
                 $permitted_resource_types
@@ -49,22 +53,26 @@ class SubCategory
      * Validate that the user is able to manage the requested subcategor
      * based on their permitted resource types, needs to be in their group
      *
-     * @param string|int $category_id
-     * @param string|int $subcategory_id
+     * @param integer $resource_type_id
+     * @param integer $category_id
+     * @param integer $subcategory_id
      * @param array $permitted_resource_types
      *
      * @return boolean
      */
     static public function existsToUserForManagement(
-        $category_id,
-        $subcategory_id,
+        int $resource_type_id,
+        int $category_id,
+        int $subcategory_id,
         array $permitted_resource_types
     ): bool
     {
         if (
+            $resource_type_id === 'nill' ||
             $category_id === 'nill' ||
             $subcategory_id === 'nill' ||
             (new SubCategoryModel())->existsToUser(
+                $resource_type_id,
                 $category_id,
                 $subcategory_id,
                 $permitted_resource_types,

--- a/config/api/category/fields.php
+++ b/config/api/category/fields.php
@@ -23,15 +23,5 @@ return [
             'max-length' => 255
         ],
         'required' => true
-    ],
-    'resource_type_id' => [
-        'field' => 'resource_type_id',
-        'title' => 'category/fields.title-resource_type_id',
-        'description' => 'category/fields.description-resource_type_id',
-        'type' => 'string',
-        'validation' => [
-            'length' => 10
-        ],
-        'required' => true
     ]
 ];

--- a/config/api/category/validation.php
+++ b/config/api/category/validation.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 return [
     'POST' => [
         'fields' => [
-            'description' => 'required|string',
-            'resource_type_id' => 'required|exists:resource_type,id'
+            'description' => 'required|string'
         ],
         'messages' => [
             'name.unique' => 'category/validation.name-unique'

--- a/config/api/item-subcategory/validation.php
+++ b/config/api/item-subcategory/validation.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 return [
     'POST' => [
         'fields' => [
-            'subcategory_id' => 'required|exists:subcategory,id'
+            'subcategory_id' => 'required|exists:sub_category,id'
         ],
         'messages' => [
             'subcategory_id.required' => 'item-subcategory/validation.subcategory_id-required',

--- a/config/api/version.php
+++ b/config/api/version.php
@@ -1,9 +1,9 @@
 <?php
 
 return [
-    'version'=> '2.00.1',
+    'version'=> '2.01.0',
     'prefix' => 'v2',
-    'release_date' => '2019-09-17',
+    'release_date' => '2019-09-xx',
     'changelog' => [
         'api' => '/v2/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/resources/lang/en/category/fields.php
+++ b/resources/lang/en/category/fields.php
@@ -7,8 +7,5 @@ return [
     'description-name' => 'Enter a name for the category',
 
     'title-description' => 'Category description',
-    'description-description' => 'Enter a description for the category',
-
-    'title-resource_type_id' => 'Resource type',
-    'description-resource_type_id' => 'The resource type that this category is a child of',
+    'description-description' => 'Enter a description for the category'
 ];

--- a/routes/api/private-routes.php
+++ b/routes/api/private-routes.php
@@ -18,11 +18,6 @@ Route::group(
         );
 
         Route::post(
-            'categories',
-            'CategoryController@create'
-        );
-
-        Route::post(
             'categories/{category_id}/subcategories',
             'SubcategoryController@create'
         );
@@ -30,6 +25,11 @@ Route::group(
         Route::post(
             'resource-types',
             'ResourceTypeController@create'
+        );
+
+        Route::post(
+            'resource-types/{resource_type_id}/categories',
+            'CategoryController@create'
         );
 
         Route::post(
@@ -58,11 +58,6 @@ Route::group(
         );
 
         Route::delete(
-            'categories/{category_id}',
-            'CategoryController@delete'
-        );
-
-        Route::delete(
             'categories/{category_id}/sub_categories/{subcategory_id}',
             'SubcategoryController@delete'
         );
@@ -70,6 +65,11 @@ Route::group(
         Route::delete(
             'resource-types/{resource_type_id}',
             'ResourceTypeController@delete'
+        );
+
+        Route::delete(
+            'resource-types/{resource_type_id}/categories/{category_id}',
+            'CategoryController@delete'
         );
 
         Route::delete(
@@ -93,11 +93,6 @@ Route::group(
         );
 
         Route::patch(
-            'categories/{category_id}',
-            'CategoryController@update'
-        );
-
-        Route::patch(
             'categories/{category_id}/subcategories/{subcategory_id}',
             'SubcategoryController@update'
         );
@@ -105,6 +100,11 @@ Route::group(
         Route::patch(
             'resource-types/{resource_type_id}',
             'ResourceTypeController@update'
+        );
+
+        Route::patch(
+            'resource-types/{resource_type_id}/categories/{category_id}',
+            'CategoryController@update'
         );
 
         Route::patch(

--- a/routes/api/private-routes.php
+++ b/routes/api/private-routes.php
@@ -18,11 +18,6 @@ Route::group(
         );
 
         Route::post(
-            'categories/{category_id}/subcategories',
-            'SubcategoryController@create'
-        );
-
-        Route::post(
             'resource-types',
             'ResourceTypeController@create'
         );
@@ -30,6 +25,11 @@ Route::group(
         Route::post(
             'resource-types/{resource_type_id}/categories',
             'CategoryController@create'
+        );
+
+        Route::post(
+            'resource-types/{resource_type_id}/categories/{category_id}/subcategories',
+            'SubcategoryController@create'
         );
 
         Route::post(
@@ -58,11 +58,6 @@ Route::group(
         );
 
         Route::delete(
-            'categories/{category_id}/sub_categories/{subcategory_id}',
-            'SubcategoryController@delete'
-        );
-
-        Route::delete(
             'resource-types/{resource_type_id}',
             'ResourceTypeController@delete'
         );
@@ -70,6 +65,11 @@ Route::group(
         Route::delete(
             'resource-types/{resource_type_id}/categories/{category_id}',
             'CategoryController@delete'
+        );
+
+        Route::delete(
+            'resource-types/{resource_type_id}/categories/{category_id}/subcategories/{subcategory_id}',
+            'SubcategoryController@delete'
         );
 
         Route::delete(
@@ -93,11 +93,6 @@ Route::group(
         );
 
         Route::patch(
-            'categories/{category_id}/subcategories/{subcategory_id}',
-            'SubcategoryController@update'
-        );
-
-        Route::patch(
             'resource-types/{resource_type_id}',
             'ResourceTypeController@update'
         );
@@ -105,6 +100,11 @@ Route::group(
         Route::patch(
             'resource-types/{resource_type_id}/categories/{category_id}',
             'CategoryController@update'
+        );
+
+        Route::patch(
+            'resource-types/{resource_type_id}/categories/{category_id}/subcategories/{subcategory_id}',
+            'SubcategoryController@update'
         );
 
         Route::patch(

--- a/routes/api/public-routes.php
+++ b/routes/api/public-routes.php
@@ -35,16 +35,6 @@ Route::group(
         );
 
         Route::get(
-            'categories',
-            'CategoryController@index'
-        );
-
-        Route::options(
-            'categories',
-            'CategoryController@optionsIndex'
-        );
-
-        Route::get(
             'resource-types',
             'ResourceTypeController@index'
         );
@@ -55,36 +45,6 @@ Route::group(
         );
 
         Route::get(
-            'categories/{category_id}',
-            'CategoryController@show'
-        );
-
-        Route::options(
-            'categories/{category_id}',
-            'CategoryController@optionsShow'
-        );
-
-        Route::get(
-            'categories/{category_id}/subcategories',
-            'SubcategoryController@index'
-        );
-
-        Route::options(
-            'categories/{category_id}/subcategories',
-            'SubcategoryController@optionsIndex'
-        );
-
-        Route::get(
-            'categories/{category_id}/subcategories/{subcategory_id}',
-            'SubcategoryController@show'
-        );
-
-        Route::options(
-            'categories/{category_id}/subcategories/{subcategory_id}',
-            'SubcategoryController@optionsShow'
-        );
-
-        Route::get(
             'resource-types/{resource_type_id}',
             'ResourceTypeController@show'
         );
@@ -92,6 +52,46 @@ Route::group(
         Route::options(
             'resource-types/{resource_type_id}',
             'ResourceTypeController@optionsShow'
+        );
+
+        Route::get(
+            'resource-types/{resource_type_id}/categories',
+            'CategoryController@index'
+        );
+
+        Route::options(
+            'resource-types/{resource_type_id}/categories',
+            'CategoryController@optionsIndex'
+        );
+
+        Route::get(
+            'resource-types/{resource_type_id}/categories/{category_id}',
+            'CategoryController@show'
+        );
+
+        Route::options(
+            'resource-types/{resource_type_id}/categories/{category_id}',
+            'CategoryController@optionsShow'
+        );
+
+        Route::get(
+            'resource-types/{resource_type_id}/categories/{category_id}/subcategories',
+            'SubcategoryController@index'
+        );
+
+        Route::options(
+            'resource-types/{resource_type_id}/categories/{category_id}/subcategories',
+            'SubcategoryController@optionsIndex'
+        );
+
+        Route::get(
+            'resource-types/{resource_type_id}/categories/{category_id}/subcategories/{subcategory_id}',
+            'SubcategoryController@show'
+        );
+
+        Route::options(
+            'resource-types/{resource_type_id}/categories/{category_id}/subcategories/{subcategory_id}',
+            'SubcategoryController@optionsShow'
         );
 
         Route::get(

--- a/routes/api/public-summary-routes.php
+++ b/routes/api/public-summary-routes.php
@@ -14,16 +14,6 @@ Route::group(
     ],
     function () {
         Route::get(
-            'summary/categories',
-            'SummaryCategoryController@index'
-        );
-
-        Route::options(
-            'summary/categories',
-            'SummaryCategoryController@optionsIndex'
-        );
-
-        Route::get(
             'summary/categories/{category_id}/subcategories',
             'SummarySubcategoryController@index'
         );
@@ -41,6 +31,16 @@ Route::group(
         Route::options(
             'summary/resource-types',
             'SummaryResourceTypeController@optionsIndex'
+        );
+
+        Route::get(
+            'summary/resource-types/{resource_type_id}/categories',
+            'SummaryCategoryController@index'
+        );
+
+        Route::options(
+            'summary/resource-types/{resource_type_id}/categories',
+            'SummaryCategoryController@optionsIndex'
         );
 
         Route::get(

--- a/routes/api/public-summary-routes.php
+++ b/routes/api/public-summary-routes.php
@@ -13,15 +13,6 @@ Route::group(
         ]
     ],
     function () {
-        Route::get(
-            'summary/categories/{category_id}/subcategories',
-            'SummarySubcategoryController@index'
-        );
-
-        Route::options(
-            'summary/categories/{category_id}/subcategories',
-            'SummarySubcategoryController@optionsIndex'
-        );
 
         Route::get(
             'summary/resource-types',
@@ -41,6 +32,16 @@ Route::group(
         Route::options(
             'summary/resource-types/{resource_type_id}/categories',
             'SummaryCategoryController@optionsIndex'
+        );
+
+        Route::get(
+            'summary/resource-types/{resource_type_id}/categories/{category_id}/subcategories',
+            'SummarySubcategoryController@index'
+        );
+
+        Route::options(
+            'summary/resource-types/{resource_type_id}/categories/{category_id}/subcategories',
+            'SummarySubcategoryController@optionsIndex'
         );
 
         Route::get(


### PR DESCRIPTION
### Added 

- We have added a `Header` utility class that can be used to generate the expected headers for collection and item requests. 
- We have added a `RoutePermission` class which returns the view and manage permission for each route. 

### Changed 
- We have updated all routes to use the new `Header`, utility class. 
- We have updated all the `Options` requests to use the new `RoutePermissions` class. 

### Fixed 
- We have fixed the item subcategory route; the field name for POST was incorrect, still had the underscore. 
- We have corrected the query for the request/access-log, rather than return the entire collection and count the results, probably easier to let MySQL count the results, doh! 
- Unable to delete a subcategory because an instance was not being returned from the model. 

### Removed 
- We have removed the category routes; they are now available below resource types. 
- We have removed the category summary routes; they are now available below the resource types summary. 
- We have removed the subcategory routes; they are now available below resource types. 
- We have removed the subcategory summary routes; they are now available below the resource types summary.