### PR TITLE
v2.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 The complete changelog for the Costs to Expect REST API, our changelog follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v2.10.2] - 2020-04-30
+### Changed
+- We have updated all item endpoints to return `updated`; this is the date and time an item was updated, not its category assignments.
+- We have updated item collection and show endpoints; we are going to allow the possibility of items not having categories and subcategories. When you add the `include-categories` and `include-subcategories` parameters to a request, we will not exclude items without category assignments.
+- We have updated the API to the latest release of Laravel 7.
+- We have updated the front end dependencies for the welcome page.
+- We have updated the `item-types` route to show additional information on each tracking method.
+- We have updated all decimal fields to 13,2 rather than 10,2.
+- We have updated all description fields; we have switched all the description fields from varchar(255) to text.
+
+### Fixed
+- We have corrected a bad link on the landing page.
+- We have corrected a typo on the landing page.
+- We have switched the table we look at to return created at for an item; we should be using the sub table, not the base item table.
+- We have corrected the `/resource-types/` OPTIONS request; `public` is not a required field.
+
 ## [v2.10.1] - 2020-04-03
 ### Changed
 - We have tweaked our Docker setup to allow a local API and App/Website; the ports have been changed and a network has been created.

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -34,10 +34,10 @@ class Handler extends ExceptionHandler
     /**
      * Report or log an exception.
      *
-     * @param  \Exception  $exception
+     * @param  \Throwable  $exception
      * @return void
      */
-    public function report(Exception $exception)
+    public function report(\Throwable $exception)
     {
         parent::report($exception);
     }
@@ -46,10 +46,10 @@ class Handler extends ExceptionHandler
      * Render an exception into an HTTP response.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Exception  $exception
+     * @param  \Throwable  $exception
      * @return \Illuminate\Http\JsonResponse
      */
