### PR TITLE
v2.05.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The complete changelog for the Costs to Expect REST API, follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v2.05.0] - 2019-12-28
+### Added 
+- We have added an X-Last-Updated header to the item summaries. It is only relevant and applied to the summaries which return a single item. Summaries that return a collection do not include the header.
+
+### Changed
+- We have updated the X-Total-Count header for summaries which return a single item; the header is now the total number of 'items' in the result.
+- We have tweaked the server config and no longer return some default server headers.
+
 ## [v2.04.3] - 2019-12-17
 ### Changed
 - We have added links to the Costs to Expect app.

--- a/app/Http/Controllers/Summary/ItemController.php
+++ b/app/Http/Controllers/Summary/ItemController.php
@@ -247,6 +247,7 @@ class ItemController extends Controller
         $headers = new Header();
         $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', 1);
+        $headers->add('X-Last-Updated', $summary[0]['last_updated']);
 
         $parameters_header = Parameters::xHeader();
         if ($parameters_header !== null) {
@@ -339,6 +340,7 @@ class ItemController extends Controller
         $headers = new Header();
         $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', count($summary));
+        $headers->add('X-Last-Updated', $summary[0]['last_updated']);
 
         $parameters_header = Parameters::xHeader();
         if ($parameters_header !== null) {
@@ -435,6 +437,7 @@ class ItemController extends Controller
         $headers = new Header();
         $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', count($summary));
+        $headers->add('X-Last-Updated', $summary[0]['last_updated']);
 
         $parameters_header = Parameters::xHeader();
         if ($parameters_header !== null) {
@@ -537,6 +540,7 @@ class ItemController extends Controller
         $headers = new Header();
         $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', count($summary));
+        $headers->add('X-Last-Updated', $summary[0]['last_updated']);
 
         $parameters_header = Parameters::xHeader();
         if ($parameters_header !== null) {
@@ -583,6 +587,7 @@ class ItemController extends Controller
         $headers = new Header();
         $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', count($summary));
+        $headers->add('X-Last-Updated', $summary[0]['last_updated']);
 
         $parameters_header = Parameters::xHeader();
         if ($parameters_header !== null) {
@@ -679,6 +684,7 @@ class ItemController extends Controller
         $headers = new Header();
         $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', count($summary));
+        $headers->add('X-Last-Updated', $summary[0]['last_updated']);
 
         $parameters_header = Parameters::xHeader();
         if ($parameters_header !== null) {

--- a/app/Http/Controllers/Summary/ItemController.php
+++ b/app/Http/Controllers/Summary/ItemController.php
@@ -245,7 +245,7 @@ class ItemController extends Controller
         }
 
         $headers = new Header();
-        $headers->add('X-Total-Count', 1);
+        $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', 1);
 
         $parameters_header = Parameters::xHeader();
@@ -337,7 +337,7 @@ class ItemController extends Controller
         }
 
         $headers = new Header();
-        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', count($summary));
 
         $parameters_header = Parameters::xHeader();
@@ -433,7 +433,7 @@ class ItemController extends Controller
         }
 
         $headers = new Header();
-        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', count($summary));
 
         $parameters_header = Parameters::xHeader();
@@ -535,7 +535,7 @@ class ItemController extends Controller
         }
 
         $headers = new Header();
-        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', count($summary));
 
         $parameters_header = Parameters::xHeader();
@@ -581,7 +581,7 @@ class ItemController extends Controller
         }
 
         $headers = new Header();
-        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', count($summary));
 
         $parameters_header = Parameters::xHeader();
@@ -677,7 +677,7 @@ class ItemController extends Controller
         }
 
         $headers = new Header();
-        $headers->add('X-Total-Count', count($summary));
+        $headers->add('X-Total-Count', $summary[0]['total_count']);
         $headers->add('X-Count', count($summary));
 
         $parameters_header = Parameters::xHeader();

