### PR TITLE
v2.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 The complete changelog for the Costs to Expect REST API, our changelog follows the format defined at https://keepachangelog.com/en/1.0.0/
 
-## [2.11.1] - 2020-06-16
+## [v2.11.2] - 2020-06-17
+### Changed
+- We have split calls to clear public and private cache keys.
+- We only clear public cache keys when modifying a public resource type.
+- We have updated the web.config; the web.config file was referring to PHP7.3.
+- Added removed class type hints now that we are running PHP7.4.
+
+## [v2.11.1] - 2020-06-16
 ### Added 
 - We have added an application cache for collections; we include the ETag header however we are not yet returning a 304.
 

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -281,7 +281,7 @@ class CategoryController extends Controller
             ]);
             $category->save();
 
-            $cache_control->clearMatchingKeys([$cache_key->categories($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([$cache_key->categories($resource_type_id)]);
         } catch (Exception $e) {
            \App\Response\Responses::failedToSaveModelForCreate();
         }
@@ -317,7 +317,7 @@ class CategoryController extends Controller
 
         try {
             (new Category())->find($category_id)->delete();
-            $cache_control->clearMatchingKeys([$cache_key->categories($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([$cache_key->categories($resource_type_id)]);
 
             \App\Response\Responses::successNoContent();
         } catch (QueryException $e) {
@@ -375,7 +375,7 @@ class CategoryController extends Controller
         try {
             $category->save();
 
-            $cache_control->clearMatchingKeys([
+            $cache_control->clearPrivateCacheKeys([
                 // We need to clear categories, resource type items
                 // and items dur to includes so simpler to clear the entire
                 // resource type

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -29,7 +29,7 @@ use Illuminate\Support\Facades\Config;
  */
 class CategoryController extends Controller
 {
-    protected $allow_entire_collection = true;
+    protected bool $allow_entire_collection = true;
 
     /**
      * Return the categories collection
@@ -281,7 +281,15 @@ class CategoryController extends Controller
             ]);
             $category->save();
 
-            $cache_control->clearPrivateCacheKeys([$cache_key->categories($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([
+                $cache_key->categories($resource_type_id)
+            ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->categories($resource_type_id)
+                ]);
+            }
         } catch (Exception $e) {
            \App\Response\Responses::failedToSaveModelForCreate();
         }
@@ -317,7 +325,15 @@ class CategoryController extends Controller
 
         try {
             (new Category())->find($category_id)->delete();
-            $cache_control->clearPrivateCacheKeys([$cache_key->categories($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([
+                $cache_key->categories($resource_type_id)
+            ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->categories($resource_type_id)
+                ]);
+            }
 
             \App\Response\Responses::successNoContent();
         } catch (QueryException $e) {
@@ -377,10 +393,16 @@ class CategoryController extends Controller
 
             $cache_control->clearPrivateCacheKeys([
                 // We need to clear categories, resource type items
-                // and items dur to includes so simpler to clear the entire
+                // and items due to includes so simpler to clear the entire
                 // resource type
                 $cache_key->resourceType($resource_type_id)
             ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->resourceType($resource_type_id)
+                ]);
+            }
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForUpdate();
         }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ResourceType;
 use App\Models\ResourceTypeAccess;
 use App\Utilities\Hash;
 use Illuminate\Http\JsonResponse;
@@ -9,30 +10,23 @@ use Illuminate\Routing\Controller as BaseController;
 
 class Controller extends BaseController
 {
-    /**
-     * @var Hash
-     */
-    protected $hash;
+    protected Hash $hash;
 
-    /**
-     * @var boolean Include public content
-     */
-    protected $include_public;
+    protected bool $include_public;
 
-    /**
-     * @var array Permitted resource types
-     */
-    protected $permitted_resource_types = [];
+    protected array $permitted_resource_types = [];
+
+    protected array $public_resource_types = [];
 
     /**
      * @var integer|null
      */
-    protected $user_id = null;
+    protected ?int $user_id = null;
 
     /**
      * @var bool Allow the entire collection to be returned ignoring pagination
      */
-    protected $allow_entire_collection = false;
+    protected bool $allow_entire_collection = false;
 
     public function __construct()
     {
@@ -50,6 +44,7 @@ class Controller extends BaseController
         if (auth()->guard('api')->check() === true && auth('api')->user() !== null) {
             $this->user_id = auth('api')->user()->id;
             $this->permitted_resource_types = (new ResourceTypeAccess())->permittedResourceTypes($this->user_id);
+            $this->public_resource_types = (new ResourceType())->publicResourceTypes();
         }
 
         $this->include_public = true;

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -284,6 +284,13 @@ class ItemCategoryController extends Controller
                 $cache_key->items($resource_type_id, $resource_id),
                 $cache_key->resourceTypeItems($resource_type_id)
             ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->items($resource_type_id, $resource_id),
+                    $cache_key->resourceTypeItems($resource_type_id)
+                ]);
+            }
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForCreate();
         }
@@ -371,6 +378,13 @@ class ItemCategoryController extends Controller
                 $cache_key->items($resource_type_id, $resource_id),
                 $cache_key->resourceTypeItems($resource_type_id)
             ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->items($resource_type_id, $resource_id),
+                    $cache_key->resourceTypeItems($resource_type_id)
+                ]);
+            }
 
             \App\Response\Responses::successNoContent();
         } catch (QueryException $e) {

--- a/app/Http/Controllers/ItemCategoryController.php
+++ b/app/Http/Controllers/ItemCategoryController.php
@@ -280,7 +280,7 @@ class ItemCategoryController extends Controller
             ]);
             $item_category->save();
 
-            $cache_control->clearMatchingKeys([
+            $cache_control->clearPrivateCacheKeys([
                 $cache_key->items($resource_type_id, $resource_id),
                 $cache_key->resourceTypeItems($resource_type_id)
             ]);
@@ -367,7 +367,7 @@ class ItemCategoryController extends Controller
         try {
             (new ItemCategory())->find($item_category_id)->delete();
 
-            $cache_control->clearMatchingKeys([
+            $cache_control->clearPrivateCacheKeys([
                 $cache_key->items($resource_type_id, $resource_id),
                 $cache_key->resourceTypeItems($resource_type_id)
             ]);

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -353,7 +353,7 @@ class ItemController extends Controller
 
             $item_type = $item_interface->create((int) $item->id);
 
-            $cache_control->clearMatchingKeys([
+            $cache_control->clearPrivateCacheKeys([
                 $cache_key->resourceTypeItems($resource_type_id),
                 $cache_key->items($resource_type_id, $resource_id)
             ]);
@@ -420,7 +420,7 @@ class ItemController extends Controller
                 $item_interface->update(request()->all(), $item_type);
             }
 
-            $cache_control->clearMatchingKeys([
+            $cache_control->clearPrivateCacheKeys([
                 $cache_key->resourceTypeItems($resource_type_id),
                 $cache_key->items($resource_type_id, $resource_id)
             ]);
@@ -477,7 +477,7 @@ class ItemController extends Controller
             $item_type->delete();
             $item->delete();
 
-            $cache_control->clearMatchingKeys([
+            $cache_control->clearPrivateCacheKeys([
                 $cache_key->resourceTypeItems($resource_type_id),
                 $cache_key->items($resource_type_id, $resource_id)
             ]);

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -358,6 +358,13 @@ class ItemController extends Controller
                 $cache_key->items($resource_type_id, $resource_id)
             ]);
 
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->resourceTypeItems($resource_type_id),
+                    $cache_key->items($resource_type_id, $resource_id)
+                ]);
+            }
+
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForCreate();
         }
@@ -424,6 +431,13 @@ class ItemController extends Controller
                 $cache_key->resourceTypeItems($resource_type_id),
                 $cache_key->items($resource_type_id, $resource_id)
             ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->resourceTypeItems($resource_type_id),
+                    $cache_key->items($resource_type_id, $resource_id)
+                ]);
+            }
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForUpdate();
         }
@@ -481,6 +495,13 @@ class ItemController extends Controller
                 $cache_key->resourceTypeItems($resource_type_id),
                 $cache_key->items($resource_type_id, $resource_id)
             ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->resourceTypeItems($resource_type_id),
+                    $cache_key->items($resource_type_id, $resource_id)
+                ]);
+            }
 
             \App\Response\Responses::successNoContent();
         } catch (QueryException $e) {

--- a/app/Http/Controllers/ItemPartialTransferController.php
+++ b/app/Http/Controllers/ItemPartialTransferController.php
@@ -125,7 +125,16 @@ class ItemPartialTransferController extends Controller
 
             if ($partial_transfer !== null) {
                 $partial_transfer->delete();
-                $cache_control->clearPrivateCacheKeys([$cache_key->partialTransfers($resource_type_id)]);
+
+                $cache_control->clearPrivateCacheKeys([
+                    $cache_key->partialTransfers($resource_type_id)
+                ]);
+
+                if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                    $cache_control->clearPublicCacheKeys([
+                        $cache_key->partialTransfers($resource_type_id)
+                    ]);
+                }
 
                 return \App\Response\Responses::successNoContent();
             }