-    public function render($request, Exception $exception)
+    public function render($request, \Throwable $exception)
     {
         if ($exception instanceof AuthenticationException) {
             Response::authenticationRequired();

--- a/app/Models/Item/AllocatedExpense.php
+++ b/app/Models/Item/AllocatedExpense.php
@@ -56,14 +56,15 @@ class AllocatedExpense extends Model implements IModel
     ): ?array
     {
         $fields = [
-            'item.id AS item_id',
-            'item_type_allocated_expense.name AS item_name',
-            'item_type_allocated_expense.description AS item_description',
-            'item_type_allocated_expense.effective_date AS item_effective_date',
-            'item_type_allocated_expense.total AS item_total',
-            'item_type_allocated_expense.percentage AS item_percentage',
-            'item_type_allocated_expense.actualised_total AS item_actualised_total',
-            'item.created_at AS item_created_at'
+            "item.id AS item_id",
+            "{$this->table}.name AS item_name",
+            "{$this->table}.description AS item_description",
+            "{$this->table}.effective_date AS item_effective_date",
+            "{$this->table}.total AS item_total",
+            "{$this->table}.percentage AS item_percentage",
+            "{$this->table}.actualised_total AS item_actualised_total",
+            "{$this->table}.created_at AS item_created_at",
+            "{$this->table}.updated_at AS item_updated_at"
         ];
 
         $result = $this->from('item')->
@@ -285,13 +286,14 @@ class AllocatedExpense extends Model implements IModel
     {
         $select_fields = [
             'item.id AS item_id',
-            'item_type_allocated_expense.name AS item_name',
-            'item_type_allocated_expense.description AS item_description',
-            'item_type_allocated_expense.effective_date AS item_effective_date',
-            'item_type_allocated_expense.total AS item_total',
-            'item_type_allocated_expense.percentage AS item_percentage',
-            'item_type_allocated_expense.actualised_total AS item_actualised_total',
-            'item.created_at AS item_created_at'
+            "{$this->table}.name AS item_name",
+            "{$this->table}.description AS item_description",
+            "{$this->table}.effective_date AS item_effective_date",
+            "{$this->table}.total AS item_total",
+            "{$this->table}.percentage AS item_percentage",
+            "{$this->table}.actualised_total AS item_actualised_total",
+            "{$this->table}.created_at AS item_created_at",
+            "{$this->table}.updated_at AS item_updated_at"
         ];
 
         $category_join = false;

--- a/app/Models/Item/AllocatedExpense.php
+++ b/app/Models/Item/AllocatedExpense.php
@@ -174,7 +174,8 @@ class AllocatedExpense extends Model implements IModel
             'item_total' => $item_type->total,
             'item_percentage' => $item_type->percentage,
             'item_actualised_total' => $item_type->actualised_total,
-            'item_created_at' => $item->created_at->toDateTimeString()
+            'item_created_at' => $item->created_at->toDateTimeString(),
+            'item_updated_at' => $item->updated_at->toDateTimeString()
         ];
     }
 

--- a/app/Models/Item/AllocatedExpense.php
+++ b/app/Models/Item/AllocatedExpense.php
@@ -78,8 +78,8 @@ class AllocatedExpense extends Model implements IModel
             array_key_exists('include-categories', $parameters) === true &&
             General::booleanValue($parameters['include-categories']) === true
         ) {
-            $result->join('item_category', 'item.id', 'item_category.item_id')->
-                join('category', 'item_category.category_id', 'category.id');
+            $result->leftJoin('item_category', 'item.id', 'item_category.item_id')->
+                leftJoin('category', 'item_category.category_id', 'category.id');
 
             $fields[] = 'item_category.id AS item_category_id';
             $fields[] = 'category.id AS category_id';
@@ -90,8 +90,8 @@ class AllocatedExpense extends Model implements IModel
                 array_key_exists('include-subcategories', $parameters) === true &&
                 General::booleanValue($parameters['include-subcategories']) === true
             ) {
-                $result->join('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
-                join('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
+                $result->leftJoin('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
+                leftJoin('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
 
                 $fields[] = 'item_sub_category.id AS item_subcategory_id';
                 $fields[] = 'sub_category.id AS subcategory_id';
@@ -104,9 +104,9 @@ class AllocatedExpense extends Model implements IModel
 
         if ($item !== null) {
            return $item->toArray();
-       } else {
-           return null;
        }
+
+        return null;
     }
 
     /**
@@ -125,10 +125,10 @@ class AllocatedExpense extends Model implements IModel
             first();
 
         if ($result === null) {
-            return intval(date('Y'));
-        } else {
-            return intval($result->year_limit);
+            return (int) (date('Y'));
         }
+
+        return (int) ($result->year_limit);
 
     }
 
@@ -148,10 +148,10 @@ class AllocatedExpense extends Model implements IModel
             first();
 
         if ($result === null) {
-            return intval(date('Y'));
-        } else {
-            return intval($result->year_limit);
+            return (int) (date('Y'));
         }
+
+        return (int) ($result->year_limit);
     }
 
     /**
@@ -307,8 +307,8 @@ class AllocatedExpense extends Model implements IModel
             array_key_exists('include-categories', $parameters) === true &&
             General::booleanValue($parameters['include-categories']) === true
         ) {
-            $collection->join('item_category', 'item.id', 'item_category.item_id')->
-                join('category', 'item_category.category_id', 'category.id');
+            $collection->leftJoin('item_category', 'item.id', 'item_category.item_id')->
+            leftJoin('category', 'item_category.category_id', 'category.id');
 
             $category_join = true;
 
@@ -326,8 +326,8 @@ class AllocatedExpense extends Model implements IModel
                 array_key_exists('include-subcategories', $parameters) === true &&
                 General::booleanValue($parameters['include-subcategories']) === true
             ) {
-                $collection->join('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
-                    join('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
+                $collection->leftJoin('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
+                leftJoin('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
 
                 $subcategory_join = true;
 

--- a/app/Models/Item/SimpleExpense.php
+++ b/app/Models/Item/SimpleExpense.php
@@ -86,8 +86,8 @@ class SimpleExpense extends Model implements IModel
             array_key_exists('include-categories', $parameters) === true &&
             General::booleanValue($parameters['include-categories']) === true
         ) {
-            $result->join('item_category', 'item.id', 'item_category.item_id')->
-            join('category', 'item_category.category_id', 'category.id');
+            $result->leftJoin('item_category', 'item.id', 'item_category.item_id')->
+                leftJoin('category', 'item_category.category_id', 'category.id');
 
             $fields[] = 'item_category.id AS item_category_id';
             $fields[] = 'category.id AS category_id';
@@ -98,8 +98,8 @@ class SimpleExpense extends Model implements IModel
                 array_key_exists('include-subcategories', $parameters) === true &&
                 General::booleanValue($parameters['include-subcategories']) === true
             ) {
-                $result->join('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
-                join('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
+                $result->leftJoin('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
+                    leftJoin('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
 
                 $fields[] = 'item_sub_category.id AS item_subcategory_id';
                 $fields[] = 'sub_category.id AS subcategory_id';
@@ -221,8 +221,8 @@ class SimpleExpense extends Model implements IModel
             array_key_exists('include-categories', $parameters) === true &&
             General::booleanValue($parameters['include-categories']) === true
         ) {
-            $collection->join('item_category', 'item.id', 'item_category.item_id')->
-                join('category', 'item_category.category_id', 'category.id');
+            $collection->leftJoin('item_category', 'item.id', 'item_category.item_id')->
+                leftJoin('category', 'item_category.category_id', 'category.id');
 
             $category_join = true;
 
@@ -240,8 +240,8 @@ class SimpleExpense extends Model implements IModel
                 array_key_exists('include-subcategories', $parameters) === true &&
                 General::booleanValue($parameters['include-subcategories']) === true
             ) {
-                $collection->join('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
-                    join('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
+                $collection->leftJoin('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
+                    leftJoin('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
 
                 $subcategory_join = true;
 

--- a/app/Models/Item/SimpleExpense.php
+++ b/app/Models/Item/SimpleExpense.php
@@ -47,7 +47,8 @@ class SimpleExpense extends Model implements IModel
             'item_name' => $item_type->name,
             'item_description' => $item_type->description,
             'item_total' => $item_type->total,
-            'item_created_at' => $item->created_at->toDateTimeString()
+            'item_created_at' => $item->created_at->toDateTimeString(),
+            'item_updated_at' => $item->updated_at->toDateTimeString()
         ];
     }
 

--- a/app/Models/Item/SimpleExpense.php
+++ b/app/Models/Item/SimpleExpense.php
@@ -71,7 +71,8 @@ class SimpleExpense extends Model implements IModel
             "{$this->table}.name AS item_name",
             "{$this->table}.description AS item_description",
             "{$this->table}.total AS item_total",
-            'item.created_at AS item_created_at'
+            "{$this->table}.created_at AS item_created_at",
+            "{$this->table}.updated_at AS item_updated_at"
         ];
 
         $result = $this->from('item')->
@@ -202,10 +203,11 @@ class SimpleExpense extends Model implements IModel
     {
         $select_fields = [
             'item.id AS item_id',
-            'item_type_simple_expense.name AS item_name',
-            'item_type_simple_expense.description AS item_description',
-            'item_type_simple_expense.total AS item_total',
-            'item.created_at AS item_created_at'
+            "{$this->table}.name AS item_name",
+            "{$this->table}.description AS item_description",
+            "{$this->table}.total AS item_total",
+            "{$this->table}.created_at AS item_created_at",
+            "{$this->table}.updated_at AS item_updated_at"
         ];
 
         $category_join = false;

--- a/app/Models/Item/SimpleItem.php
+++ b/app/Models/Item/SimpleItem.php
@@ -47,7 +47,8 @@ class SimpleItem extends Model implements IModel
             'item_name' => $item_type->name,
             'item_description' => $item_type->description,
             'item_quantity' => $item_type->total,
-            'item_created_at' => $item->created_at->toDateTimeString()
+            'item_created_at' => $item->created_at->toDateTimeString(),
+            'item_updated_at' => $item->updated_at->toDateTimeString()
         ];
     }
 

--- a/app/Models/Item/SimpleItem.php
+++ b/app/Models/Item/SimpleItem.php
@@ -71,7 +71,8 @@ class SimpleItem extends Model implements IModel
             "{$this->table}.name AS item_name",
             "{$this->table}.description AS item_description",
             "{$this->table}.quantity AS item_quantity",
-            'item.created_at AS item_created_at'
+            "{$this->table}.created_at AS item_created_at",
+            "{$this->table}.updated_at AS item_updated_at"
         ];
 
         $result = $this->from('item')->
@@ -161,7 +162,8 @@ class SimpleItem extends Model implements IModel
             "{$this->table}.name AS item_name",
             "{$this->table}.description AS item_description",
             "{$this->table}.quantity AS item_quantity",
-            'item.created_at AS item_created_at'
+            "{$this->table}.created_at AS item_created_at",
+            "{$this->table}.updated_at AS item_updated_at"
         ];
 
         $collection = $this->from('item')->

--- a/app/Models/ItemType.php
+++ b/app/Models/ItemType.php
@@ -57,7 +57,9 @@ class ItemType extends Model
         $collection = $this->select(
             'item_type.id AS item_type_id',
             'item_type.name AS item_type_name',
+            'item_type.friendly_name AS item_type_friendly_name',
             'item_type.description AS item_type_description',
+            'item_type.example AS item_type_example',
             'item_type.created_at AS item_type_created_at'
         );
 
@@ -97,7 +99,9 @@ class ItemType extends Model
         $result = $this->select(
             'item_type.id AS item_type_id',
             'item_type.name AS item_type_name',
+            'item_type.friendly_name AS item_type_friendly_name',
             'item_type.description AS item_type_description',
+            'item_type.example AS item_type_example',
             'item_type.created_at AS item_type_created_at'
         );
 

--- a/app/Models/ResourceType.php
+++ b/app/Models/ResourceType.php
@@ -20,7 +20,7 @@ class ResourceType extends Model
 {
     protected $table = 'resource_type';
 
-    protected $guarded = ['id', 'created_at', 'updated_at'];
+    protected $guarded = ['id'];
 
     /**
      * Return an array of the fields that can be PATCHed.

--- a/app/Models/ResourceTypeItem/AllocatedExpense.php
+++ b/app/Models/ResourceTypeItem/AllocatedExpense.php
@@ -149,8 +149,8 @@ class AllocatedExpense extends Model implements IModel
             array_key_exists('include-categories', $parameters_collection) === true &&
             General::booleanValue($parameters_collection['include-categories']) === true
         ) {
-            $collection->join('item_category', 'item.id', 'item_category.item_id')->
-                join('category', 'item_category.category_id', 'category.id');
+            $collection->leftJoin('item_category', 'item.id', 'item_category.item_id')->
+                leftJoin('category', 'item_category.category_id', 'category.id');
 
             $category_join = true;
 
@@ -168,8 +168,8 @@ class AllocatedExpense extends Model implements IModel
                 array_key_exists('include-subcategories', $parameters_collection) === true &&
                 General::booleanValue($parameters_collection['include-subcategories']) === true
             ) {
-                $collection->join('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
-                    join('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
+                $collection->leftJoin('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
+                    leftJoin('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
 
                 $subcategory_join = true;
 

--- a/app/Models/ResourceTypeItem/AllocatedExpense.php
+++ b/app/Models/ResourceTypeItem/AllocatedExpense.php
@@ -135,7 +135,7 @@ class AllocatedExpense extends Model implements IModel
             'item_type_allocated_expense.percentage AS item_percentage',
             'item_type_allocated_expense.actualised_total AS item_actualised_total',
             'item_type_allocated_expense.created_at AS item_created_at',
-            'item_type_allocated_expense.updated_at_at AS item_updated_at'
+            'item_type_allocated_expense.updated_at AS item_updated_at'
         ];
 
         $collection = $this->join('item_type_allocated_expense', 'item.id', 'item_type_allocated_expense.item_id')->

--- a/app/Models/ResourceTypeItem/AllocatedExpense.php
+++ b/app/Models/ResourceTypeItem/AllocatedExpense.php
@@ -134,7 +134,8 @@ class AllocatedExpense extends Model implements IModel
             'item_type_allocated_expense.total AS item_total',
             'item_type_allocated_expense.percentage AS item_percentage',
             'item_type_allocated_expense.actualised_total AS item_actualised_total',
-            'item.created_at AS item_created_at'
+            'item_type_allocated_expense.created_at AS item_created_at',
+            'item_type_allocated_expense.updated_at_at AS item_updated_at'
         ];
 
         $collection = $this->join('item_type_allocated_expense', 'item.id', 'item_type_allocated_expense.item_id')->

--- a/app/Models/ResourceTypeItem/SimpleExpense.php
+++ b/app/Models/ResourceTypeItem/SimpleExpense.php
@@ -109,7 +109,8 @@ class SimpleExpense extends Model implements IModel
             'item_type_simple_expense.name AS item_name',
             'item_type_simple_expense.description AS item_description',
             'item_type_simple_expense.total AS item_total',
-            'item.created_at AS item_created_at'
+            'item_type_simple_expense.created_at AS item_created_at',
+            'item_type_simple_expense.updated_at AS item_updated_at'
         ];
 
         $collection = $this->join('item_type_simple_expense', 'item.id', 'item_type_simple_expense.item_id')->

--- a/app/Models/ResourceTypeItem/SimpleExpense.php
+++ b/app/Models/ResourceTypeItem/SimpleExpense.php
@@ -124,8 +124,8 @@ class SimpleExpense extends Model implements IModel
             array_key_exists('include-categories', $parameters_collection) === true &&
             General::booleanValue($parameters_collection['include-categories']) === true
         ) {
-            $collection->join('item_category', 'item.id', 'item_category.item_id')->
-                join('category', 'item_category.category_id', 'category.id');
+            $collection->leftJoin('item_category', 'item.id', 'item_category.item_id')->
+                leftJoin('category', 'item_category.category_id', 'category.id');
 
             $category_join = true;
 
@@ -143,8 +143,8 @@ class SimpleExpense extends Model implements IModel
                 array_key_exists('include-subcategories', $parameters_collection) === true &&
                 General::booleanValue($parameters_collection['include-subcategories']) === true
             ) {
-                $collection->join('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
-                    join('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
+                $collection->leftJoin('item_sub_category', 'item_category.id', 'item_sub_category.item_category_id')->
+                    leftJoin('sub_category', 'item_sub_category.sub_category_id', 'sub_category.id');
 
                 $subcategory_join = true;
 

--- a/app/Models/ResourceTypeItem/SimpleItem.php
+++ b/app/Models/ResourceTypeItem/SimpleItem.php
@@ -93,7 +93,8 @@ class SimpleItem extends Model implements IModel
             "{$this->item_table}.name AS item_name",
             "{$this->item_table}.description AS item_description",
             "{$this->item_table}.quantity AS item_quantity",
-            'item.created_at AS item_created_at'
+            "{$this->item_table}.created_at AS item_created_at",
+            "{$this->item_table}.updated_at AS item_updated_at"
         ];
 
         $collection = $this->join($this->item_table, 'item.id', "{$this->item_table}.item_id")->

--- a/app/Models/Transformers/ItemType.php
+++ b/app/Models/Transformers/ItemType.php
@@ -34,7 +34,9 @@ class ItemType extends Transformer
         return [
             'id' => $this->hash->itemType()->encode($this->data_to_transform['item_type_id']),
             'name' => $this->data_to_transform['item_type_name'],
+            'friendly_name' => $this->data_to_transform['item_type_friendly_name'],
             'description' => $this->data_to_transform['item_type_description'],
+            'example' => $this->data_to_transform['item_type_example'],
             'created' => $this->data_to_transform['item_type_created_at']
         ];
     }

--- a/app/Models/Transformers/ItemType/AllocatedExpense.php
+++ b/app/Models/Transformers/ItemType/AllocatedExpense.php
@@ -33,7 +33,8 @@ class AllocatedExpense extends Transformer
             'percentage' => $this->item['item_percentage'],
             'actualised_total' => number_format((float) $this->item['item_actualised_total'], 2, '.', ''),
             'effective_date' => $this->item['item_effective_date'],
-            'created' => $this->item['item_created_at']
+            'created' => $this->item['item_created_at'],
+            'updated' => $this->item['item_updated_at']
         ];
 
         if (

--- a/app/Models/Transformers/ItemType/AllocatedExpense.php
+++ b/app/Models/Transformers/ItemType/AllocatedExpense.php
@@ -40,25 +40,33 @@ class AllocatedExpense extends Transformer
             array_key_exists('category_id', $this->item) === true &&
             array_key_exists('category_name', $this->item) === true
         ) {
-            $item['category'] = [
-                'id' => $this->hash->category()->encode($this->item['category_id']),
-                'name' => $this->item['category_name'],
-                'description' => $this->item['category_description'],
-                'uri' => '/category/' . $this->hash->itemCategory()->encode($this->item['item_category_id'])
-            ];
+            if ($this->item['category_id'] !== null) {
+                $item['category'] = [
+                    'id' => $this->hash->category()->encode($this->item['category_id']),
+                    'name' => $this->item['category_name'],
+                    'description' => $this->item['category_description'],
+                    'uri' => '/category/' . $this->hash->itemCategory()->encode($this->item['item_category_id'])
+                ];
+            } else {
+                $item['category'] = null;    
+            }
 
             if (
                 array_key_exists('subcategory_id', $this->item) === true &&
                 array_key_exists('subcategory_name', $this->item) === true
             ) {
-                $item['subcategory'] = [
-                    'id' => $this->hash->subCategory()->encode($this->item['subcategory_id']),
-                    'name' => $this->item['subcategory_name'],
-                    'description' => $this->item['subcategory_description'],
-                    'uri' => '/category/' .
-                        $this->hash->itemCategory()->encode($this->item['item_category_id']) .
-                        '/subcategory/' . $this->hash->itemSubCategory()->encode($this->item['item_subcategory_id'])
-                ];
+                if ($this->item['subcategory_id'] !== null) {
+                    $item['subcategory'] = [
+                        'id' => $this->hash->subCategory()->encode($this->item['subcategory_id']),
+                        'name' => $this->item['subcategory_name'],
+                        'description' => $this->item['subcategory_description'],
+                        'uri' => '/category/' .
+                            $this->hash->itemCategory()->encode($this->item['item_category_id']) .
+                            '/subcategory/' . $this->hash->itemSubCategory()->encode($this->item['item_subcategory_id'])
+                    ];
+                } else {
+                    $item['subcategory'] = null;
+                }
             }
         }
 

--- a/app/Models/Transformers/ItemType/SimpleExpense.php
+++ b/app/Models/Transformers/ItemType/SimpleExpense.php
@@ -37,25 +37,33 @@ class SimpleExpense extends Transformer
             array_key_exists('category_id', $this->item) === true &&
             array_key_exists('category_name', $this->item) === true
         ) {
-            $item['category'] = [
-                'id' => $this->hash->category()->encode($this->item['category_id']),
-                'name' => $this->item['category_name'],
-                'description' => $this->item['category_description'],
-                'uri' => '/category/' . $this->hash->itemCategory()->encode($this->item['item_category_id'])
-            ];
+            if ($this->item['category_id'] !== null) {
+                $item['category'] = [
+                    'id' => $this->hash->category()->encode($this->item['category_id']),
+                    'name' => $this->item['category_name'],
+                    'description' => $this->item['category_description'],
+                    'uri' => '/category/' . $this->hash->itemCategory()->encode($this->item['item_category_id'])
+                ];
+            } else {
+                $item['category'] = null;
+            }
 
             if (
                 array_key_exists('subcategory_id', $this->item) === true &&
                 array_key_exists('subcategory_name', $this->item) === true
             ) {
-                $item['subcategory'] = [
-                    'id' => $this->hash->subCategory()->encode($this->item['subcategory_id']),
-                    'name' => $this->item['subcategory_name'],
-                    'description' => $this->item['subcategory_description'],
-                    'uri' => '/category/' .
-                        $this->hash->itemCategory()->encode($this->item['item_category_id']) .
-                        '/subcategory/' . $this->hash->itemSubCategory()->encode($this->item['item_subcategory_id'])
-                ];
+                if ($this->item['subcategory_id'] !== null) {
+                    $item['subcategory'] = [
+                        'id' => $this->hash->subCategory()->encode($this->item['subcategory_id']),
+                        'name' => $this->item['subcategory_name'],
+                        'description' => $this->item['subcategory_description'],
+                        'uri' => '/category/' .
+                            $this->hash->itemCategory()->encode($this->item['item_category_id']) .
+                            '/subcategory/' . $this->hash->itemSubCategory()->encode($this->item['item_subcategory_id'])
+                    ];
+                } else {
+                    $item['subcategory'] = null;
+                }
             }
         }
 

--- a/app/Models/Transformers/ItemType/SimpleExpense.php
+++ b/app/Models/Transformers/ItemType/SimpleExpense.php
@@ -30,7 +30,8 @@ class SimpleExpense extends Transformer
             'name' => $this->item['item_name'],
             'description' => $this->item['item_description'],
             'total' => number_format((float) $this->item['item_total'],2, '.', ''),
-            'created' => $this->item['item_created_at']
+            'created' => $this->item['item_created_at'],
+            'updated' => $this->item['item_updated_at']
         ];
 
         if (

--- a/app/Models/Transformers/ItemType/SimpleItem.php
+++ b/app/Models/Transformers/ItemType/SimpleItem.php
@@ -30,7 +30,8 @@ class SimpleItem extends Transformer
             'name' => $this->item['item_name'],
             'description' => $this->item['item_description'],
             'quantity' => (int) $this->item['item_quantity'],
-            'created' => $this->item['item_created_at']
+            'created' => $this->item['item_created_at'],
+            'updated' => $this->item['item_updated_at']
         ];
 
         return $item;

--- a/app/Models/Transformers/ResourceTypeItemType/AllocatedExpense.php
+++ b/app/Models/Transformers/ResourceTypeItemType/AllocatedExpense.php
@@ -42,6 +42,7 @@ class AllocatedExpense extends Transformer
             'actualised_total' => number_format((float) $this->item['item_actualised_total'], 2, '.', ''),
             'effective_date' => $this->item['item_effective_date'],
             'created' => $this->item['item_created_at'],
+            'updated' => $this->item['item_updated_at'],
             'resource' => [
                 'id' => $this->hash->resource()->encode($this->item['resource_id']),
                 'name' => $this->item['resource_name'],

--- a/app/Models/Transformers/ResourceTypeItemType/AllocatedExpense.php
+++ b/app/Models/Transformers/ResourceTypeItemType/AllocatedExpense.php
@@ -53,25 +53,33 @@ class AllocatedExpense extends Transformer
             array_key_exists('category_id', $this->item) === true &&
             array_key_exists('category_name', $this->item) === true
         ) {
-            $item['category'] = [
-                'id' => $this->hash->category()->encode($this->item['category_id']),
-                'name' => $this->item['category_name'],
-                'description' => $this->item['category_description'],
-                'uri' => '/category/' . $this->hash->itemCategory()->encode($this->item['item_category_id'])
-            ];
+            if ($this->item['category_id'] !== null) {
+                $item['category'] = [
+                    'id' => $this->hash->category()->encode($this->item['category_id']),
+                    'name' => $this->item['category_name'],
+                    'description' => $this->item['category_description'],
+                    'uri' => '/category/' . $this->hash->itemCategory()->encode($this->item['item_category_id'])
+                ];
+            } else {
+                $item['category'] = null;
+            }
 
             if (
                 array_key_exists('subcategory_id', $this->item) === true &&
                 array_key_exists('subcategory_name', $this->item) === true
             ) {
-                $item['subcategory'] = [
-                    'id' => $this->hash->subCategory()->encode($this->item['subcategory_id']),
-                    'name' => $this->item['subcategory_name'],
-                    'description' => $this->item['subcategory_description'],
-                    'uri' => '/category/' .
-                        $this->hash->itemCategory()->encode($this->item['item_category_id']) .
-                        '/subcategory/' . $this->hash->itemSubCategory()->encode($this->item['item_subcategory_id'])
-                ];
+                if ($this->item['subcategory_id'] !== null) {
+                    $item['subcategory'] = [
+                        'id' => $this->hash->subCategory()->encode($this->item['subcategory_id']),
+                        'name' => $this->item['subcategory_name'],
+                        'description' => $this->item['subcategory_description'],
+                        'uri' => '/category/' .
+                            $this->hash->itemCategory()->encode($this->item['item_category_id']) .
+                            '/subcategory/' . $this->hash->itemSubCategory()->encode($this->item['item_subcategory_id'])
+                    ];
+                } else {
+                    $item['subcategory'] = null;
+                }
             }
         }
 

--- a/app/Models/Transformers/ResourceTypeItemType/SimpleExpense.php
+++ b/app/Models/Transformers/ResourceTypeItemType/SimpleExpense.php
@@ -50,25 +50,33 @@ class SimpleExpense extends Transformer
             array_key_exists('category_id', $this->item) === true &&
             array_key_exists('category_name', $this->item) === true
         ) {
-            $item['category'] = [
-                'id' => $this->hash->category()->encode($this->item['category_id']),
-                'name' => $this->item['category_name'],
-                'description' => $this->item['category_description'],
-                'uri' => '/category/' . $this->hash->itemCategory()->encode($this->item['item_category_id'])
-            ];
+            if ($this->item['category_id'] !== null) {
+                $item['category'] = [
+                    'id' => $this->hash->category()->encode($this->item['category_id']),
+                    'name' => $this->item['category_name'],
+                    'description' => $this->item['category_description'],
+                    'uri' => '/category/' . $this->hash->itemCategory()->encode($this->item['item_category_id'])
+                ];
+            } else {
+                $item['category'] = null;
+            }
 
             if (
                 array_key_exists('subcategory_id', $this->item) === true &&
                 array_key_exists('subcategory_name', $this->item) === true
             ) {
-                $item['subcategory'] = [
-                    'id' => $this->hash->subCategory()->encode($this->item['subcategory_id']),
-                    'name' => $this->item['subcategory_name'],
-                    'description' => $this->item['subcategory_description'],
-                    'uri' => '/category/' .
-                        $this->hash->itemCategory()->encode($this->item['item_category_id']) .
-                        '/subcategory/' . $this->hash->itemSubCategory()->encode($this->item['item_subcategory_id'])
-                ];
+                if ($this->item['subcategory_id'] !== null) {
+                    $item['subcategory'] = [
+                        'id' => $this->hash->subCategory()->encode($this->item['subcategory_id']),
+                        'name' => $this->item['subcategory_name'],
+                        'description' => $this->item['subcategory_description'],
+                        'uri' => '/category/' .
+                            $this->hash->itemCategory()->encode($this->item['item_category_id']) .
+                            '/subcategory/' . $this->hash->itemSubCategory()->encode($this->item['item_subcategory_id'])
+                    ];
+                } else {
+                    $item['subcategory'] = null;
+                }
             }
         }
 

--- a/app/Models/Transformers/ResourceTypeItemType/SimpleExpense.php
+++ b/app/Models/Transformers/ResourceTypeItemType/SimpleExpense.php
@@ -39,6 +39,7 @@ class SimpleExpense extends Transformer
             'description' => $this->item['item_description'],
             'total' => number_format((float) $this->item['item_total'], 2, '.', ''),
             'created' => $this->item['item_created_at'],
+            'updated' => $this->item['item_updated_at'],
             'resource' => [
                 'id' => $this->hash->resource()->encode($this->item['resource_id']),
                 'name' => $this->item['resource_name'],

--- a/app/Models/Transformers/ResourceTypeItemType/SimpleItem.php
+++ b/app/Models/Transformers/ResourceTypeItemType/SimpleItem.php
@@ -39,6 +39,7 @@ class SimpleItem extends Transformer
             'description' => $this->item['item_description'],
             'quantity' => (int) $this->item['item_quantity'],
             'created' => $this->item['item_created_at'],
+            'updated' => $this->item['item_updated_at'],
             'resource' => [
                 'id' => $this->hash->resource()->encode($this->item['resource_id']),
                 'name' => $this->item['resource_name'],

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
         "fideloper/proxy": "^4.0",
         "guzzlehttp/guzzle": "^6.3",
         "hashids/hashids": "^3.0",
-        "laravel/framework": "^6.0",
+        "laravel/framework": "^7.0",
         "laravel/helpers": "^1.2",
         "laravel/passport": "^7.0",
-        "laravel/tinker": "^1.0"
+        "laravel/tinker": "^2.0"
     },
     "require-dev": {
         "filp/whoops": "^2.0",
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",
-        "nunomaduro/collision": "^2.0",
-        "phpunit/phpunit": "^7.0"
+        "nunomaduro/collision": "^4.1",
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,54 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bfa9d47db5effe4c4c313f354ef0383",
+    "content-hash": "ba31ff95e4de10b6387dac3409abe460",
     "packages": [
+        {
+            "name": "brick/math",
+            "version": "0.8.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "9b08d412b9da9455b210459ff71414de7e6241cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/9b08d412b9da9455b210459ff71414de7e6241cd",
+                "reference": "9b08d412b9da9455b210459ff71414de7e6241cd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^7.5.15|^8.5",
+                "vimeo/psalm": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "brick",
+                "math"
+            ],
+            "time": "2020-04-15T15:59:35+00:00"
+        },
         {
             "name": "defuse/php-encryption",
             "version": "v2.2.1",
@@ -955,107 +1001,17 @@
             "time": "2018-03-12T16:30:09+00:00"
         },
         {
-            "name": "jakub-onderka/php-console-color",
-            "version": "v0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/JakubOnderka/PHP-Console-Color.git",
-                "reference": "d5deaecff52a0d61ccb613bb3804088da0307191"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/JakubOnderka/PHP-Console-Color/zipball/d5deaecff52a0d61ccb613bb3804088da0307191",
-                "reference": "d5deaecff52a0d61ccb613bb3804088da0307191",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "jakub-onderka/php-code-style": "1.0",
-                "jakub-onderka/php-parallel-lint": "1.0",
-                "jakub-onderka/php-var-dump-check": "0.*",
-                "phpunit/phpunit": "~4.3",
-                "squizlabs/php_codesniffer": "1.*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "JakubOnderka\\PhpConsoleColor\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jakub Onderka",
-                    "email": "jakub.onderka@gmail.com"
-                }
-            ],
-            "abandoned": "php-parallel-lint/php-console-color",
-            "time": "2018-09-29T17:23:10+00:00"
-        },
-        {
-            "name": "jakub-onderka/php-console-highlighter",
-            "version": "v0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/JakubOnderka/PHP-Console-Highlighter.git",
-                "reference": "9f7a229a69d52506914b4bc61bfdb199d90c5547"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/JakubOnderka/PHP-Console-Highlighter/zipball/9f7a229a69d52506914b4bc61bfdb199d90c5547",
-                "reference": "9f7a229a69d52506914b4bc61bfdb199d90c5547",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "jakub-onderka/php-console-color": "~0.2",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "jakub-onderka/php-code-style": "~1.0",
-                "jakub-onderka/php-parallel-lint": "~1.0",
-                "jakub-onderka/php-var-dump-check": "~0.1",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "JakubOnderka\\PhpConsoleHighlighter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jakub Onderka",
-                    "email": "acci@acci.cz",
-                    "homepage": "http://www.acci.cz/"
-                }
-            ],
-            "description": "Highlight PHP code in terminal",
-            "abandoned": "php-parallel-lint/php-console-highlighter",
-            "time": "2018-09-29T18:48:56+00:00"
-        },
-        {
             "name": "laravel/framework",
-            "version": "v6.18.11",
+            "version": "v7.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "73bc10bb23aab7539c8ffae6d5dc3c4b277de557"
+                "reference": "757b155658ae6da429065ba8f22242fe599824f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/73bc10bb23aab7539c8ffae6d5dc3c4b277de557",
-                "reference": "73bc10bb23aab7539c8ffae6d5dc3c4b277de557",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/757b155658ae6da429065ba8f22242fe599824f7",
+                "reference": "757b155658ae6da429065ba8f22242fe599824f7",
                 "shasum": ""
             },
             "require": {
@@ -1067,24 +1023,26 @@
                 "ext-openssl": "*",
                 "league/commonmark": "^1.3",
                 "league/flysystem": "^1.0.8",
-                "monolog/monolog": "^1.12|^2.0",
-                "nesbot/carbon": "^2.0",
+                "monolog/monolog": "^2.0",
+                "nesbot/carbon": "^2.17",
                 "opis/closure": "^3.1",
-                "php": "^7.2",
+                "php": "^7.2.5",
                 "psr/container": "^1.0",
                 "psr/simple-cache": "^1.0",
-                "ramsey/uuid": "^3.7",
+                "ramsey/uuid": "^3.7|^4.0",
                 "swiftmailer/swiftmailer": "^6.0",
-                "symfony/console": "^4.3.4",
-                "symfony/debug": "^4.3.4",
-                "symfony/finder": "^4.3.4",
-                "symfony/http-foundation": "^4.3.4",
-                "symfony/http-kernel": "^4.3.4",
-                "symfony/process": "^4.3.4",
-                "symfony/routing": "^4.3.4",
-                "symfony/var-dumper": "^4.3.4",
-                "tijsverkoyen/css-to-inline-styles": "^2.2.1",
-                "vlucas/phpdotenv": "^3.3"
+                "symfony/console": "^5.0",
+                "symfony/error-handler": "^5.0",
+                "symfony/finder": "^5.0",
+                "symfony/http-foundation": "^5.0",
+                "symfony/http-kernel": "^5.0",
+                "symfony/mime": "^5.0",
+                "symfony/process": "^5.0",
+                "symfony/routing": "^5.0",
+                "symfony/var-dumper": "^5.0",
+                "tijsverkoyen/css-to-inline-styles": "^2.2.2",
+                "vlucas/phpdotenv": "^4.0",
+                "voku/portable-ascii": "^1.4.8"
             },
             "conflict": {
                 "tightenco/collect": "<5.5.33"
@@ -1115,6 +1073,7 @@
                 "illuminate/routing": "self.version",
                 "illuminate/session": "self.version",
                 "illuminate/support": "self.version",
+                "illuminate/testing": "self.version",
                 "illuminate/translation": "self.version",
                 "illuminate/validation": "self.version",
                 "illuminate/view": "self.version"
@@ -1123,15 +1082,15 @@
                 "aws/aws-sdk-php": "^3.0",
                 "doctrine/dbal": "^2.6",
                 "filp/whoops": "^2.4",
-                "guzzlehttp/guzzle": "^6.3|^7.0",
+                "guzzlehttp/guzzle": "^6.3.1|^7.0",
                 "league/flysystem-cached-adapter": "^1.0",
                 "mockery/mockery": "^1.3.1",
                 "moontoast/math": "^1.1",
-                "orchestra/testbench-core": "^4.0",
+                "orchestra/testbench-core": "^5.0",
                 "pda/pheanstalk": "^4.0",
-                "phpunit/phpunit": "^7.5.15|^8.4|^9.0",
+                "phpunit/phpunit": "^8.4|^9.0",
                 "predis/predis": "^1.1.1",
-                "symfony/cache": "^4.3.4"
+                "symfony/cache": "^5.0"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.0).",
@@ -1143,24 +1102,27 @@
                 "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
                 "filp/whoops": "Required for friendly error pages in development (^2.4).",
                 "fzaninotto/faker": "Required to use the eloquent factory builder (^1.9.1).",
-                "guzzlehttp/guzzle": "Required to use the Mailgun mail driver and the ping methods on schedules (^6.0|^7.0).",
+                "guzzlehttp/guzzle": "Required to use the HTTP Client, Mailgun mail driver and the ping methods on schedules (^6.3.1|^7.0).",
                 "laravel/tinker": "Required to use the tinker console command (^2.0).",
                 "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",
                 "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
                 "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
+                "mockery/mockery": "Required to use mocking (^1.3.1).",
                 "moontoast/math": "Required to use ordered UUIDs (^1.1).",
                 "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
                 "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
+                "phpunit/phpunit": "Required to use assertions and run tests (^8.4|^9.0).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
                 "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
-                "symfony/cache": "Required to PSR-6 cache bridge (^4.3.4).",
-                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.2).",
+                "symfony/cache": "Required to PSR-6 cache bridge (^5.0).",
+                "symfony/filesystem": "Required to create relative storage directory symbolic links (^5.0).",
+                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",
                 "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.x-dev"
+                    "dev-master": "7.x-dev"
                 }
             },
             "autoload": {
@@ -1188,7 +1150,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2020-04-28T15:18:58+00:00"
+            "time": "2020-04-28T16:09:20+00:00"
         },
         {
             "name": "laravel/helpers",
@@ -1316,36 +1278,37 @@
         },
         {
             "name": "laravel/tinker",
-            "version": "v1.0.10",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/tinker.git",
-                "reference": "ad571aacbac1539c30d480908f9d0c9614eaf1a7"
+                "reference": "cde90a7335a2130a4488beb68f4b2141869241db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/tinker/zipball/ad571aacbac1539c30d480908f9d0c9614eaf1a7",
-                "reference": "ad571aacbac1539c30d480908f9d0c9614eaf1a7",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/cde90a7335a2130a4488beb68f4b2141869241db",
+                "reference": "cde90a7335a2130a4488beb68f4b2141869241db",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "~5.1|^6.0",
-                "illuminate/contracts": "~5.1|^6.0",
-                "illuminate/support": "~5.1|^6.0",
-                "php": ">=5.5.9",
-                "psy/psysh": "0.7.*|0.8.*|0.9.*",
-                "symfony/var-dumper": "~3.0|~4.0"
+                "illuminate/console": "^6.0|^7.0|^8.0",
+                "illuminate/contracts": "^6.0|^7.0|^8.0",
+                "illuminate/support": "^6.0|^7.0|^8.0",
+                "php": "^7.2",
+                "psy/psysh": "^0.10.3",
+                "symfony/var-dumper": "^4.3|^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0|~5.0"
+                "mockery/mockery": "^1.3.1",
+                "phpunit/phpunit": "^8.4|^9.0"
             },
             "suggest": {
-                "illuminate/database": "The Illuminate Database package (~5.1)."
+                "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.x-dev"
                 },
                 "laravel": {
                     "providers": [
@@ -1375,7 +1338,7 @@
                 "laravel",
                 "psysh"
             ],
-            "time": "2019-08-07T15:10:45+00:00"
+            "time": "2020-04-07T15:01:31+00:00"
         },
         {
             "name": "lcobucci/jwt",
@@ -1800,21 +1763,22 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.32.2",
+            "version": "2.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "f10e22cf546704fab1db4ad4b9dedbc5c797a0dc"
+                "reference": "4d93cb95a80d9ffbff4018fe58ae3b7dd7f4b99b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/f10e22cf546704fab1db4ad4b9dedbc5c797a0dc",
-                "reference": "f10e22cf546704fab1db4ad4b9dedbc5c797a0dc",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4d93cb95a80d9ffbff4018fe58ae3b7dd7f4b99b",
+                "reference": "4d93cb95a80d9ffbff4018fe58ae3b7dd7f4b99b",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "php": "^7.1.8 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/translation": "^3.4 || ^4.0 || ^5.0"
             },
             "require-dev": {
@@ -1867,7 +1831,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2020-03-31T13:43:19+00:00"
+            "time": "2020-04-20T15:05:43+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2224,6 +2188,52 @@
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
             "name": "psr/http-factory",
             "version": "1.0.1",
             "source": {
@@ -2422,32 +2432,30 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.9.12",
+            "version": "v0.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "90da7f37568aee36b116a030c5f99c915267edd4"
+                "reference": "2bde2fa03e05dff0aee834598b951d6fc7c6fe02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/90da7f37568aee36b116a030c5f99c915267edd4",
-                "reference": "90da7f37568aee36b116a030c5f99c915267edd4",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/2bde2fa03e05dff0aee834598b951d6fc7c6fe02",
+                "reference": "2bde2fa03e05dff0aee834598b951d6fc7c6fe02",
                 "shasum": ""
             },
             "require": {
                 "dnoegel/php-xdg-base-dir": "0.1.*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "jakub-onderka/php-console-highlighter": "0.3.*|0.4.*",
-                "nikic/php-parser": "~1.3|~2.0|~3.0|~4.0",
-                "php": ">=5.4.0",
-                "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0|~5.0",
-                "symfony/var-dumper": "~2.7|~3.0|~4.0|~5.0"
+                "nikic/php-parser": "~4.0|~3.0|~2.0|~1.3",
+                "php": "^8.0 || ^7.0 || ^5.5.9",
+                "symfony/console": "~5.0|~4.0|~3.0|^2.4.2|~2.3.10",
+                "symfony/var-dumper": "~5.0|~4.0|~3.0|~2.7"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.2",
-                "hoa/console": "~2.15|~3.16",
-                "phpunit/phpunit": "~4.8.35|~5.0|~6.0|~7.0"
+                "hoa/console": "3.17.*"
             },
             "suggest": {
                 "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
@@ -2462,7 +2470,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-develop": "0.9.x-dev"
+                    "dev-master": "0.10.x-dev"
                 }
             },
             "autoload": {
@@ -2492,7 +2500,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2019-12-06T14:19:43+00:00"
+            "time": "2020-04-07T06:44:48+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -2535,54 +2543,124 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
-            "name": "ramsey/uuid",
-            "version": "3.9.3",
+            "name": "ramsey/collection",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ramsey/uuid.git",
-                "reference": "7e1633a6964b48589b142d60542f9ed31bd37a92"
+                "url": "https://github.com/ramsey/collection.git",
+                "reference": "925ad8cf55ba7a3fc92e332c58fd0478ace3e1ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/7e1633a6964b48589b142d60542f9ed31bd37a92",
-                "reference": "7e1633a6964b48589b142d60542f9ed31bd37a92",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/925ad8cf55ba7a3fc92e332c58fd0478ace3e1ca",
+                "reference": "925ad8cf55ba7a3fc92e332c58fd0478ace3e1ca",
                 "shasum": ""
             },
             "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "fzaninotto/faker": "^1.5",
+                "jakub-onderka/php-parallel-lint": "^1",
+                "jangregor/phpstan-prophecy": "^0.6",
+                "mockery/mockery": "^1.3",
+                "phpstan/extension-installer": "^1",
+                "phpstan/phpdoc-parser": "0.4.1",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-mockery": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^8.5",
+                "slevomat/coding-standard": "^6.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Collection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "A PHP 7.2+ library for representing and manipulating collections.",
+            "homepage": "https://github.com/ramsey/collection",
+            "keywords": [
+                "array",
+                "collection",
+                "hash",
+                "map",
+                "queue",
+                "set"
+            ],
+            "time": "2020-01-05T00:22:59+00:00"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "ba8fff1d3abb8bb4d35a135ed22a31c6ef3ede3d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/ba8fff1d3abb8bb4d35a135ed22a31c6ef3ede3d",
+                "reference": "ba8fff1d3abb8bb4d35a135ed22a31c6ef3ede3d",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.8",
                 "ext-json": "*",
-                "paragonie/random_compat": "^1 | ^2 | 9.99.99",
-                "php": "^5.4 | ^7 | ^8",
+                "php": "^7.2 || ^8",
+                "ramsey/collection": "^1.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "replace": {
                 "rhumsaa/uuid": "self.version"
             },
             "require-dev": {
-                "codeception/aspect-mock": "^1 | ^2",
-                "doctrine/annotations": "^1.2",
-                "goaop/framework": "1.0.0-alpha.2 | ^1 | ^2.1",
-                "jakub-onderka/php-parallel-lint": "^1",
-                "mockery/mockery": "^0.9.11 | ^1",
+                "codeception/aspect-mock": "^3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
+                "doctrine/annotations": "^1.8",
+                "goaop/framework": "^2",
+                "mockery/mockery": "^1.3",
                 "moontoast/math": "^1.1",
                 "paragonie/random-lib": "^2",
-                "php-mock/php-mock-phpunit": "^0.3 | ^1.1",
-                "phpunit/phpunit": "^4.8 | ^5.4 | ^6.5",
-                "squizlabs/php_codesniffer": "^3.5"
+                "php-mock/php-mock-mockery": "^1.3",
+                "php-mock/php-mock-phpunit": "^2.5",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpdoc-parser": "0.4.3",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-mockery": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^8.5",
+                "psy/psysh": "^0.10.0",
+                "slevomat/coding-standard": "^6.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "3.9.4"
             },
             "suggest": {
-                "ext-ctype": "Provides support for PHP Ctype functions",
-                "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
-                "ext-openssl": "Provides the OpenSSL extension for use with the OpenSslGenerator",
-                "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
-                "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
+                "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
+                "ext-ctype": "Enables faster processing of character classification using ctype functions.",
+                "ext-gmp": "Enables faster math with arbitrary-precision integers using GMP.",
+                "ext-uuid": "Enables the use of PeclUuidTimeGenerator and PeclUuidRandomGenerator.",
                 "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
-                "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
                 "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.x-dev"
+                    "dev-master": "4.x-dev"
                 }
             },
             "autoload": {
@@ -2597,29 +2675,14 @@
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Ben Ramsey",
-                    "email": "ben@benramsey.com",
-                    "homepage": "https://benramsey.com"
-                },
-                {
-                    "name": "Marijn Huizendveld",
-                    "email": "marijn.huizendveld@gmail.com"
-                },
-                {
-                    "name": "Thibaud Fabre",
-                    "email": "thibaud@aztech.io"
-                }
-            ],
-            "description": "Formerly rhumsaa/uuid. A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
+            "description": "A PHP library for generating and working with universally unique identifiers (UUIDs).",
             "homepage": "https://github.com/ramsey/uuid",
             "keywords": [
                 "guid",
                 "identifier",
                 "uuid"
             ],
-            "time": "2020-02-21T04:36:14+00:00"
+            "time": "2020-03-29T20:13:32+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -2685,41 +2748,41 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.4.8",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "10bb3ee3c97308869d53b3e3d03f6ac23ff985f7"
+                "reference": "5fa1caadc8cdaa17bcfb25219f3b53fe294a9935"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/10bb3ee3c97308869d53b3e3d03f6ac23ff985f7",
-                "reference": "10bb3ee3c97308869d53b3e3d03f6ac23ff985f7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5fa1caadc8cdaa17bcfb25219f3b53fe294a9935",
+                "reference": "5fa1caadc8cdaa17bcfb25219f3b53fe294a9935",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^7.2.5",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
                 "symfony/service-contracts": "^1.1|^2"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.4",
-                "symfony/event-dispatcher": "<4.3|>=5",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/event-dispatcher": "<4.4",
                 "symfony/lock": "<4.4",
-                "symfony/process": "<3.3"
+                "symfony/process": "<4.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "^3.4|^4.0|^5.0",
-                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-                "symfony/event-dispatcher": "^4.3",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
                 "symfony/lock": "^4.4|^5.0",
-                "symfony/process": "^3.4|^4.0|^5.0",
-                "symfony/var-dumper": "^4.3|^5.0"
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -2730,7 +2793,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2757,7 +2820,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2020-03-30T11:41:10+00:00"
+            "time": "2020-03-30T11:42:42+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -2813,79 +2876,22 @@
             "time": "2020-03-27T16:56:45+00:00"
         },
         {
-            "name": "symfony/debug",
-            "version": "v4.4.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "346636d2cae417992ecfd761979b2ab98b339a45"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/346636d2cae417992ecfd761979b2ab98b339a45",
-                "reference": "346636d2cae417992ecfd761979b2ab98b339a45",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3",
-                "psr/log": "~1.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": "<3.4"
-            },
-            "require-dev": {
-                "symfony/http-kernel": "^3.4|^4.0|^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Debug Component",
-            "homepage": "https://symfony.com",
-            "time": "2020-03-27T16:54:36+00:00"
-        },
-        {
             "name": "symfony/error-handler",
-            "version": "v4.4.8",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "7e9828fc98aa1cf27b422fe478a84f5b0abb7358"
+                "reference": "949ffc17c3ac3a9f8e6232220e2da33913c04ea4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/7e9828fc98aa1cf27b422fe478a84f5b0abb7358",
-                "reference": "7e9828fc98aa1cf27b422fe478a84f5b0abb7358",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/949ffc17c3ac3a9f8e6232220e2da33913c04ea4",
+                "reference": "949ffc17c3ac3a9f8e6232220e2da33913c04ea4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
-                "psr/log": "~1.0",
-                "symfony/debug": "^4.4.5",
+                "php": "^7.2.5",
+                "psr/log": "^1.0",
                 "symfony/var-dumper": "^4.4|^5.0"
             },
             "require-dev": {
@@ -2895,7 +2901,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2922,41 +2928,41 @@
             ],
             "description": "Symfony ErrorHandler Component",
             "homepage": "https://symfony.com",
-            "time": "2020-03-30T14:07:33+00:00"
+            "time": "2020-03-30T14:14:32+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.4.8",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "abc8e3618bfdb55e44c8c6a00abd333f831bbfed"
+                "reference": "24f40d95385774ed5c71dbf014edd047e2f2f3dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/abc8e3618bfdb55e44c8c6a00abd333f831bbfed",
-                "reference": "abc8e3618bfdb55e44c8c6a00abd333f831bbfed",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/24f40d95385774ed5c71dbf014edd047e2f2f3dc",
+                "reference": "24f40d95385774ed5c71dbf014edd047e2f2f3dc",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
-                "symfony/event-dispatcher-contracts": "^1.1"
+                "php": "^7.2.5",
+                "symfony/event-dispatcher-contracts": "^2"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.4"
+                "symfony/dependency-injection": "<4.4"
             },
             "provide": {
                 "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "1.1"
+                "symfony/event-dispatcher-implementation": "2.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "^3.4|^4.0|^5.0",
-                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-                "symfony/expression-language": "^3.4|^4.0|^5.0",
-                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/http-foundation": "^4.4|^5.0",
                 "symfony/service-contracts": "^1.1|^2",
-                "symfony/stopwatch": "^3.4|^4.0|^5.0"
+                "symfony/stopwatch": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -2965,7 +2971,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2992,33 +2998,33 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2020-03-27T16:54:36+00:00"
+            "time": "2020-03-27T16:56:45+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v1.1.7",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18"
+                "reference": "af23c2584d4577d54661c434446fb8fbed6025dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
-                "reference": "c43ab685673fb6c8d84220c77897b1d6cdbe1d18",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/af23c2584d4577d54661c434446fb8fbed6025dd",
+                "reference": "af23c2584d4577d54661c434446fb8fbed6025dd",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.2.5",
+                "psr/event-dispatcher": "^1"
             },
             "suggest": {
-                "psr/event-dispatcher": "",
                 "symfony/event-dispatcher-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3050,29 +3056,29 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-09-17T09:54:03+00:00"
+            "time": "2019-11-18T17:27:11+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.4.8",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "5729f943f9854c5781984ed4907bbb817735776b"
+                "reference": "600a52c29afc0d1caa74acbec8d3095ca7e9910d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/5729f943f9854c5781984ed4907bbb817735776b",
-                "reference": "5729f943f9854c5781984ed4907bbb817735776b",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/600a52c29afc0d1caa74acbec8d3095ca7e9910d",
+                "reference": "600a52c29afc0d1caa74acbec8d3095ca7e9910d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.2.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3099,35 +3105,35 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2020-03-27T16:54:36+00:00"
+            "time": "2020-03-27T16:56:45+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v4.4.8",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "ec5bd254c223786f5fa2bb49a1e705c1b8e7cee2"
+                "reference": "e47fdf8b24edc12022ba52923150ec6484d7f57d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/ec5bd254c223786f5fa2bb49a1e705c1b8e7cee2",
-                "reference": "ec5bd254c223786f5fa2bb49a1e705c1b8e7cee2",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e47fdf8b24edc12022ba52923150ec6484d7f57d",
+                "reference": "e47fdf8b24edc12022ba52923150ec6484d7f57d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
-                "symfony/mime": "^4.3|^5.0",
+                "php": "^7.2.5",
+                "symfony/mime": "^4.4|^5.0",
                 "symfony/polyfill-mbstring": "~1.1"
             },
             "require-dev": {
                 "predis/predis": "~1.0",
-                "symfony/expression-language": "^3.4|^4.0|^5.0"
+                "symfony/expression-language": "^4.4|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3154,59 +3160,66 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2020-04-18T20:40:08+00:00"
+            "time": "2020-04-18T20:50:06+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v4.4.8",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "1799a6c01f0db5851f399151abdb5d6393fec277"
+                "reference": "3565e51eecd06106304baba5ccb7ba89db2d7d2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/1799a6c01f0db5851f399151abdb5d6393fec277",
-                "reference": "1799a6c01f0db5851f399151abdb5d6393fec277",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/3565e51eecd06106304baba5ccb7ba89db2d7d2b",
+                "reference": "3565e51eecd06106304baba5ccb7ba89db2d7d2b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^7.2.5",
                 "psr/log": "~1.0",
-                "symfony/error-handler": "^4.4",
-                "symfony/event-dispatcher": "^4.4",
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^5.0",
                 "symfony/http-foundation": "^4.4|^5.0",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-php73": "^1.9"
             },
             "conflict": {
-                "symfony/browser-kit": "<4.3",
-                "symfony/config": "<3.4",
-                "symfony/console": ">=5",
-                "symfony/dependency-injection": "<4.3",
-                "symfony/translation": "<4.2",
-                "twig/twig": "<1.34|<2.4,>=2"
+                "symfony/browser-kit": "<4.4",
+                "symfony/cache": "<5.0",
+                "symfony/config": "<5.0",
+                "symfony/console": "<4.4",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/doctrine-bridge": "<5.0",
+                "symfony/form": "<5.0",
+                "symfony/http-client": "<5.0",
+                "symfony/mailer": "<5.0",
+                "symfony/messenger": "<5.0",
+                "symfony/translation": "<5.0",
+                "symfony/twig-bridge": "<5.0",
+                "symfony/validator": "<5.0",
+                "twig/twig": "<2.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0"
             },
             "require-dev": {
                 "psr/cache": "~1.0",
-                "symfony/browser-kit": "^4.3|^5.0",
-                "symfony/config": "^3.4|^4.0|^5.0",
-                "symfony/console": "^3.4|^4.0",
-                "symfony/css-selector": "^3.4|^4.0|^5.0",
-                "symfony/dependency-injection": "^4.3|^5.0",
-                "symfony/dom-crawler": "^3.4|^4.0|^5.0",
-                "symfony/expression-language": "^3.4|^4.0|^5.0",
-                "symfony/finder": "^3.4|^4.0|^5.0",
-                "symfony/process": "^3.4|^4.0|^5.0",
-                "symfony/routing": "^3.4|^4.0|^5.0",
-                "symfony/stopwatch": "^3.4|^4.0|^5.0",
-                "symfony/templating": "^3.4|^4.0|^5.0",
-                "symfony/translation": "^4.2|^5.0",
+                "symfony/browser-kit": "^4.4|^5.0",
+                "symfony/config": "^5.0",
+                "symfony/console": "^4.4|^5.0",
+                "symfony/css-selector": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/dom-crawler": "^4.4|^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/finder": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/routing": "^4.4|^5.0",
+                "symfony/stopwatch": "^4.4|^5.0",
+                "symfony/translation": "^4.4|^5.0",
                 "symfony/translation-contracts": "^1.1|^2",
-                "twig/twig": "^1.34|^2.4|^3.0"
+                "twig/twig": "^2.4|^3.0"
             },
             "suggest": {
                 "symfony/browser-kit": "",
@@ -3217,7 +3230,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3244,7 +3257,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2020-04-28T18:47:42+00:00"
+            "time": "2020-04-28T18:53:25+00:00"
         },
         {
             "name": "symfony/mime",
@@ -3661,25 +3674,25 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.4.8",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "4b6a9a4013baa65d409153cbb5a895bf093dc7f4"
+                "reference": "3179f68dff5bad14d38c4114a1dab98030801fd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4b6a9a4013baa65d409153cbb5a895bf093dc7f4",
-                "reference": "4b6a9a4013baa65d409153cbb5a895bf093dc7f4",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3179f68dff5bad14d38c4114a1dab98030801fd7",
+                "reference": "3179f68dff5bad14d38c4114a1dab98030801fd7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.2.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3706,7 +3719,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2020-04-15T15:56:18+00:00"
+            "time": "2020-04-15T15:59:10+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -3775,34 +3788,34 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v4.4.8",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "67b4e1f99c050cbc310b8f3d0dbdc4b0212c052c"
+                "reference": "9b18480a6e101f8d9ab7c483ace7c19441be5111"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/67b4e1f99c050cbc310b8f3d0dbdc4b0212c052c",
-                "reference": "67b4e1f99c050cbc310b8f3d0dbdc4b0212c052c",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/9b18480a6e101f8d9ab7c483ace7c19441be5111",
+                "reference": "9b18480a6e101f8d9ab7c483ace7c19441be5111",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.2.5"
             },
             "conflict": {
-                "symfony/config": "<4.2",
-                "symfony/dependency-injection": "<3.4",
-                "symfony/yaml": "<3.4"
+                "symfony/config": "<5.0",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/yaml": "<4.4"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.2",
                 "psr/log": "~1.0",
-                "symfony/config": "^4.2|^5.0",
-                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-                "symfony/expression-language": "^3.4|^4.0|^5.0",
-                "symfony/http-foundation": "^3.4|^4.0|^5.0",
-                "symfony/yaml": "^3.4|^4.0|^5.0"
+                "symfony/config": "^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/yaml": "^4.4|^5.0"
             },
             "suggest": {
                 "doctrine/annotations": "For using the annotation loader",
@@ -3814,7 +3827,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3847,7 +3860,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2020-04-21T19:59:53+00:00"
+            "time": "2020-04-21T21:02:50+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3909,42 +3922,43 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v4.4.8",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "8272bbd2b7e220ef812eba2a2b30068a5c64b191"
+                "reference": "c3879db7a68fe3e12b41263b05879412c87b27fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/8272bbd2b7e220ef812eba2a2b30068a5c64b191",
-                "reference": "8272bbd2b7e220ef812eba2a2b30068a5c64b191",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/c3879db7a68fe3e12b41263b05879412c87b27fd",
+                "reference": "c3879db7a68fe3e12b41263b05879412c87b27fd",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^7.2.5",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation-contracts": "^1.1.6|^2"
+                "symfony/translation-contracts": "^2"
             },
             "conflict": {
-                "symfony/config": "<3.4",
-                "symfony/dependency-injection": "<3.4",
-                "symfony/http-kernel": "<4.4",
-                "symfony/yaml": "<3.4"
+                "symfony/config": "<4.4",
+                "symfony/dependency-injection": "<5.0",
+                "symfony/http-kernel": "<5.0",
+                "symfony/twig-bundle": "<5.0",
+                "symfony/yaml": "<4.4"
             },
             "provide": {
-                "symfony/translation-implementation": "1.0"
+                "symfony/translation-implementation": "2.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "^3.4|^4.0|^5.0",
-                "symfony/console": "^3.4|^4.0|^5.0",
-                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-                "symfony/finder": "~2.8|~3.0|~4.0|^5.0",
-                "symfony/http-kernel": "^4.4",
-                "symfony/intl": "^3.4|^4.0|^5.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/console": "^4.4|^5.0",
+                "symfony/dependency-injection": "^5.0",
+                "symfony/finder": "^4.4|^5.0",
+                "symfony/http-kernel": "^5.0",
+                "symfony/intl": "^4.4|^5.0",
                 "symfony/service-contracts": "^1.1.2|^2",
-                "symfony/yaml": "^3.4|^4.0|^5.0"
+                "symfony/yaml": "^4.4|^5.0"
             },
             "suggest": {
                 "psr/log-implementation": "To use logging capability in translator",
@@ -3954,7 +3968,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3981,7 +3995,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2020-04-12T16:45:36+00:00"
+            "time": "2020-04-12T16:45:47+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -4042,32 +4056,31 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v4.4.8",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "c587e04ce5d1aa62d534a038f574d9a709e814cf"
+                "reference": "09de28632f16f81058a85fcf318397218272a07b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c587e04ce5d1aa62d534a038f574d9a709e814cf",
-                "reference": "c587e04ce5d1aa62d534a038f574d9a709e814cf",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/09de28632f16f81058a85fcf318397218272a07b",
+                "reference": "09de28632f16f81058a85fcf318397218272a07b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php72": "~1.5"
+                "php": "^7.2.5",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-                "symfony/console": "<3.4"
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/console": "<4.4"
             },
             "require-dev": {
                 "ext-iconv": "*",
-                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/console": "^4.4|^5.0",
                 "symfony/process": "^4.4|^5.0",
-                "twig/twig": "^1.34|^2.4|^3.0"
+                "twig/twig": "^2.4|^3.0"
             },
             "suggest": {
                 "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
@@ -4080,7 +4093,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4114,7 +4127,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2020-04-12T16:14:02+00:00"
+            "time": "2020-04-12T16:45:47+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -4167,24 +4180,25 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v3.6.3",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "1b3103013797f04521c6cae5560f604649484066"
+                "reference": "feb6dad5ae24b1380827aee1629b730080fde500"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/1b3103013797f04521c6cae5560f604649484066",
-                "reference": "1b3103013797f04521c6cae5560f604649484066",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/feb6dad5ae24b1380827aee1629b730080fde500",
+                "reference": "feb6dad5ae24b1380827aee1629b730080fde500",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.4 || ^7.0",
-                "phpoption/phpoption": "^1.5",
+                "php": "^5.5.9 || ^7.0",
+                "phpoption/phpoption": "^1.7.2",
                 "symfony/polyfill-ctype": "^1.9"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.3",
                 "ext-filter": "*",
                 "ext-pcre": "*",
                 "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0"
@@ -4196,7 +4210,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.6-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -4226,7 +4240,56 @@
                 "env",
                 "environment"
             ],
-            "time": "2020-04-12T15:18:03+00:00"
+            "time": "2020-04-12T15:20:09+00:00"
+        },
+        {
+            "name": "voku/portable-ascii",
+            "version": "1.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/voku/portable-ascii.git",
+                "reference": "240e93829a5f985fab0984a6e55ae5e26b78a334"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/240e93829a5f985fab0984a6e55ae5e26b78a334",
+                "reference": "240e93829a5f985fab0984a6e55ae5e26b78a334",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6.0 || ~7.0"
+            },
+            "suggest": {
+                "ext-intl": "Use Intl for transliterator_transliterate() support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "voku\\": "src/voku/",
+                    "voku\\tests\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Moelleken",
+                    "homepage": "http://www.moelleken.org/"
+                }
+            ],
+            "description": "Portable ASCII library - performance optimized (ascii) string functions for php.",
+            "homepage": "https://github.com/voku/portable-ascii",
+            "keywords": [
+                "ascii",
+                "clean",
+                "php"
+            ],
+            "time": "2020-03-13T01:23:26+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -4353,6 +4416,50 @@
                 "instantiate"
             ],
             "time": "2019-10-21T16:45:58+00:00"
+        },
+        {
+            "name": "facade/ignition-contracts",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/facade/ignition-contracts.git",
+                "reference": "f445db0fb86f48e205787b2592840dd9c80ded28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/facade/ignition-contracts/zipball/f445db0fb86f48e205787b2592840dd9c80ded28",
+                "reference": "f445db0fb86f48e205787b2592840dd9c80ded28",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Facade\\IgnitionContracts\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://flareapp.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Solution contracts for Ignition",
+            "homepage": "https://github.com/facade/ignition-contracts",
+            "keywords": [
+                "contracts",
+                "flare",
+                "ignition"
+            ],
+            "time": "2019-08-30T14:06:08+00:00"
         },
         {
             "name": "filp/whoops",
@@ -4628,29 +4735,35 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v2.1.1",
+            "version": "v4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "b5feb0c0d92978ec7169232ce5d70d6da6b29f63"
+                "reference": "d50490417eded97be300a92cd7df7badc37a9018"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/b5feb0c0d92978ec7169232ce5d70d6da6b29f63",
-                "reference": "b5feb0c0d92978ec7169232ce5d70d6da6b29f63",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/d50490417eded97be300a92cd7df7badc37a9018",
+                "reference": "d50490417eded97be300a92cd7df7badc37a9018",
                 "shasum": ""
             },
             "require": {
-                "filp/whoops": "^2.1.4",
-                "jakub-onderka/php-console-highlighter": "0.3.*|0.4.*",
-                "php": "^7.1",
-                "symfony/console": "~2.8|~3.3|~4.0"
+                "facade/ignition-contracts": "^1.0",
+                "filp/whoops": "^2.4",
+                "php": "^7.2.5",
+                "symfony/console": "^5.0"
             },
             "require-dev": {
-                "laravel/framework": "5.7.*",
-                "nunomaduro/larastan": "^0.3.0",
-                "phpstan/phpstan": "^0.10",
-                "phpunit/phpunit": "~7.3"
+                "facade/ignition": "^2.0",
+                "fideloper/proxy": "^4.2",
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "fruitcake/laravel-cors": "^1.0",
+                "laravel/framework": "^7.0",
+                "laravel/tinker": "^2.0",
+                "nunomaduro/larastan": "^0.5",
+                "orchestra/testbench": "^5.0",
+                "phpstan/phpstan": "^0.12.3",
+                "phpunit/phpunit": "^8.5.1 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -4688,7 +4801,7 @@
                 "php",
                 "symfony"
             ],
-            "time": "2018-11-21T21:40:54+00:00"
+            "time": "2020-04-04T19:56:08+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -5005,40 +5118,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.1.4",
+            "version": "7.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f1884187926fbb755a9aaf0b3836ad3165b478bf",
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^2.0",
+                "php": "^7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
+                "phpunit/php-token-stream": "^3.1.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/environment": "^4.2.2",
                 "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -5064,7 +5177,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-31T16:06:48+00:00"
+            "time": "2019-11-20T13:55:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -5257,45 +5370,44 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.20",
+            "version": "8.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
+                "reference": "8474e22d7d642f665084ba5ec780626cbd1efd23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8474e22d7d642f665084ba5ec780626cbd1efd23",
+                "reference": "8474e22d7d642f665084ba5ec780626cbd1efd23",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.1",
+                "doctrine/instantiator": "^1.2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.7",
-                "phar-io/manifest": "^1.0.2",
-                "phar-io/version": "^2.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.7",
-                "phpunit/php-file-iterator": "^2.0.1",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.2",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^7.0.7",
+                "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1",
-                "sebastian/comparator": "^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^4.0",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/exporter": "^3.1.1",
+                "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
                 "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
@@ -5303,7 +5415,7 @@
             "suggest": {
                 "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -5311,7 +5423,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.5-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -5337,7 +5449,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-01-08T08:45:45+00:00"
+            "time": "2020-04-23T04:39:42+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -5626,23 +5738,26 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -5650,7 +5765,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -5673,7 +5788,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2019-02-01T05:30:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -5861,6 +5976,52 @@
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "time": "2018-10-04T04:07:39+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2019-07-02T08:10:15+00:00"
         },
         {
             "name": "sebastian/version",

--- a/composer.lock
+++ b/composer.lock
@@ -186,16 +186,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "v2.10.1",
+            "version": "2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8"
+                "reference": "aab745e7b6b2de3b47019da81e7225e14dcfdac8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8",
-                "reference": "c2b8e6e82732a64ecde1cddf9e1e06cb8556e3d8",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/aab745e7b6b2de3b47019da81e7225e14dcfdac8",
+                "reference": "aab745e7b6b2de3b47019da81e7225e14dcfdac8",
                 "shasum": ""
             },
             "require": {
@@ -207,9 +207,11 @@
             "require-dev": {
                 "doctrine/coding-standard": "^6.0",
                 "jetbrains/phpstorm-stubs": "^2019.1",
-                "phpstan/phpstan": "^0.11.3",
+                "nikic/php-parser": "^4.4",
+                "phpstan/phpstan": "^0.12",
                 "phpunit/phpunit": "^8.4.1",
-                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0"
+                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
+                "vimeo/psalm": "^3.11"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -274,7 +276,7 @@
                 "sqlserver",
                 "sqlsrv"
             ],
-            "time": "2020-01-04T12:56:21+00:00"
+            "time": "2020-04-20T17:19:26+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -699,23 +701,24 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.2",
+            "version": "6.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "43ece0e75098b7ecd8d13918293029e555a50f82"
+                "reference": "aab4ebd862aa7d04f01a4b51849d657db56d882e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/43ece0e75098b7ecd8d13918293029e555a50f82",
-                "reference": "43ece0e75098b7ecd8d13918293029e555a50f82",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aab4ebd862aa7d04f01a4b51849d657db56d882e",
+                "reference": "aab4ebd862aa7d04f01a4b51849d657db56d882e",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^1.0",
                 "guzzlehttp/psr7": "^1.6.1",
-                "php": ">=5.5"
+                "php": ">=5.5",
+                "symfony/polyfill-intl-idn": "^1.11"
             },
             "require-dev": {
                 "ext-curl": "*",
@@ -723,7 +726,6 @@
                 "psr/log": "^1.1"
             },
             "suggest": {
-                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
@@ -762,7 +764,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2019-12-23T11:57:10+00:00"
+            "time": "2020-04-18T10:38:46+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -992,6 +994,7 @@
                     "email": "jakub.onderka@gmail.com"
                 }
             ],
+            "abandoned": "php-parallel-lint/php-console-color",
             "time": "2018-09-29T17:23:10+00:00"
         },
         {
@@ -1038,20 +1041,21 @@
                 }
             ],
             "description": "Highlight PHP code in terminal",
+            "abandoned": "php-parallel-lint/php-console-highlighter",
             "time": "2018-09-29T18:48:56+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v6.18.3",
+            "version": "v6.18.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "4e48acfaba87f08320a2764d36c3b6a4a4112ccf"
+                "reference": "73bc10bb23aab7539c8ffae6d5dc3c4b277de557"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/4e48acfaba87f08320a2764d36c3b6a4a4112ccf",
-                "reference": "4e48acfaba87f08320a2764d36c3b6a4a4112ccf",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/73bc10bb23aab7539c8ffae6d5dc3c4b277de557",
+                "reference": "73bc10bb23aab7539c8ffae6d5dc3c4b277de557",
                 "shasum": ""
             },
             "require": {
@@ -1184,7 +1188,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2020-03-24T16:37:50+00:00"
+            "time": "2020-04-28T15:18:58+00:00"
         },
         {
             "name": "laravel/helpers",
@@ -1430,16 +1434,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "1.3.2",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "75542a366ccbe1896ed79fcf3e8e68206d6c4257"
+                "reference": "9e780d972185e4f737a03bade0fd34a9e67bbf31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/75542a366ccbe1896ed79fcf3e8e68206d6c4257",
-                "reference": "75542a366ccbe1896ed79fcf3e8e68206d6c4257",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/9e780d972185e4f737a03bade0fd34a9e67bbf31",
+                "reference": "9e780d972185e4f737a03bade0fd34a9e67bbf31",
                 "shasum": ""
             },
             "require": {
@@ -1457,7 +1461,7 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "~1.4",
                 "mikehaertl/php-shellcommand": "^1.4",
-                "phpstan/phpstan-shim": "^0.11.5",
+                "phpstan/phpstan": "^0.12",
                 "phpunit/phpunit": "^7.5",
                 "scrutinizer/ocular": "^1.5",
                 "symfony/finder": "^4.2"
@@ -1500,7 +1504,7 @@
                 "md",
                 "parser"
             ],
-            "time": "2020-03-25T19:55:28+00:00"
+            "time": "2020-04-24T13:39:56+00:00"
         },
         {
             "name": "league/event",
@@ -1554,16 +1558,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.66",
+            "version": "1.0.67",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "021569195e15f8209b1c4bebb78bd66aa4f08c21"
+                "reference": "5b1f36c75c4bdde981294c2a0ebdb437ee6f275e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/021569195e15f8209b1c4bebb78bd66aa4f08c21",
-                "reference": "021569195e15f8209b1c4bebb78bd66aa4f08c21",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/5b1f36c75c4bdde981294c2a0ebdb437ee6f275e",
+                "reference": "5b1f36c75c4bdde981294c2a0ebdb437ee6f275e",
                 "shasum": ""
             },
             "require": {
@@ -1634,7 +1638,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2020-03-17T18:58:12+00:00"
+            "time": "2020-04-16T13:21:26+00:00"
         },
         {
             "name": "league/oauth2-server",
@@ -1867,16 +1871,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.3.0",
+            "version": "v4.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
+                "reference": "bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120",
+                "reference": "bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120",
                 "shasum": ""
             },
             "require": {
@@ -1915,7 +1919,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-11-08T13:50:10+00:00"
+            "time": "2020-04-10T16:34:50+00:00"
         },
         {
             "name": "opis/closure",
@@ -2080,16 +2084,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.26",
+            "version": "2.0.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "09655fcc1f8bab65727be036b28f6f20311c126c"
+                "reference": "34620af4df7d1988d8f0d7e91f6c8a3bf931d8dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/09655fcc1f8bab65727be036b28f6f20311c126c",
-                "reference": "09655fcc1f8bab65727be036b28f6f20311c126c",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/34620af4df7d1988d8f0d7e91f6c8a3bf931d8dc",
+                "reference": "34620af4df7d1988d8f0d7e91f6c8a3bf931d8dc",
                 "shasum": ""
             },
             "require": {
@@ -2168,7 +2172,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2020-03-13T04:15:39+00:00"
+            "time": "2020-04-04T23:17:33+00:00"
         },
         {
             "name": "psr/container",
@@ -2681,7 +2685,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -2757,7 +2761,7 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.0.7",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -2810,7 +2814,7 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -2866,7 +2870,7 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
@@ -2922,7 +2926,7 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
@@ -3050,7 +3054,7 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -3099,16 +3103,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "62f92509c9abfd1f73e17b8cf1b72c0bdac6611b"
+                "reference": "ec5bd254c223786f5fa2bb49a1e705c1b8e7cee2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/62f92509c9abfd1f73e17b8cf1b72c0bdac6611b",
-                "reference": "62f92509c9abfd1f73e17b8cf1b72c0bdac6611b",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/ec5bd254c223786f5fa2bb49a1e705c1b8e7cee2",
+                "reference": "ec5bd254c223786f5fa2bb49a1e705c1b8e7cee2",
                 "shasum": ""
             },
             "require": {
@@ -3150,20 +3154,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2020-03-30T14:07:33+00:00"
+            "time": "2020-04-18T20:40:08+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "f356a489e51856b99908005eb7f2c51a1dfc95dc"
+                "reference": "1799a6c01f0db5851f399151abdb5d6393fec277"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/f356a489e51856b99908005eb7f2c51a1dfc95dc",
-                "reference": "f356a489e51856b99908005eb7f2c51a1dfc95dc",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/1799a6c01f0db5851f399151abdb5d6393fec277",
+                "reference": "1799a6c01f0db5851f399151abdb5d6393fec277",
                 "shasum": ""
             },
             "require": {
@@ -3240,20 +3244,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2020-03-30T14:59:15+00:00"
+            "time": "2020-04-28T18:47:42+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v5.0.7",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "481b7d6da88922fb1e0d86a943987722b08f3955"
+                "reference": "5d6c81c39225a750f3f43bee15f03093fb9aaa0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/481b7d6da88922fb1e0d86a943987722b08f3955",
-                "reference": "481b7d6da88922fb1e0d86a943987722b08f3955",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/5d6c81c39225a750f3f43bee15f03093fb9aaa0b",
+                "reference": "5d6c81c39225a750f3f43bee15f03093fb9aaa0b",
                 "shasum": ""
             },
             "require": {
@@ -3302,7 +3306,7 @@
                 "mime",
                 "mime-type"
             ],
-            "time": "2020-03-27T16:56:45+00:00"
+            "time": "2020-04-17T03:29:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3657,16 +3661,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "3e40e87a20eaf83a1db825e1fa5097ae89042db3"
+                "reference": "4b6a9a4013baa65d409153cbb5a895bf093dc7f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/3e40e87a20eaf83a1db825e1fa5097ae89042db3",
-                "reference": "3e40e87a20eaf83a1db825e1fa5097ae89042db3",
+                "url": "https://api.github.com/repos/symfony/process/zipball/4b6a9a4013baa65d409153cbb5a895bf093dc7f4",
+                "reference": "4b6a9a4013baa65d409153cbb5a895bf093dc7f4",
                 "shasum": ""
             },
             "require": {
@@ -3702,7 +3706,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2020-03-27T16:54:36+00:00"
+            "time": "2020-04-15T15:56:18+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -3771,16 +3775,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "0f562fa613e288d7dbae6c63abbc9b33ed75a8f8"
+                "reference": "67b4e1f99c050cbc310b8f3d0dbdc4b0212c052c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/0f562fa613e288d7dbae6c63abbc9b33ed75a8f8",
-                "reference": "0f562fa613e288d7dbae6c63abbc9b33ed75a8f8",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/67b4e1f99c050cbc310b8f3d0dbdc4b0212c052c",
+                "reference": "67b4e1f99c050cbc310b8f3d0dbdc4b0212c052c",
                 "shasum": ""
             },
             "require": {
@@ -3843,7 +3847,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2020-03-30T11:41:10+00:00"
+            "time": "2020-04-21T19:59:53+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3905,16 +3909,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "4e54d336f2eca5facad449d0b0118bb449375b76"
+                "reference": "8272bbd2b7e220ef812eba2a2b30068a5c64b191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/4e54d336f2eca5facad449d0b0118bb449375b76",
-                "reference": "4e54d336f2eca5facad449d0b0118bb449375b76",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/8272bbd2b7e220ef812eba2a2b30068a5c64b191",
+                "reference": "8272bbd2b7e220ef812eba2a2b30068a5c64b191",
                 "shasum": ""
             },
             "require": {
@@ -3977,7 +3981,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2020-03-27T16:54:36+00:00"
+            "time": "2020-04-12T16:45:36+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -4038,16 +4042,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "5a0c2d93006131a36cf6f767d10e2ca8333b0d4a"
+                "reference": "c587e04ce5d1aa62d534a038f574d9a709e814cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/5a0c2d93006131a36cf6f767d10e2ca8333b0d4a",
-                "reference": "5a0c2d93006131a36cf6f767d10e2ca8333b0d4a",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c587e04ce5d1aa62d534a038f574d9a709e814cf",
+                "reference": "c587e04ce5d1aa62d534a038f574d9a709e814cf",
                 "shasum": ""
             },
             "require": {
@@ -4110,7 +4114,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2020-03-27T16:54:36+00:00"
+            "time": "2020-04-12T16:14:02+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -4163,16 +4167,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v3.6.2",
+            "version": "v3.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "786a947e57086cf236cefdee80784634224b99fa"
+                "reference": "1b3103013797f04521c6cae5560f604649484066"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/786a947e57086cf236cefdee80784634224b99fa",
-                "reference": "786a947e57086cf236cefdee80784634224b99fa",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/1b3103013797f04521c6cae5560f604649484066",
+                "reference": "1b3103013797f04521c6cae5560f604649484066",
                 "shasum": ""
             },
             "require": {
@@ -4222,7 +4226,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2020-03-27T23:36:02+00:00"
+            "time": "2020-04-12T15:18:03+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -4790,23 +4794,20 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
@@ -4838,7 +4839,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2018-08-07T13:53:10+00:00"
+            "time": "2020-04-27T09:25:28+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -5946,16 +5947,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
                 "shasum": ""
             },
             "require": {
@@ -5963,7 +5964,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "vimeo/psalm": "<3.6.0"
+                "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
@@ -5990,7 +5991,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-02-14T12:15:55+00:00"
+            "time": "2020-04-18T12:12:48+00:00"
         }
     ],
     "aliases": [],

--- a/config/api/app/version.php
+++ b/config/api/app/version.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 return [
-    'version'=> '2.10.1',
+    'version'=> '2.10.2',
     'prefix' => 'v2',
-    'release_date' => '2020-04-03',
+    'release_date' => '2020-04-30',
     'changelog' => [
         'api' => '/v2/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/config/api/category/fields-patch.php
+++ b/config/api/category/fields-patch.php
@@ -19,9 +19,6 @@ return [
         'title' => 'category/fields.title-description',
         'description' => 'category/fields.description-description',
         'type' => 'string',
-        'validation' => [
-            'max-length' => 255
-        ],
         'required' => false
     ]
 ];

--- a/config/api/category/fields.php
+++ b/config/api/category/fields.php
@@ -19,9 +19,6 @@ return [
         'title' => 'category/fields.title-description',
         'description' => 'category/fields.description-description',
         'type' => 'string',
-        'validation' => [
-            'max-length' => 255
-        ],
         'required' => true
     ]
 ];

--- a/config/api/category/validation.php
+++ b/config/api/category/validation.php
@@ -18,8 +18,7 @@ return [
         'fields' => [
             'description' => [
                 'sometimes',
-                'string',
-                'max:255'
+                'string'
             ]
         ],
         'messages' => [

--- a/config/api/item-type-allocated-expense/fields.php
+++ b/config/api/item-type-allocated-expense/fields.php
@@ -18,9 +18,6 @@ return [
         'title' => 'item-type-allocated-expense/fields.title-description',
         'description' => 'item-type-allocated-expense/fields.description-description',
         'type' => 'string',
-        'validation' => [
-            'max-length' => 255
-        ],
         'required' => false
     ],
     'effective_date' => [

--- a/config/api/item-type-allocated-expense/validation.php
+++ b/config/api/item-type-allocated-expense/validation.php
@@ -12,8 +12,7 @@ return [
             ],
             'description' => [
                 'sometimes',
-                'string',
-                'max:255'
+                'string'
             ],
             'effective_date' => [
                 'required',
@@ -49,8 +48,7 @@ return [
             'description' => [
                 'sometimes',
                 'nullable',
-                'string',
-                'max:255'
+                'string'
             ],
             'effective_date' => [
                 'sometimes',

--- a/config/api/item-type-simple-expense/fields.php
+++ b/config/api/item-type-simple-expense/fields.php
@@ -18,9 +18,6 @@ return [
         'title' => 'item-type-simple-expense/fields.title-description',
         'description' => 'item-type-simple-expense/fields.description-description',
         'type' => 'string',
-        'validation' => [
-            'max-length' => 255
-        ],
         'required' => false
     ],
     'total' => [

--- a/config/api/item-type-simple-expense/validation.php
+++ b/config/api/item-type-simple-expense/validation.php
@@ -12,8 +12,7 @@ return [
             ],
             'description' => [
                 'sometimes',
-                'string',
-                'max:255'
+                'string'
             ],
             'total' => [
                 'required',
@@ -35,8 +34,7 @@ return [
             'description' => [
                 'sometimes',
                 'nullable',
-                'string',
-                'max:255'
+                'string'
             ],
             'total' => [
                 'sometimes',

--- a/config/api/item-type-simple-item/fields.php
+++ b/config/api/item-type-simple-item/fields.php
@@ -18,9 +18,6 @@ return [
         'title' => 'item-type-simple-item/fields.title-description',
         'description' => 'item-type-simple-item/fields.description-description',
         'type' => 'string',
-        'validation' => [
-            'max-length' => 255
-        ],
         'required' => false
     ],
     'quantity' => [

--- a/config/api/item-type-simple-item/validation.php
+++ b/config/api/item-type-simple-item/validation.php
@@ -12,8 +12,7 @@ return [
             ],
             'description' => [
                 'sometimes',
-                'string',
-                'max:255'
+                'string'
             ],
             'quantity' => [
                 'required',
@@ -32,8 +31,7 @@ return [
             'description' => [
                 'sometimes',
                 'nullable',
-                'string',
-                'max:255',
+                'string'
             ],
             'quantity' => [
                 'sometimes',

--- a/config/api/resource-type/fields-patch.php
+++ b/config/api/resource-type/fields-patch.php
@@ -18,9 +18,6 @@ return [
         'title' => 'resource-type/fields.title-description',
         'description' => 'resource-type/fields.description-description',
         'type' => 'string',
-        'validation' => [
-            'max-length' => 255
-        ],
         'required' => true
     ],
     'public' => [

--- a/config/api/resource-type/fields-patch.php
+++ b/config/api/resource-type/fields-patch.php
@@ -28,6 +28,6 @@ return [
         'title' => 'resource-type/fields.title-public',
         'description' => 'resource-type/fields.description-public',
         'type' => 'boolean',
-        'required' => true
+        'required' => false
     ]
 ];

--- a/config/api/resource-type/fields.php
+++ b/config/api/resource-type/fields.php
@@ -18,9 +18,6 @@ return [
         'title' => 'resource-type/fields.title-description',
         'description' => 'resource-type/fields.description-description',
         'type' => 'string',
-        'validation' => [
-            'max-length' => 255
-        ],
         'required' => true
     ],
     'item_type_id' => [

--- a/config/api/resource-type/fields.php
+++ b/config/api/resource-type/fields.php
@@ -38,6 +38,6 @@ return [
         'title' => 'resource-type/fields.title-public',
         'description' => 'resource-type/fields.description-public',
         'type' => 'boolean',
-        'required' => true
+        'required' => false
     ]
 ];

--- a/config/api/resource-type/validation.php
+++ b/config/api/resource-type/validation.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 return [
     'POST' => [
         'fields' => [
-            'description' => 'required|string|max:255',
+            'description' => 'required|string',
             'public' => 'sometimes|boolean'
         ],
         'messages' => [
@@ -16,8 +16,7 @@ return [
         'fields' => [
             'description' => [
                 'sometimes',
-                'string',
-                'max:255'
+                'string'
             ],
             'public' => 'sometimes|boolean'
         ],

--- a/config/api/resource/fields.php
+++ b/config/api/resource/fields.php
@@ -19,9 +19,6 @@ return [
         'title' => 'resource/fields.title-description',
         'description' => 'resource/fields.description-description',
         'type' => 'string',
-        'validation' => [
-            'max-length' => 255
-        ],
         'required' => true
     ],
     'effective_date' => [

--- a/config/api/resource/validation.php
+++ b/config/api/resource/validation.php
@@ -7,8 +7,7 @@ return [
         'fields' => [
             'description' => [
                 'required',
-                'string',
-                'max:255'
+                'string'
             ],
             'effective_date' => [
                 'required',
@@ -24,8 +23,7 @@ return [
         'fields' => [
             'description' => [
                 'sometimes',
-                'string',
-                'max:255'
+                'string'
             ],
             'effective_date' => [
                 'sometimes',

--- a/config/api/subcategory/fields.php
+++ b/config/api/subcategory/fields.php
@@ -19,9 +19,6 @@ return [
         'title' => 'subcategory/fields.title-description',
         'description' => 'subcategory/fields.description-description',
         'type' => 'string',
-        'validation' => [
-            'max-length' => 255
-        ],
         'required' => true
     ]
 ];

--- a/config/api/subcategory/validation.php
+++ b/config/api/subcategory/validation.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 return [
     'POST' => [
         'fields' => [
-            'description' => 'required|string|max:255'
+            'description' => 'required|string'
         ],
         'messages' => [
             'name.unique' => 'subcategory/validation.name-unique'
@@ -16,8 +16,7 @@ return [
             'description' =>
                 [
                     'sometimes',
-                    'string',
-                    'max:255'
+                    'string'
                 ]
         ],
         'messages' => [

--- a/database/migrations/2020_04_30_141648_add_detail_to_item_types_table.php
+++ b/database/migrations/2020_04_30_141648_add_detail_to_item_types_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDetailToItemTypesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('item_type', function (Blueprint $table) {
+            $table->string('example')->after('description')->nullable();
+            $table->string('friendly_name')->after('name')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('item_type', function (Blueprint $table) {
+            $table->dropColumn('example');
+            $table->dropColumn('friendly_name');
+        });
+    }
+}

--- a/database/migrations/2020_04_30_205957_update_decimal_fields.php
+++ b/database/migrations/2020_04_30_205957_update_decimal_fields.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateDecimalFields extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('item_type_allocated_expense', function (Blueprint $table) {
+            $table->decimal('total', 13, 2)->change();
+            $table->decimal('actualised_total', 13, 2)->change();
+        });
+
+        Schema::table('item_type_simple_expense', function (Blueprint $table) {
+            $table->decimal('total', 13, 2)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('item_type_allocated_expense', function (Blueprint $table) {
+            $table->decimal('total', 10, 2)->change();
+            $table->decimal('actualised_total', 10, 2)->change();
+        });
+
+        Schema::table('item_type_simple_expense', function (Blueprint $table) {
+            $table->decimal('total', 10, 2)->change();
+        });
+    }
+}

--- a/database/migrations/2020_04_30_213659_description_fields_text.php
+++ b/database/migrations/2020_04_30_213659_description_fields_text.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DescriptionFieldsText extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('category', function (Blueprint $table) {
+            $table->text('description')->change();
+        });
+
+        Schema::table('item_type_allocated_expense', function (Blueprint $table) {
+            $table->text('description')->nullable()->change();
+        });
+
+        Schema::table('item_type_simple_expense', function (Blueprint $table) {
+            $table->text('description')->nullable()->change();
+        });
+
+        Schema::table('item_type_simple_item', function (Blueprint $table) {
+            $table->text('description')->nullable()->change();
+        });
+
+        Schema::table('resource', function (Blueprint $table) {
+            $table->text('description')->change();
+        });
+
+        Schema::table('resource_type', function (Blueprint $table) {
+            $table->text('description')->change();
+        });
+
+        Schema::table('sub_category', function (Blueprint $table) {
+            $table->text('description')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('category', function (Blueprint $table) {
+            $table->string('description', 255)->change();
+        });
+
+        Schema::table('item_type_allocated_expense', function (Blueprint $table) {
+            $table->string('description')->nullable()->change();
+        });
+
+        Schema::table('item_type_simple_expense', function (Blueprint $table) {
+            $table->string('description')->nullable()->change();
+        });
+
+        Schema::table('item_type_simple_item', function (Blueprint $table) {
+            $table->string('description')->nullable()->change();
+        });
+
+        Schema::table('resource', function (Blueprint $table) {
+            $table->string('description')->change();
+        });
+
+        Schema::table('resource_type', function (Blueprint $table) {
+            $table->string('description')->change();
+        });
+
+        Schema::table('sub_category', function (Blueprint $table) {
+            $table->string('description')->change();
+        });
+    }
+}

--- a/public/package.json
+++ b/public/package.json
@@ -4,7 +4,7 @@
     "description": "The Costs to Expect API",
     "dependencies": {
         "bootstrap": "^4.3",
-        "jquery": "^3.4",
+        "jquery": "^3.5",
         "open-iconic": "^1.1.1",
         "popper.js": "^1.16"
     },

--- a/public/yarn.lock
+++ b/public/yarn.lock
@@ -7,10 +7,10 @@ bootstrap@^4.3:
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.4.1.tgz#8582960eea0c5cd2bede84d8b0baf3789c3e8b01"
   integrity sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA==
 
-jquery@^3.4:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+jquery@^3.5:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
+  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
 
 open-iconic@^1.1.1:
   version "1.1.1"

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -233,6 +233,13 @@
                         <li>We have renamed the third parameter of the route validation methods; we changed the name from `$manage` to `$write`.</li>
                         <li>We have renamed a response helper method; it was not clear from the name that the method is used for updates and delete.</li>
                         <li>We have tweaked our Docker setup to allow a local API and App/Website; the ports have been changed and a network has been created.</li>
+                        <li>We have updated all item endpoints to return `updated`; this is the date and time an item was updated, not its category assignments.</li>
+                        <li>We have updated item collection and show endpoints; we are going to allow the possibility of items not having categories and subcategories. When you add the `include-categories` and `include-subcategories` parameters to a request, we will not exclude items without category assignments.</li>
+                        <li>We have updated the API to the latest release of Laravel 7.</li>
+                        <li>We have updated the front end dependencies for the welcome page.</li>
+                        <li>We have updated the `item-types` route to show additional information on each tracking method.</li>
+                        <li>We have updated all decimal fields to 13,2 rather than 10,2.</li>
+                        <li>We have updated all description fields; we have switched all the description fields from varchar(255) to text.</li>
                     </ul>
 
                     <h3>Fixed</h3>
@@ -240,6 +247,10 @@
                     <ul>
                         <li>It is possible to set the quantity for a `simple-item` item as zero.</li>
                         <li>It is possible to clear optional values in a PATCH request.</li>
+                        <li>We have corrected a bad link on the landing page.</li>
+                        <li>We have corrected a typo on the landing page.</li>
+                        <li>We have switched the table we look at to return created at for an item; we should be using the sub table, not the base item table.</li>
+                        <li>We have corrected the `/resource-types/` OPTIONS request; `public` is not a required field.</li>
                     </ul>
                 </div>
             </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -71,7 +71,7 @@
         </div>
         <div class="col-xl-10 col-lg-9 col-md-9 container-right">
             <nav class="navbar navbar-light d-md-none">
-                <a class="navbar-brand" href="/dashboard">
+                <a class="navbar-brand" href="/">
                     <img src="https://app.costs-to-expect.com/images/theme/logo-100.png" width="32" height="32" alt="Costs to Expect Logo"
                          title="Back to the dashboard"/><span class="d-none">C</span>osts to Expect.com
                 </a>
@@ -178,7 +178,7 @@
                         </dt>
                         <dd class="col-sm-8 col-md-8 col-lg-9 col-xl-10"><p>Our <a href="https://app.costs-to-expect.com/">App</a> is the
                             commercial offering for Costs to Expect,
-                            we are <a href="https://app.costs-to-expect.com/roadmap">working</a> towards the public alpha, out aim is to make tracking and
+                            we are <a href="https://app.costs-to-expect.com/roadmap">working</a> towards the public alpha, our aim is to make tracking and
                                 forecasting expenses as simple as possible.</p></dd>
 
                         <dt class="col-sm-4 col-md-4 col-lg-3 col-xl-2">


### PR DESCRIPTION
## Changed
- We have updated all item endpoints to return `updated`; this is the date and time an item was updated, not its category assignments.
- We have updated item collection and show endpoints; we are going to allow the possibility of items not having categories and subcategories. When you add the `include-categories` and `include-subcategories` parameters to a request, we will not exclude items without category assignments.
- We have updated the API to the latest release of Laravel 7.
- We have updated the front end dependencies for the welcome page.
- We have updated the `item-types` route to show additional information on each tracking method.
- We have updated all decimal fields to 13,2 rather than 10,2.
- We have updated all description fields; we have switched all the description fields from varchar(255) to text.
## Fixed
- We have corrected a bad link on the landing page.
- We have corrected a typo on the landing page.
- We have switched the table we look at to return created at for an item; we should be using the sub table, not the base item table.
- We have corrected the `/resource-types/` OPTIONS request; `public` is not a required field.