--- a/app/Models/Summary/ItemType/AllocatedExpense.php
+++ b/app/Models/Summary/ItemType/AllocatedExpense.php
@@ -82,7 +82,9 @@ class AllocatedExpense extends Model
                 category.name AS name, 
                 category.description AS description, 
                 SUM({$this->sub_table}.actualised_total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count")->
+                COUNT({$this->sub_table}.item_id) AS total_count, 
+                MAX({$this->sub_table}.effective_date) AS last_updated
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -129,7 +131,8 @@ class AllocatedExpense extends Model
         $collection = $this->
             selectRaw("
                 SUM({$this->sub_table}.actualised_total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count
+                COUNT({$this->sub_table}.item_id) AS total_count,
+                MAX({$this->sub_table}.effective_date) AS last_updated
             ")->
             join($this->sub_table, 'item.id', 'item_type_allocated_expense.item_id')->
             join("resource", "resource.id", "item.resource_id")->
@@ -225,7 +228,8 @@ class AllocatedExpense extends Model
             selectRaw("
                 MONTH({$this->sub_table}.effective_date) as month, 
                 SUM({$this->sub_table}.actualised_total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count
+                COUNT({$this->sub_table}.item_id) AS total_count,
+                MAX({$this->sub_table}.effective_date) AS last_updated
             ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
@@ -311,7 +315,8 @@ class AllocatedExpense extends Model
                 sub_category.name AS name, 
                 sub_category.description AS description,
                 SUM({$this->sub_table}.actualised_total) AS total,
-                COUNT({$this->sub_table}.item_id) AS total_count
+                COUNT({$this->sub_table}.item_id) AS total_count, 
+                MAX({$this->sub_table}.effective_date) AS last_updated
             ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
@@ -350,8 +355,9 @@ class AllocatedExpense extends Model
     {
         $collection = $this->selectRaw("
                 SUM({$this->sub_table}.actualised_total) AS total,
-                COUNT({$this->sub_table}.item_id) AS total_count"
-            )->
+                COUNT({$this->sub_table}.item_id) AS total_count, 
+                MAX({$this->sub_table}.effective_date) AS last_updated
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join('resource', 'item.resource_id', 'resource.id')->
             where('resource_id', '=', $resource_id)->
@@ -418,7 +424,8 @@ class AllocatedExpense extends Model
             selectRaw("
                 YEAR({$this->sub_table}.effective_date) as year, 
                 SUM({$this->sub_table}.actualised_total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count
+                COUNT({$this->sub_table}.item_id) AS total_count, 
+                MAX({$this->sub_table}.effective_date) AS last_updated
             ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->

--- a/app/Models/Summary/ItemType/AllocatedExpense.php
+++ b/app/Models/Summary/ItemType/AllocatedExpense.php
@@ -40,7 +40,8 @@ class AllocatedExpense extends Model
                 category.id, 
                 category.name AS name, 
                 category.description AS description,
-                SUM({$this->sub_table}.actualised_total) AS total")->
+                SUM({$this->sub_table}.actualised_total) AS total
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -80,7 +81,8 @@ class AllocatedExpense extends Model
                 category.id, 
                 category.name AS name, 
                 category.description AS description, 
-                SUM({$this->sub_table}.actualised_total) AS total")->
+                SUM({$this->sub_table}.actualised_total) AS total, 
+                COUNT({$this->sub_table}.item_id) AS total_count")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -125,7 +127,10 @@ class AllocatedExpense extends Model
     ): array
     {
         $collection = $this->
-            selectRaw("SUM({$this->sub_table}.actualised_total) AS total")->
+            selectRaw("
+                SUM({$this->sub_table}.actualised_total) AS total, 
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")->
             join($this->sub_table, 'item.id', 'item_type_allocated_expense.item_id')->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -178,7 +183,10 @@ class AllocatedExpense extends Model
     ): array
     {
         $collection = $this->
-            selectRaw("MONTH({$this->sub_table}.effective_date) as month, SUM({$this->sub_table}.actualised_total) AS total")->
+            selectRaw("
+                MONTH({$this->sub_table}.effective_date) as month, 
+                SUM({$this->sub_table}.actualised_total) AS total
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -214,7 +222,11 @@ class AllocatedExpense extends Model
     ): array
     {
         $collection = $this->
-            selectRaw("MONTH({$this->sub_table}.effective_date) as month, SUM({$this->sub_table}.actualised_total) AS total")->
+            selectRaw("
+                MONTH({$this->sub_table}.effective_date) as month, 
+                SUM({$this->sub_table}.actualised_total) AS total, 
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -253,7 +265,8 @@ class AllocatedExpense extends Model
                 sub_category.id, 
                 sub_category.name AS name, 
                 sub_category.description AS description,
-                SUM({$this->sub_table}.actualised_total) AS total")->
+                SUM({$this->sub_table}.actualised_total) AS total
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -297,7 +310,9 @@ class AllocatedExpense extends Model
                 sub_category.id, 
                 sub_category.name AS name, 
                 sub_category.description AS description,
-                SUM({$this->sub_table}.actualised_total) AS total")->
+                SUM({$this->sub_table}.actualised_total) AS total,
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -333,7 +348,10 @@ class AllocatedExpense extends Model
         array $parameters = []
     ): array
     {
-        $collection = $this->selectRaw("sum({$this->sub_table}.actualised_total) AS total")->
+        $collection = $this->selectRaw("
+                SUM({$this->sub_table}.actualised_total) AS total,
+                COUNT({$this->sub_table}.item_id) AS total_count"
+            )->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join('resource', 'item.resource_id', 'resource.id')->
             where('resource_id', '=', $resource_id)->
@@ -361,7 +379,10 @@ class AllocatedExpense extends Model
     ): array
     {
         $collection = $this->
-            selectRaw("YEAR({$this->sub_table}.effective_date) as year, SUM({$this->sub_table}.actualised_total) AS total")->
+            selectRaw("
+                YEAR({$this->sub_table}.effective_date) as year, 
+                SUM({$this->sub_table}.actualised_total) AS total
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -394,7 +415,11 @@ class AllocatedExpense extends Model
     ): array
     {
         $collection = $this->
-            selectRaw("YEAR({$this->sub_table}.effective_date) as year, SUM({$this->sub_table}.actualised_total) AS total")->
+            selectRaw("
+                YEAR({$this->sub_table}.effective_date) as year, 
+                SUM({$this->sub_table}.actualised_total) AS total, 
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->

--- a/app/Models/Summary/ItemType/SimpleExpense.php
+++ b/app/Models/Summary/ItemType/SimpleExpense.php
@@ -77,7 +77,9 @@ class SimpleExpense extends Model
                 category.id, 
                 category.name AS name, 
                 category.description AS description, 
-                SUM({$this->sub_table}.total) AS total")->
+                SUM({$this->sub_table}.total) AS total, 
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -120,7 +122,10 @@ class SimpleExpense extends Model
     ): array
     {
         $collection = $this->
-            selectRaw("SUM({$this->sub_table}.total) AS total")->
+            selectRaw("
+                SUM({$this->sub_table}.total) AS total, 
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -205,7 +210,11 @@ class SimpleExpense extends Model
     ): array
     {
         $collection = $this->
-            selectRaw("MONTH({$this->sub_table}.effective_date) as month, SUM({$this->sub_table}.total) AS total")->
+            selectRaw("
+                MONTH({$this->sub_table}.effective_date) as month, 
+                SUM({$this->sub_table}.total) AS total, 
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -284,7 +293,9 @@ class SimpleExpense extends Model
                 sub_category.id, 
                 sub_category.name AS name, 
                 sub_category.description AS description,
-                SUM({$this->sub_table}.total) AS total")->
+                SUM({$this->sub_table}.total) AS total, 
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -318,7 +329,10 @@ class SimpleExpense extends Model
         array $parameters = []
     ): array
     {
-        $collection = $this->selectRaw("sum({$this->sub_table}.total) AS total")->
+        $collection = $this->selectRaw("
+                SUM({$this->sub_table}.total) AS total, 
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join('resource', 'item.resource_id', 'resource.id')->
             where('resource_id', '=', $resource_id)->
@@ -344,7 +358,10 @@ class SimpleExpense extends Model
     ): array
     {
         $collection = $this->
-            selectRaw("YEAR({$this->sub_table}.effective_date) as year, SUM({$this->sub_table}.total) AS total")->
+            selectRaw("
+                YEAR({$this->sub_table}.effective_date) as year, 
+                SUM({$this->sub_table}.total) AS total
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->
@@ -375,7 +392,11 @@ class SimpleExpense extends Model
     ): array
     {
         $collection = $this->
-            selectRaw("YEAR({$this->sub_table}.effective_date) as year, SUM({$this->sub_table}.total) AS total")->
+            selectRaw("
+                YEAR({$this->sub_table}.effective_date) as year, 
+                SUM({$this->sub_table}.total) AS total, 
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
             join("resource_type", "resource_type.id", "resource.resource_type_id")->

--- a/app/Models/Summary/ItemType/SimpleExpense.php
+++ b/app/Models/Summary/ItemType/SimpleExpense.php
@@ -78,7 +78,8 @@ class SimpleExpense extends Model
                 category.name AS name, 
                 category.description AS description, 
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count
+                COUNT({$this->sub_table}.item_id) AS total_count, 
+                MAX({$this->sub_table}.effective_date) AS last_updated
             ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
@@ -124,7 +125,8 @@ class SimpleExpense extends Model
         $collection = $this->
             selectRaw("
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count
+                COUNT({$this->sub_table}.item_id) AS total_count, 
+                MAX({$this->sub_table}.effective_date) AS last_updated
             ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
@@ -213,7 +215,8 @@ class SimpleExpense extends Model
             selectRaw("
                 MONTH({$this->sub_table}.effective_date) as month, 
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count
+                COUNT({$this->sub_table}.item_id) AS total_count, 
+                MAX({$this->sub_table}.effective_date) AS last_updated
             ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
@@ -294,7 +297,8 @@ class SimpleExpense extends Model
                 sub_category.name AS name, 
                 sub_category.description AS description,
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count
+                COUNT({$this->sub_table}.item_id) AS total_count, 
+                MAX({$this->sub_table}.effective_date) AS last_updated
             ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->
@@ -331,7 +335,8 @@ class SimpleExpense extends Model
     {
         $collection = $this->selectRaw("
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count
+                COUNT({$this->sub_table}.item_id) AS total_count, 
+                MAX({$this->sub_table}.effective_date) AS last_updated
             ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join('resource', 'item.resource_id', 'resource.id')->
@@ -395,7 +400,8 @@ class SimpleExpense extends Model
             selectRaw("
                 YEAR({$this->sub_table}.effective_date) as year, 
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count
+                COUNT({$this->sub_table}.item_id) AS total_count, 
+                MAX({$this->sub_table}.effective_date) AS last_updated
             ")->
             join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
             join("resource", "resource.id", "item.resource_id")->

--- a/config/api/app/version.php
+++ b/config/api/app/version.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 return [
-    'version'=> '2.04.3',
+    'version'=> '2.05.0',
     'prefix' => 'v2',
-    'release_date' => '2019-12-17',
+    'release_date' => '2019-12-28',
     'changelog' => [
         'api' => '/v2/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/public/web.config
+++ b/public/web.config
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <system.webServer>
+        <security>
+            <requestFiltering removeServerHeader="true"/>
+        </security>
         <rewrite>
             <rules>
                 <rule name="Main Rule" stopProcessing="true">
@@ -13,9 +16,14 @@
                 </rule>
             </rules>
         </rewrite>
-	<handlers>
-	    <remove name="PHP73_via_FastCGI" />
-	    <add name="PHP73_via_FastCGI" path="*.php" verb="GET,PUT,POST,PATCH,DELETE,HEAD,OPTIONS" modules="FastCgiModule" scriptProcessor="D:\Program Files (x86)\PHP\v7.3\php-cgi.exe" resourceType="Either" requireAccess="Script" />
-	</handlers>
+	      <handlers>
+	          <remove name="PHP73_via_FastCGI" />
+	          <add name="PHP73_via_FastCGI" path="*.php" verb="GET,PUT,POST,PATCH,DELETE,HEAD,OPTIONS" modules="FastCgiModule" scriptProcessor="D:\Program Files (x86)\PHP\v7.3\php-cgi.exe" resourceType="Either" requireAccess="Script" />
+	      </handlers>
+        <httpProtocol>
+            <customHeaders>
+                <remove name="X-Powered-By" />
+            </customHeaders>
+        </httpProtocol>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
### Added 
- We have added an X-Last-Updated header to the item summaries. It is only relevant and applied to the summaries which return a single item. Summaries that return a collection do not include the header.

### Changed
- We have updated the X-Total-Count header for summaries which return a single item; the header is now the total number of 'items' in the result.
- We have tweaked the server config and no longer return some default server headers. 