@@ -219,7 +228,15 @@ class ItemPartialTransferController extends Controller
             ]);
             $partial_transfer->save();
 
-            $cache_control->clearPrivateCacheKeys([$cache_key->partialTransfers($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([
+                $cache_key->partialTransfers($resource_type_id)
+            ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->partialTransfers($resource_type_id)
+                ]);
+            }
         } catch (QueryException $e) {
             return \App\Response\Responses::foreignKeyConstraintError();
         } catch (Exception $e) {

--- a/app/Http/Controllers/ItemPartialTransferController.php
+++ b/app/Http/Controllers/ItemPartialTransferController.php
@@ -125,7 +125,7 @@ class ItemPartialTransferController extends Controller
 
             if ($partial_transfer !== null) {
                 $partial_transfer->delete();
-                $cache_control->clearMatchingKeys([$cache_key->partialTransfers($resource_type_id)]);
+                $cache_control->clearPrivateCacheKeys([$cache_key->partialTransfers($resource_type_id)]);
 
                 return \App\Response\Responses::successNoContent();
             }
@@ -219,7 +219,7 @@ class ItemPartialTransferController extends Controller
             ]);
             $partial_transfer->save();
 
-            $cache_control->clearMatchingKeys([$cache_key->partialTransfers($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([$cache_key->partialTransfers($resource_type_id)]);
         } catch (QueryException $e) {
             return \App\Response\Responses::foreignKeyConstraintError();
         } catch (Exception $e) {

--- a/app/Http/Controllers/ItemSubcategoryController.php
+++ b/app/Http/Controllers/ItemSubcategoryController.php
@@ -318,7 +318,7 @@ class ItemSubcategoryController extends Controller
             ]);
             $item_sub_category->save();
 
-            $cache_control->clearMatchingKeys([
+            $cache_control->clearPrivateCacheKeys([
                 $cache_key->items($resource_type_id, $resource_id),
                 $cache_key->resourceTypeItems($resource_type_id)
             ]);
@@ -416,7 +416,7 @@ class ItemSubcategoryController extends Controller
         try {
             (new ItemSubcategory())->find($item_subcategory_id)->delete();
 
-            $cache_control->clearMatchingKeys([
+            $cache_control->clearPrivateCacheKeys([
                 $cache_key->items($resource_type_id, $resource_id),
                 $cache_key->resourceTypeItems($resource_type_id)
             ]);

--- a/app/Http/Controllers/ItemSubcategoryController.php
+++ b/app/Http/Controllers/ItemSubcategoryController.php
@@ -322,6 +322,13 @@ class ItemSubcategoryController extends Controller
                 $cache_key->items($resource_type_id, $resource_id),
                 $cache_key->resourceTypeItems($resource_type_id)
             ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->items($resource_type_id, $resource_id),
+                    $cache_key->resourceTypeItems($resource_type_id)
+                ]);
+            }
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForCreate();
         }
@@ -420,6 +427,13 @@ class ItemSubcategoryController extends Controller
                 $cache_key->items($resource_type_id, $resource_id),
                 $cache_key->resourceTypeItems($resource_type_id)
             ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->items($resource_type_id, $resource_id),
+                    $cache_key->resourceTypeItems($resource_type_id)
+                ]);
+            }
 
             \App\Response\Responses::successNoContent();
         } catch (QueryException $e) {

--- a/app/Http/Controllers/ItemTransferController.php
+++ b/app/Http/Controllers/ItemTransferController.php
@@ -283,7 +283,15 @@ class ItemTransferController extends Controller
             ]);
             $item_transfer->save();
 
-            $cache_control->clearPrivateCacheKeys([$cache_key->transfers($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([
+                $cache_key->transfers($resource_type_id)
+            ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->transfers($resource_type_id)
+                ]);
+            }
         } catch (QueryException $e) {
             return \App\Response\Responses::foreignKeyConstraintError();
         } catch (Exception $e) {

--- a/app/Http/Controllers/ItemTransferController.php
+++ b/app/Http/Controllers/ItemTransferController.php
@@ -283,7 +283,7 @@ class ItemTransferController extends Controller
             ]);
             $item_transfer->save();
 
-            $cache_control->clearMatchingKeys([$cache_key->transfers($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([$cache_key->transfers($resource_type_id)]);
         } catch (QueryException $e) {
             return \App\Response\Responses::foreignKeyConstraintError();
         } catch (Exception $e) {

--- a/app/Http/Controllers/ItemTypeController.php
+++ b/app/Http/Controllers/ItemTypeController.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Facades\Config;
  */
 class ItemTypeController extends Controller
 {
-    protected $allow_entire_collection = true;
+    protected bool $allow_entire_collection = true;
 
     /**
      * Return all the item types

--- a/app/Http/Controllers/PermittedUserController.php
+++ b/app/Http/Controllers/PermittedUserController.php
@@ -24,7 +24,7 @@ use Illuminate\Support\Facades\Config;
  */
 class PermittedUserController extends Controller
 {
-    protected $allow_entire_collection = true;
+    protected bool $allow_entire_collection = true;
 
     /**
      * Return all the permitted users for the given resource type

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -270,7 +270,7 @@ class ResourceController extends Controller
             ]);
             $resource->save();
 
-            $cache_control->clearMatchingKeys([$cache_key->resourceType($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([$cache_key->resourceType($resource_type_id)]);
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForCreate();
         }
@@ -307,7 +307,7 @@ class ResourceController extends Controller
         try {
             (new Resource())->find($resource_id)->delete();
 
-            $cache_control->clearMatchingKeys([$cache_key->resourceType($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([$cache_key->resourceType($resource_type_id)]);
 
             \App\Response\Responses::successNoContent();
         } catch (QueryException $e) {
@@ -368,7 +368,7 @@ class ResourceController extends Controller
         try {
             $resource->save();
 
-            $cache_control->clearMatchingKeys([$cache_key->resourceType($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([$cache_key->resourceType($resource_type_id)]);
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForUpdate();
         }

--- a/app/Http/Controllers/ResourceController.php
+++ b/app/Http/Controllers/ResourceController.php
@@ -30,7 +30,7 @@ use Illuminate\Support\Facades\Config;
  */
 class ResourceController extends Controller
 {
-    protected $allow_entire_collection = true;
+    protected bool $allow_entire_collection = true;
 
     /**
      * Return all the resources
@@ -270,7 +270,15 @@ class ResourceController extends Controller
             ]);
             $resource->save();
 
-            $cache_control->clearPrivateCacheKeys([$cache_key->resourceType($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([
+                $cache_key->resourceType($resource_type_id)
+            ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->resourceType($resource_type_id)
+                ]);
+            }
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForCreate();
         }
@@ -307,7 +315,15 @@ class ResourceController extends Controller
         try {
             (new Resource())->find($resource_id)->delete();
 
-            $cache_control->clearPrivateCacheKeys([$cache_key->resourceType($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([
+                $cache_key->resourceType($resource_type_id)
+            ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->resourceType($resource_type_id)
+                ]);
+            }
 
             \App\Response\Responses::successNoContent();
         } catch (QueryException $e) {
@@ -368,7 +384,15 @@ class ResourceController extends Controller
         try {
             $resource->save();
 
-            $cache_control->clearPrivateCacheKeys([$cache_key->resourceType($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([
+                $cache_key->resourceType($resource_type_id)
+            ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->resourceType($resource_type_id)
+                ]);
+            }
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForUpdate();
         }

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -34,7 +34,7 @@ use Illuminate\Support\Facades\Config;
  */
 class ResourceTypeController extends Controller
 {
-    protected $allow_entire_collection = true;
+    protected bool $allow_entire_collection = true;
 
     /**
      * Return all the resource types
@@ -264,7 +264,15 @@ class ResourceTypeController extends Controller
             ]);
             $resource_type_item_type->save();
 
-            $cache_control->clearPrivateCacheKeys([$cache_key->resourcesTypes()]);
+            $cache_control->clearPrivateCacheKeys([
+                $cache_key->resourcesTypes()
+            ]);
+
+            if (request()->input('public', 0) !== 0) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->resourcesTypes()
+                ]);
+            }
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForCreate();
         }
@@ -330,6 +338,13 @@ class ResourceTypeController extends Controller
                     $cache_key->permittedUsers($resource_type_id)
                 ]);
 
+                if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                    $cache_control->clearPublicCacheKeys([
+                        $cache_key->resourcesTypes(),
+                        $cache_key->permittedUsers($resource_type_id)
+                    ]);
+                }
+
                 \App\Response\Responses::successNoContent();
             } catch (QueryException $e) {
                 \App\Response\Responses::foreignKeyConstraintError();
@@ -390,7 +405,15 @@ class ResourceTypeController extends Controller
 
         try {
             $resource_type->save();
-            $cache_control->clearPrivateCacheKeys([$cache_key->resourcesTypes()]);
+            $cache_control->clearPrivateCacheKeys([
+                $cache_key->resourcesTypes()
+            ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->resourcesTypes()
+                ]);
+            }
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForUpdate();
         }

--- a/app/Http/Controllers/ResourceTypeController.php
+++ b/app/Http/Controllers/ResourceTypeController.php
@@ -264,7 +264,7 @@ class ResourceTypeController extends Controller
             ]);
             $resource_type_item_type->save();
 
-            $cache_control->clearMatchingKeys([$cache_key->resourcesTypes()]);
+            $cache_control->clearPrivateCacheKeys([$cache_key->resourcesTypes()]);
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForCreate();
         }
@@ -325,7 +325,7 @@ class ResourceTypeController extends Controller
                 $permitted_user->delete();
                 $resource_type->delete();
 
-                $cache_control->clearMatchingKeys([
+                $cache_control->clearPrivateCacheKeys([
                     $cache_key->resourcesTypes(),
                     $cache_key->permittedUsers($resource_type_id)
                 ]);
@@ -390,7 +390,7 @@ class ResourceTypeController extends Controller
 
         try {
             $resource_type->save();
-            $cache_control->clearMatchingKeys([$cache_key->resourcesTypes()]);
+            $cache_control->clearPrivateCacheKeys([$cache_key->resourcesTypes()]);
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForUpdate();
         }

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -280,7 +280,7 @@ class SubcategoryController extends Controller
             ]);
             $sub_category->save();
 
-            $cache_control->clearMatchingKeys([$cache_key->categories($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([$cache_key->categories($resource_type_id)]);
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForCreate();
         }
@@ -329,7 +329,7 @@ class SubcategoryController extends Controller
         try {
             $sub_category->delete();
 
-            $cache_control->clearMatchingKeys([$cache_key->categories($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([$cache_key->categories($resource_type_id)]);
 
             \App\Response\Responses::successNoContent();
         } catch (QueryException $e) {
@@ -393,7 +393,7 @@ class SubcategoryController extends Controller
         try {
             $subcategory->save();
 
-            $cache_control->clearMatchingKeys([
+            $cache_control->clearPrivateCacheKeys([
                 // We need to clear subcategories, resource type items
                 // and items dur to includes so simpler to clear the entire
                 // resource type

--- a/app/Http/Controllers/SubcategoryController.php
+++ b/app/Http/Controllers/SubcategoryController.php
@@ -30,7 +30,7 @@ use Illuminate\Support\Facades\Config;
  */
 class SubcategoryController extends Controller
 {
-    protected $allow_entire_collection = true;
+    protected bool $allow_entire_collection = true;
 
     /**
      * Return all the sub categories assigned to the given category
@@ -280,7 +280,15 @@ class SubcategoryController extends Controller
             ]);
             $sub_category->save();
 
-            $cache_control->clearPrivateCacheKeys([$cache_key->categories($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([
+                $cache_key->categories($resource_type_id)
+            ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->categories($resource_type_id)
+                ]);
+            }
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForCreate();
         }
@@ -329,7 +337,15 @@ class SubcategoryController extends Controller
         try {
             $sub_category->delete();
 
-            $cache_control->clearPrivateCacheKeys([$cache_key->categories($resource_type_id)]);
+            $cache_control->clearPrivateCacheKeys([
+                $cache_key->categories($resource_type_id)
+            ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->categories($resource_type_id)
+                ]);
+            }
 
             \App\Response\Responses::successNoContent();
         } catch (QueryException $e) {
@@ -399,6 +415,12 @@ class SubcategoryController extends Controller
                 // resource type
                 $cache_key->resourceType($resource_type_id)
             ]);
+
+            if (in_array($resource_type_id, $this->public_resource_types, true)) {
+                $cache_control->clearPublicCacheKeys([
+                    $cache_key->resourceType($resource_type_id)
+                ]);
+            }
         } catch (Exception $e) {
             \App\Response\Responses::failedToSaveModelForUpdate();
         }

--- a/app/Models/Cache.php
+++ b/app/Models/Cache.php
@@ -37,7 +37,7 @@ class Cache extends Model
         bool $include_summaries = false
     ): array
     {
-        $result = $this->where('key', '=', $prefix . $key . '%')->
+        $result = $this->where('key', 'LIKE', $prefix . $key . '%')->
             orWhere('key', '=', $prefix . $key);
 
         if ($include_summaries === true) {

--- a/app/Models/Cache.php
+++ b/app/Models/Cache.php
@@ -21,39 +21,28 @@ class Cache extends Model
     protected $guarded = ['key', 'value', 'expiration'];
 
     /**
-     * Fetch all the matching cache keys that are a wildcard match for the
-     * given key prefix, we look for private and public vrsions of the cache
+     * Fetch all the matching private cache keys that are a match or wildcard
+     * match for the given key and prefix, optionally we can fetch summary
+     * cache keys
      *
-     * @param string $public_prefix
-     * @param string $key_wildcard
-     * @param string|null $private_prefix
+     * @param string $prefix
+     * @param string $key
      * @param bool $include_summaries
      *
      * @return array
      */
     public function matchingKeys(
-        string $public_prefix,
-        string $key_wildcard,
-        string $private_prefix = null,
+        string $prefix,
+        string $key,
         bool $include_summaries = false
     ): array
     {
-        $result = $this->where('key', 'LIKE', $public_prefix . $key_wildcard . '%')->
-            orWhere('key', '=', $public_prefix . $key_wildcard);
-
-        if ($private_prefix !== null) {
-            $result->orWhere('key', 'LIKE', $private_prefix . $key_wildcard . '%')->
-                orWhere('key', '=', $private_prefix . $key_wildcard);
-        }
+        $result = $this->where('key', '=', $prefix . $key . '%')->
+            orWhere('key', '=', $prefix . $key);
 
         if ($include_summaries === true) {
-            $result->orWhere('key', 'LIKE', str_replace('v2/', 'v2/summary/', $public_prefix . $key_wildcard) . '%')->
-                orWhere('key', '=', str_replace('v2/', 'v2/summary/', $public_prefix . $key_wildcard));
-
-            if ($private_prefix !== null) {
-                $result->orWhere('key', 'LIKE', str_replace('v2/', 'v2/summary/', $private_prefix . $key_wildcard) . '%')
-                    ->orWhere('key', '=', str_replace('v2/', 'v2/summary/', $private_prefix . $key_wildcard));
-            }
+            $result->orWhere('key', 'LIKE', str_replace('v2/', 'v2/summary/', $prefix . $key) . '%')->
+                orWhere('key', '=', str_replace('v2/', 'v2/summary/', $prefix . $key));
         }
 
         return $result->select('key')->

--- a/app/Models/ResourceType.php
+++ b/app/Models/ResourceType.php
@@ -33,6 +33,27 @@ class ResourceType extends Model
     }
 
     /**
+     * Fetch all the public resource types
+     *
+     * @return array
+     */
+    public function publicResourceTypes(): array
+    {
+        $public = [];
+
+        $results = $this->where('public', '=', 1)->
+            select('id')->
+            get()->
+            toArray();
+
+        foreach ($results as $row) {
+            $public[] = (int) $row['id'];
+        }
+
+        return $public;
+    }
+
+    /**
      * Return the total number of resource types
      *
      * @param array $permitted_resource_types

--- a/app/Request/Parameter/Filter.php
+++ b/app/Request/Parameter/Filter.php
@@ -15,7 +15,7 @@ use DateTime;
  */
 class Filter
 {
-    private static $parameters = [];
+    private static array $parameters = [];
 
     /**
      * Check the URI for the filter parameter, if the format is valid split the

--- a/app/Request/Parameter/Request.php
+++ b/app/Request/Parameter/Request.php
@@ -20,7 +20,7 @@ use App\Utilities\General;
  */
 class Request
 {
-    private static $parameters = [];
+    private static array $parameters = [];
 
     /**
      * Fetch any GET parameters from the URI and alter the type if necessary

--- a/app/Request/Parameter/Search.php
+++ b/app/Request/Parameter/Search.php
@@ -12,7 +12,7 @@ namespace App\Request\Parameter;
  */
 class Search
 {
-    private static $fields = [];
+    private static array $fields = [];
 
     /**
      * Check the URI for the search parameter, if the format is valid split the

--- a/app/Request/Parameter/Sort.php
+++ b/app/Request/Parameter/Sort.php
@@ -12,7 +12,7 @@ namespace App\Request\Parameter;
  */
 class Sort
 {
-    private static $fields = [];
+    private static array $fields = [];
 
     /**
      * Check the URI for the sort parameter, if the format is valid split the

--- a/app/Response/Cache/Collection.php
+++ b/app/Response/Cache/Collection.php
@@ -14,11 +14,11 @@ namespace App\Response\Cache;
  */
 class Collection
 {
-    private $cached;
-    private $collection;
-    private $headers;
-    private $pagination;
-    private $total;
+    private bool $cached;
+    private array $collection;
+    private array $headers;
+    private array $pagination;
+    private int $total;
 
     /**
      * Create a cache response object

--- a/app/Response/Cache/Control.php
+++ b/app/Response/Cache/Control.php
@@ -233,7 +233,7 @@ class Control
     {
         if ($this->key_prefix_private !== null) {
             return (new \App\Models\Cache())->matchingKeys(
-                $this->key_prefix_private,
+                Config::get('cache.prefix') . $this->key_prefix_private,
                 $key_wildcard,
                 $include_summaries
             );
@@ -256,7 +256,7 @@ class Control
     ): array
     {
         return (new \App\Models\Cache())->matchingKeys(
-            $this->key_prefix_public,
+            Config::get('cache.prefix') . $this->key_prefix_public,
             $key_wildcard,
             $include_summaries
         );

--- a/app/Response/Cache/Control.php
+++ b/app/Response/Cache/Control.php
@@ -16,14 +16,14 @@ use Illuminate\Support\Facades\Config;
  */
 class Control
 {
-    private $cacheable = false;
+    private bool $cacheable = false;
 
-    private $key_prefix_private;
-    private $key_prefix_public;
+    private ?string $key_prefix_private;
+    private string $key_prefix_public;
 
-    private $ttl;
+    private int $ttl;
 
-    private $visibility = 'public';
+    private string $visibility = 'public';
 
     /**
      * Create an instance of the cache class. The prefix needs to be a
@@ -82,13 +82,34 @@ class Control
      * @param array $key_wildcards
      * @param bool $include_summaries
      */
-    public function clearMatchingKeys(
+    public function clearPublicCacheKeys(
         array $key_wildcards,
         bool $include_summaries = true
     ): void
     {
         foreach ($key_wildcards as $key_wildcard) {
-            $keys = $this->matchingKeys($key_wildcard, $include_summaries);
+            $keys = $this->matchingPublicCacheKeys($key_wildcard, $include_summaries);
+
+            foreach ($keys as $key) {
+                // We strip the cache prefix as we went to the db and the prefix will be in the strings already
+                LaravelCache::forget(str_replace_first(Config::get('cache.prefix'), '', $key['key']));
+            }
+        }
+    }
+
+    /**
+     * Clear any keys matching the supplied $key_wildcards
+     *
+     * @param array $key_wildcards
+     * @param bool $include_summaries
+     */
+    public function clearPrivateCacheKeys(
+        array $key_wildcards,
+        bool $include_summaries = true
+    ): void
+    {
+        foreach ($key_wildcards as $key_wildcard) {
+            $keys = $this->matchingPrivateCacheKeys($key_wildcard, $include_summaries);
 
             foreach ($keys as $key) {
                 // We strip the cache prefix as we went to the db and the prefix will be in the strings already
@@ -205,15 +226,38 @@ class Control
      *
      * @return array
      */
-    private function matchingKeys(
+    private function matchingPrivateCacheKeys(
+        string $key_wildcard,
+        bool $include_summaries = false
+    ): array
+    {
+        if ($this->key_prefix_private !== null) {
+            return (new \App\Models\Cache())->matchingKeys(
+                $this->key_prefix_private,
+                $key_wildcard,
+                $include_summaries
+            );
+        }
+
+        return [];
+    }
+
+    /**
+     * Fetch any matching cache keys, performs a wildcard search
+     *
+     * @param string $key_wildcard
+     * @param bool $include_summaries
+     *
+     * @return array
+     */
+    private function matchingPublicCacheKeys(
         string $key_wildcard,
         bool $include_summaries = false
     ): array
     {
         return (new \App\Models\Cache())->matchingKeys(
-            Config::get('cache.prefix') . $this->key_prefix_public,
+            $this->key_prefix_public,
             $key_wildcard,
-            ($this->key_prefix_private !== null ? Config::get('cache.prefix') . $this->key_prefix_private : null),
             $include_summaries
         );
     }

--- a/app/Response/Cache/Key.php
+++ b/app/Response/Cache/Key.php
@@ -7,7 +7,7 @@ use App\Utilities\Hash;
 
 class Key
 {
-    private $hash;
+    private Hash $hash;
 
     public function __construct()
     {

--- a/app/Response/Header/Header.php
+++ b/app/Response/Header/Header.php
@@ -16,10 +16,7 @@ namespace App\Response\Header;
  */
 class Header
 {
-    /**
-     * @var array
-     */
-    private $headers;
+    private array $headers;
 
     public function __construct()
     {

--- a/app/Response/Header/Headers.php
+++ b/app/Response/Header/Headers.php
@@ -13,7 +13,7 @@ namespace App\Response\Header;
  */
 class Headers
 {
-    private $headers;
+    private Header $headers;
 
     public function __construct()
     {

--- a/app/Rules/ResourceTypeName.php
+++ b/app/Rules/ResourceTypeName.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace App\Rules;
 
@@ -8,8 +9,8 @@ use Illuminate\Support\Facades\DB;
 
 class ResourceTypeName implements Rule
 {
-    private $user_id;
-    private $resource_type_id;
+    private int $user_id;
+    private ?int $resource_type_id;
 
     /**
      * Create a new rule instance.

--- a/app/Utilities/Hash.php
+++ b/app/Utilities/Hash.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\Config;
  */
 class Hash
 {
-    private $hashers;
+    private array $hashers;
 
     public function __construct()
     {

--- a/config/api/app/version.php
+++ b/config/api/app/version.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 return [
-    'version'=> '2.11.1',
+    'version'=> '2.11.2',
     'prefix' => 'v2',
-    'release_date' => '2020-06-16',
+    'release_date' => '2020-06-17',
     'changelog' => [
         'api' => '/v2/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/public/web.config
+++ b/public/web.config
@@ -18,8 +18,8 @@
             </rules>
         </rewrite>
 	      <handlers>
-	          <remove name="PHP73_via_FastCGI" />
-	          <add name="PHP73_via_FastCGI" path="*.php" verb="GET,PUT,POST,PATCH,DELETE,HEAD,OPTIONS" modules="FastCgiModule" scriptProcessor="D:\Program Files (x86)\PHP\v7.3\php-cgi.exe" resourceType="Either" requireAccess="Script" />
+	          <remove name="PHP74_via_FastCGI" />
+	          <add name="PHP74_via_FastCGI" path="*.php" verb="GET,PUT,POST,PATCH,DELETE,HEAD,OPTIONS" modules="FastCgiModule" scriptProcessor="D:\Program Files (x86)\PHP\v7.4\php-cgi.exe" resourceType="Either" requireAccess="Script" />
 	      </handlers>
         <httpProtocol>
             <customHeaders>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -241,6 +241,10 @@
                         <li>We have moved our `RoutePermission` utility class; the `Permission` class sits inside the `App\Request` namespace.</li>
                         <li>We have moved and simplified our `Parameter` classes; the `Parameter` classes sit inside the `App\Request` namespace.</li>
                         <li>We have moved and renamed the `RequestUtility` class; the `BodyValidation` class sits in the `App\Request` namespace.</li>
+                        <li>We have split calls to clear public and private cache keys.</li>
+                        <li>We only clear public cache keys when modifying a public resource type.</li>
+                        <li>We have updated the web.config; the web.config file was referring to PHP7.3.</li>
+                        <li>Added removed class type hints now that we are running PHP7.4.</li>
                     </ul>
 
                     <h3>Fixed</h3>


### PR DESCRIPTION
## Changed
- We have split calls to clear public and private cache keys.
- We only clear public cache keys when modifying a public resource type.
- We have updated the web.config; the web.config file was referring to PHP7.3.
- Added removed class type hints now that we are running PHP7.4.