### PR TITLE
v2.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The complete changelog for the Costs to Expect REST API, our changelog follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v2.17.1] - 2020-11-28
+### Changed
+- We have added the `X-Last-Updated` header to the `resource-types`, `resources`, `categories`, `subcategories`, `items` and `resource items` collection routes.
+- We have added the `X-Last-Updated` header to additional summary routes; the header was missing, and we are going to use it.
+- We have increased the coverage of our request test suite.
+- We have relocated our `Transformer` classes; we have moved them out of the `Models` namespace.
+
+### Fixed
+- We have updated the way we calculated the value for `X-Last-Updated`. We are using the max of the `created at` and `updated at`, not just looking at the `created at` time.
+
 ## [v2.17.0] - 2020-11-22
 ### Added 
 - We have added a `complete` parameter for the `game` item-type; when the parameter is included and set to true, only complete games will be returned in collections and summaries.

--- a/app/Http/Controllers/CategoryManage.php
+++ b/app/Http/Controllers/CategoryManage.php
@@ -6,7 +6,7 @@ use App\Jobs\ClearCache;
 use App\Request\BodyValidation;
 Use App\Response\Cache;
 use App\Models\Category;
-use App\Models\Transformers\Category as CategoryTransformer;
+use App\Transformers\Category as CategoryTransformer;
 use App\Request\Validate\Category as CategoryValidator;
 use App\Response\Responses;
 use Exception;

--- a/app/Http/Controllers/CategoryView.php
+++ b/app/Http/Controllers/CategoryView.php
@@ -77,6 +77,11 @@ class CategoryView extends Controller
                 $sort_parameters
             );
 
+            $last_updated = null;
+            if (count($categories) && array_key_exists('last_updated', $categories[0])) {
+                $last_updated = $categories[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($category) {
                     return (new CategoryTransformer($category))->asArray();
@@ -85,11 +90,16 @@ class CategoryView extends Controller
             );
 
             $headers = new Headers();
-            $headers->collection($pagination_parameters, count($categories), $total)->
-                addCacheControl($cache_control->visibility(), $cache_control->ttl())->
-                addETag($collection)->
-                addSearch(Parameter\Search::xHeader())->
-                addSort(Parameter\Sort::xHeader());
+            $headers
+                ->collection($pagination_parameters, count($categories), $total)
+                ->addCacheControl($cache_control->visibility(), $cache_control->ttl())
+                ->addETag($collection)
+                ->addSearch(Parameter\Search::xHeader())
+                ->addSort(Parameter\Sort::xHeader());
+
+            if ($last_updated !== null) {
+                $headers->addLastUpdated($last_updated);
+            }
 
             $cache_collection->create($total, $collection, $pagination_parameters, $headers->headers());
             $cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/Http/Controllers/CategoryView.php
+++ b/app/Http/Controllers/CategoryView.php
@@ -11,7 +11,7 @@ use App\Request\Parameter;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
 use App\Models\Category;
-use App\Models\Transformers\Category as CategoryTransformer;
+use App\Transformers\Category as CategoryTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 

--- a/app/Http/Controllers/CurrencyView.php
+++ b/app/Http/Controllers/CurrencyView.php
@@ -9,7 +9,7 @@ use App\Response\Cache;
 use App\Response\Header\Headers;
 use App\Request\Parameter;
 use App\Response\Pagination as UtilityPagination;
-use App\Models\Transformers\Currency as CurrencyTransformer;
+use App\Transformers\Currency as CurrencyTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 

--- a/app/Http/Controllers/ItemCategoryManage.php
+++ b/app/Http/Controllers/ItemCategoryManage.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers;
 use App\ItemType\Entity;
 use App\Jobs\ClearCache;
 use App\Models\ItemCategory;
-use App\Models\Transformers\ItemCategory as ItemCategoryTransformer;
+use App\Transformers\ItemCategory as ItemCategoryTransformer;
 use App\Request\Validate\ItemCategory as ItemCategoryValidator;
 use App\Response\Cache;
 use Exception;

--- a/app/Http/Controllers/ItemCategoryView.php
+++ b/app/Http/Controllers/ItemCategoryView.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\ItemType\Entity;
 use App\Models\ItemCategory;
-use App\Models\Transformers\ItemCategory as ItemCategoryTransformer;
+use App\Transformers\ItemCategory as ItemCategoryTransformer;
 use App\Option\ItemCategoryCollection;
 use App\Option\ItemCategoryItem;
 use App\Response\Cache;

--- a/app/Http/Controllers/ItemPartialTransferManage.php
+++ b/app/Http/Controllers/ItemPartialTransferManage.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Jobs\ClearCache;
 use App\Models\ItemPartialTransfer;
-use App\Models\Transformers\ItemPartialTransfer as ItemPartialTransferTransformer;
+use App\Transformers\ItemPartialTransfer as ItemPartialTransferTransformer;
 use App\Response\Cache;
 use App\Request\Validate\ItemPartialTransfer as ItemPartialTransferValidator;
 use App\Response\Responses;

--- a/app/Http/Controllers/ItemPartialTransferView.php
+++ b/app/Http/Controllers/ItemPartialTransferView.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\ItemType\Entity;
 use App\Models\ItemPartialTransfer;
-use App\Models\Transformers\ItemPartialTransfer as ItemPartialTransferTransformer;
+use App\Transformers\ItemPartialTransfer as ItemPartialTransferTransformer;
 use App\Option\ItemPartialTransferCollection;
 use App\Option\ItemPartialTransferItem;
 use App\Option\ItemPartialTransferTransfer;

--- a/app/Http/Controllers/ItemSubcategoryManage.php
+++ b/app/Http/Controllers/ItemSubcategoryManage.php
@@ -6,7 +6,7 @@ use App\ItemType\Entity;
 use App\Jobs\ClearCache;
 use App\Models\ItemCategory;
 use App\Models\ItemSubcategory;
-use App\Models\Transformers\ItemSubcategory as ItemSubcategoryTransformer;
+use App\Transformers\ItemSubcategory as ItemSubcategoryTransformer;
 use App\Request\Validate\ItemSubcategory as ItemSubcategoryValidator;
 use App\Response\Cache;
 use Exception;

--- a/app/Http/Controllers/ItemSubcategoryView.php
+++ b/app/Http/Controllers/ItemSubcategoryView.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers;
 use App\ItemType\Entity;
 use App\Models\ItemCategory;
 use App\Models\ItemSubcategory;
-use App\Models\Transformers\ItemSubcategory as ItemSubcategoryTransformer;
+use App\Transformers\ItemSubcategory as ItemSubcategoryTransformer;
 use App\Option\ItemSubcategoryCollection;
 use App\Option\ItemSubcategoryItem;
 use App\Response\Cache;

--- a/app/Http/Controllers/ItemSubtypeView.php
+++ b/app/Http/Controllers/ItemSubtypeView.php
@@ -11,7 +11,7 @@ use App\Request\Parameter;
 use App\Request\Route;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
-use App\Models\Transformers\ItemSubtype as ItemSubtypeTransformer;
+use App\Transformers\ItemSubtype as ItemSubtypeTransformer;
 use App\Response\Responses;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;

--- a/app/Http/Controllers/ItemTransferView.php
+++ b/app/Http/Controllers/ItemTransferView.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\ItemTransfer;
-use App\Models\Transformers\ItemTransfer as ItemTransferTransformer;
+use App\Transformers\ItemTransfer as ItemTransferTransformer;
 use App\Option\ItemTransferCollection;
 use App\Option\ItemTransferItem;
 use App\Option\ItemTransferTransfer;

--- a/app/Http/Controllers/ItemTypeView.php
+++ b/app/Http/Controllers/ItemTypeView.php
@@ -10,7 +10,7 @@ use App\Response\Header\Headers;
 use App\Request\Parameter;
 use App\Request\Route;
 use App\Response\Pagination as UtilityPagination;
-use App\Models\Transformers\ItemType as ItemTypeTransformer;
+use App\Transformers\ItemType as ItemTypeTransformer;
 use App\Response\Responses;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;

--- a/app/Http/Controllers/PermittedUserView.php
+++ b/app/Http/Controllers/PermittedUserView.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\PermittedUser;
-use App\Models\Transformers\PermittedUser as PermittedUserTransformer;
+use App\Transformers\PermittedUser as PermittedUserTransformer;
 use App\Option\PermittedUserCollection;
 use App\Response\Cache;
 use App\Request\Parameter;

--- a/app/Http/Controllers/QueueView.php
+++ b/app/Http/Controllers/QueueView.php
@@ -10,7 +10,7 @@ use App\Response\Header\Headers;
 use App\Request\Parameter;
 use App\Request\Route;
 use App\Response\Pagination as UtilityPagination;
-use App\Models\Transformers\Queue as QueueTransformer;
+use App\Transformers\Queue as QueueTransformer;
 use Illuminate\Http\JsonResponse;
 
 /**

--- a/app/Http/Controllers/RequestView.php
+++ b/app/Http/Controllers/RequestView.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Option\ErrorLog;
 use App\Models\RequestErrorLog;
-use App\Models\Transformers\RequestErrorLog as RequestErrorLogTransformer;
+use App\Transformers\RequestErrorLog as RequestErrorLogTransformer;
 use App\Response\Pagination as UtilityPagination;
 use Illuminate\Http\JsonResponse;
 

--- a/app/Http/Controllers/ResourceManage.php
+++ b/app/Http/Controllers/ResourceManage.php
@@ -7,7 +7,7 @@ use App\Models\ResourceItemSubtype;
 use App\Models\ResourceType;
 use App\Response\Cache;
 use App\Models\Resource;
-use App\Models\Transformers\Resource as ResourceTransformer;
+use App\Transformers\Resource as ResourceTransformer;
 use App\Request\Validate\Resource as ResourceValidator;
 use App\Response\Responses;
 use Exception;

--- a/app/Http/Controllers/ResourceTypeManage.php
+++ b/app/Http/Controllers/ResourceTypeManage.php
@@ -9,7 +9,7 @@ use App\Models\Resource;
 use App\Models\ResourceTypeItemType;
 use App\Response\Cache;
 use App\Models\ResourceType;
-use App\Models\Transformers\ResourceType as ResourceTypeTransformer;
+use App\Transformers\ResourceType as ResourceTypeTransformer;
 use App\Request\Validate\ResourceType as ResourceTypeValidator;
 use Exception;
 use Illuminate\Database\QueryException;

--- a/app/Http/Controllers/ResourceTypeView.php
+++ b/app/Http/Controllers/ResourceTypeView.php
@@ -11,7 +11,7 @@ use App\Response\Header\Headers;
 use App\Request\Parameter;
 use App\Response\Pagination as UtilityPagination;
 use App\Models\ResourceType;
-use App\Models\Transformers\ResourceType as ResourceTypeTransformer;
+use App\Transformers\ResourceType as ResourceTypeTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 

--- a/app/Http/Controllers/ResourceTypeView.php
+++ b/app/Http/Controllers/ResourceTypeView.php
@@ -64,6 +64,11 @@ class ResourceTypeView extends Controller
                 $sort_parameters
             );
 
+            $last_updated = null;
+            if (count($resource_types) && array_key_exists('last_updated', $resource_types[0])) {
+                $last_updated = $resource_types[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($resource_type) {
                     return (new ResourceTypeTransformer($resource_type))->asArray();
@@ -78,6 +83,10 @@ class ResourceTypeView extends Controller
                 ->addETag($collection)
                 ->addSearch(Parameter\Search::xHeader())
                 ->addSort(Parameter\Sort::xHeader());
+
+            if ($last_updated !== null) {
+                $headers->addLastUpdated($last_updated);
+            }
 
             $cache_collection->create($total, $collection, $pagination_parameters, $headers->headers());
             $cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/Http/Controllers/ResourceView.php
+++ b/app/Http/Controllers/ResourceView.php
@@ -79,6 +79,11 @@ class ResourceView extends Controller
                 $sort_parameters
             );
 
+            $last_updated = null;
+            if (count($resources) && array_key_exists('last_updated', $resources[0])) {
+                $last_updated = $resources[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($resource) {
                     return (new ResourceTransformer($resource))->asArray();
@@ -87,11 +92,16 @@ class ResourceView extends Controller
             );
 
             $headers = new Headers();
-            $headers->collection($pagination_parameters, count($resources), $total)->
-                addCacheControl($cache_control->visibility(), $cache_control->ttl())->
-                addETag($collection)->
-                addSearch(Parameter\Search::xHeader())->
-                addSort(Parameter\Sort::xHeader());
+            $headers
+                ->collection($pagination_parameters, count($resources), $total)
+                ->addCacheControl($cache_control->visibility(), $cache_control->ttl())
+                ->addETag($collection)
+                ->addSearch(Parameter\Search::xHeader())
+                ->addSort(Parameter\Sort::xHeader());
+
+            if ($last_updated !== null) {
+                $headers->addLastUpdated($last_updated);
+            }
 
             $cache_collection->create($total, $collection, $pagination_parameters, $headers->headers());
             $cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/Http/Controllers/ResourceView.php
+++ b/app/Http/Controllers/ResourceView.php
@@ -12,7 +12,7 @@ use App\Request\Parameter;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
 use App\Models\Resource;
-use App\Models\Transformers\Resource as ResourceTransformer;
+use App\Transformers\Resource as ResourceTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 

--- a/app/Http/Controllers/SubcategoryManage.php
+++ b/app/Http/Controllers/SubcategoryManage.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers;
 use App\Jobs\ClearCache;
 use App\Response\Cache;
 use App\Models\Subcategory;
-use App\Models\Transformers\Subcategory as SubcategoryTransformer;
+use App\Transformers\Subcategory as SubcategoryTransformer;
 use App\Request\Validate\Subcategory as SubcategoryValidator;
 use App\Response\Responses;
 use Exception;

--- a/app/Http/Controllers/SubcategoryView.php
+++ b/app/Http/Controllers/SubcategoryView.php
@@ -10,7 +10,7 @@ use App\Request\Parameter;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
 use App\Models\Subcategory;
-use App\Models\Transformers\Subcategory as SubcategoryTransformer;
+use App\Transformers\Subcategory as SubcategoryTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 

--- a/app/Http/Controllers/SubcategoryView.php
+++ b/app/Http/Controllers/SubcategoryView.php
@@ -71,6 +71,11 @@ class SubcategoryView extends Controller
                 $sort_parameters
             );
 
+            $last_updated = null;
+            if (count($subcategories) && array_key_exists('last_updated', $subcategories[0])) {
+                $last_updated = $subcategories[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($subcategory) {
                     return (new SubcategoryTransformer($subcategory))->asArray();
@@ -79,11 +84,16 @@ class SubcategoryView extends Controller
             );
 
             $headers = new Headers();
-            $headers->collection($pagination_parameters, count($subcategories), $total)->
-                addCacheControl($cache_control->visibility(), $cache_control->ttl())->
-                addETag($collection)->
-                addSearch(Parameter\Search::xHeader())->
-                addSort(Parameter\Sort::xHeader());
+            $headers
+                ->collection($pagination_parameters, count($subcategories), $total)
+                ->addCacheControl($cache_control->visibility(), $cache_control->ttl())
+                ->addETag($collection)
+                ->addSearch(Parameter\Search::xHeader())
+                ->addSort(Parameter\Sort::xHeader());
+
+            if ($last_updated !== null) {
+                $headers->addLastUpdated($last_updated);
+            }
 
             $cache_collection->create($total, $collection, $pagination_parameters, $headers->headers());
             $cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/Http/Controllers/Summary/CategoryView.php
+++ b/app/Http/Controllers/Summary/CategoryView.php
@@ -54,14 +54,29 @@ class CategoryView extends Controller
                 $search_parameters
             );
 
+            $total = 0;
+            $last_updated = null;
+            if (count($summary) === 1 && array_key_exists('total', $summary[0])) {
+                $total = (int) $summary[0]['total'];
+
+                if (array_key_exists('last_updated', $summary[0])) {
+                    $last_updated = $summary[0]['last_updated'];
+                }
+            }
+
             $collection = [
-                'categories' => $summary
+                'categories' => $total
             ];
 
             $headers = new Headers();
-            $headers->addCacheControl($cache_control->visibility(), $cache_control->ttl())->
-                addETag($collection)->
-                addSearch(Parameter\Search::xHeader());
+            $headers
+                ->addCacheControl($cache_control->visibility(), $cache_control->ttl())
+                ->addETag($collection)
+                ->addSearch(Parameter\Search::xHeader());
+
+            if ($last_updated !== null) {
+                $headers->addLastUpdated($last_updated);
+            }
 
             $cache_summary->create($collection, $headers->headers());
             $cache_control->putByKey(request()->getRequestUri(), $cache_summary->content());

--- a/app/Http/Controllers/Summary/ResourceTypeView.php
+++ b/app/Http/Controllers/Summary/ResourceTypeView.php
@@ -44,14 +44,29 @@ class ResourceTypeView extends Controller
                 $search_parameters
             );
 
+            $total = 0;
+            $last_updated = null;
+            if (count($summary) === 1 && array_key_exists('total', $summary[0])) {
+                $total = (int) $summary[0]['total'];
+
+                if (array_key_exists('last_updated', $summary[0])) {
+                    $last_updated = $summary[0]['last_updated'];
+                }
+            }
+
             $collection = [
-                'resource_types' => $summary
+                'resource_types' => $total
             ];
 
             $headers = new Headers();
-            $headers->addCacheControl($cache_control->visibility(), $cache_control->ttl())->
-                addETag($collection)->
-                addSearch(Parameter\Search::xHeader());
+            $headers
+                ->addCacheControl($cache_control->visibility(), $cache_control->ttl())
+                ->addETag($collection)
+                ->addSearch(Parameter\Search::xHeader());
+
+            if ($last_updated !== null) {
+                $headers->addLastUpdated($last_updated);
+            }
 
             $cache_summary->create($collection, $headers->headers());
             $cache_control->putByKey(request()->getRequestUri(), $cache_summary->content());

--- a/app/Http/Controllers/Summary/ResourceView.php
+++ b/app/Http/Controllers/Summary/ResourceView.php
@@ -54,14 +54,29 @@ class ResourceView extends Controller
                 $search_parameters
             );
 
+            $total = 0;
+            $last_updated = null;
+            if (count($summary) === 1 && array_key_exists('total', $summary[0])) {
+                $total = (int) $summary[0]['total'];
+
+                if (array_key_exists('last_updated', $summary[0])) {
+                    $last_updated = $summary[0]['last_updated'];
+                }
+            }
+
             $collection = [
-                'resources' => $summary
+                'resources' => $total
             ];
 
             $headers = new Headers();
-            $headers->addCacheControl($cache_control->visibility(), $cache_control->ttl())->
-                addETag($collection)->
-                addSearch(Parameter\Search::xHeader());
+            $headers
+                ->addCacheControl($cache_control->visibility(), $cache_control->ttl())
+                ->addETag($collection)
+                ->addSearch(Parameter\Search::xHeader());
+
+            if ($last_updated !== null) {
+                $headers->addLastUpdated($last_updated);
+            }
 
             $cache_summary->create($collection, $headers->headers());
             $cache_control->putByKey(request()->getRequestUri(), $cache_summary->content());

--- a/app/Http/Controllers/Summary/SubcategoryView.php
+++ b/app/Http/Controllers/Summary/SubcategoryView.php
@@ -55,14 +55,29 @@ class SubcategoryView extends Controller
                 $search_parameters
             );
 
+            $total = 0;
+            $last_updated = null;
+            if (count($summary) === 1 && array_key_exists('total', $summary[0])) {
+                $total = (int) $summary[0]['total'];
+
+                if (array_key_exists('last_updated', $summary[0])) {
+                    $last_updated = $summary[0]['last_updated'];
+                }
+            }
+
             $collection = [
-                'subcategories' => $summary
+                'subcategories' => $total
             ];
 
             $headers = new Headers();
-            $headers->addCacheControl($cache_control->visibility(), $cache_control->ttl())->
-                addETag($collection)->
-                addSearch(Parameter\Search::xHeader());
+            $headers
+                ->addCacheControl($cache_control->visibility(), $cache_control->ttl())
+                ->addETag($collection)
+                ->addSearch(Parameter\Search::xHeader());
+
+            if ($last_updated !== null) {
+                $headers->addLastUpdated($last_updated);
+            }
 
             $cache_summary->create($collection, $headers->headers());
             $cache_control->putByKey(request()->getRequestUri(), $cache_summary->content());

--- a/app/ItemType/AllocatedExpense/Item.php
+++ b/app/ItemType/AllocatedExpense/Item.php
@@ -5,7 +5,7 @@ namespace App\ItemType\AllocatedExpense;
 
 use App\AllowedValue\Currency;
 use App\ItemType\ItemType;
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 use App\Request\Hash;
 use App\Request\Validate\Validator;
 use Illuminate\Database\Eloquent\Model;

--- a/app/ItemType/AllocatedExpense/Model.php
+++ b/app/ItemType/AllocatedExpense/Model.php
@@ -420,9 +420,29 @@ class Model extends LaravelModel
         $collection->offset($offset);
         $collection->limit($limit);
 
-        return $collection->select($select_fields)->
-            get()->
-            toArray();
+        return $collection
+            ->select($select_fields)
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->table}`.`item_id` = `item`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
+            ->get()
+            ->toArray();
     }
 
     public function hasCategoryAssignments(int $item_id): bool

--- a/app/ItemType/AllocatedExpense/ResourceTypeModel.php
+++ b/app/ItemType/AllocatedExpense/ResourceTypeModel.php
@@ -260,7 +260,7 @@ class ResourceTypeModel extends LaravelModel
                         `{$this->item_table}`
                     INNER JOIN 
                         `item` ON 
-                            {$this->item_table}.`id` = `{$this->table}`.`id`
+                            {$this->item_table}.`item_id` = `{$this->table}`.`id`
                     INNER JOIN 
                         `resource` ON 
                             `item`.`resource_id` = `resource`.`id`

--- a/app/ItemType/AllocatedExpense/ResourceTypeModel.php
+++ b/app/ItemType/AllocatedExpense/ResourceTypeModel.php
@@ -245,11 +245,34 @@ class ResourceTypeModel extends LaravelModel
             $collection->orderBy('item.created_at', 'desc');
         }
 
-        $collection->offset($offset);
-        $collection->limit($limit);
-        $collection->select($select_fields);
-
-        return $collection->get()->toArray();
+        return $collection
+            ->offset($offset)
+            ->limit($limit)
+            ->select($select_fields)
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->item_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->item_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->item_table}`
+                    INNER JOIN 
+                        `item` ON 
+                            {$this->item_table}.`id` = `{$this->table}`.`id`
+                    INNER JOIN 
+                        `resource` ON 
+                            `item`.`resource_id` = `resource`.`id`
+                    WHERE
+                        `resource`.`resource_type_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_type_id
+                ]
+            )
+            ->get()
+            ->toArray();
     }
 
     /**

--- a/app/ItemType/AllocatedExpense/ResourceTypeResponse.php
+++ b/app/ItemType/AllocatedExpense/ResourceTypeResponse.php
@@ -50,6 +50,11 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
                 $this->sort_fields
             );
 
+            $last_updated = null;
+            if (count($items) && array_key_exists('last_updated', $items[0])) {
+                $last_updated = $items[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($item) {
                     return (new Transformer($item))->asArray();
@@ -65,7 +70,8 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
                     $pagination_parameters,
                     count($items),
                     $total,
-                    $collection
+                    $collection,
+                    $last_updated
                 )
             );
             $this->cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/ItemType/AllocatedExpense/ResourceTypeTransformer.php
+++ b/app/ItemType/AllocatedExpense/ResourceTypeTransformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\AllocatedExpense;
 
-use App\Models\Transformers\Transformer as BaseTransformer;
+use App\Transformers\Transformer as BaseTransformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/AllocatedExpense/Response.php
+++ b/app/ItemType/AllocatedExpense/Response.php
@@ -52,6 +52,11 @@ class Response extends ItemTypeResponse
                 $this->sort_fields
             );
 
+            $last_updated = null;
+            if (count($items) && array_key_exists('last_updated', $items[0])) {
+                $last_updated = $items[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($item) {
                     return (new Transformer($item))->asArray();
@@ -67,7 +72,8 @@ class Response extends ItemTypeResponse
                     $pagination_parameters,
                     count($items),
                     $total,
-                    $collection
+                    $collection,
+                    $last_updated
                 )
             );
             $this->cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/ItemType/AllocatedExpense/SummaryModel.php
+++ b/app/ItemType/AllocatedExpense/SummaryModel.php
@@ -42,9 +42,27 @@ class SummaryModel extends LaravelModel
                 category.description AS description,
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.actualised_total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -88,9 +106,27 @@ class SummaryModel extends LaravelModel
                 category.description AS description, 
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.actualised_total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -127,9 +163,27 @@ class SummaryModel extends LaravelModel
             ->selectRaw("
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.actualised_total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count,
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', 'item_type_allocated_expense.item_id')
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -196,9 +250,27 @@ class SummaryModel extends LaravelModel
                 MONTH({$this->sub_table}.effective_date) as month,
                 currency.code AS currency_code, 
                 SUM({$this->sub_table}.actualised_total) AS total,            
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -240,9 +312,27 @@ class SummaryModel extends LaravelModel
                 MONTH({$this->sub_table}.effective_date) as month, 
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.actualised_total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count,
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -285,9 +375,27 @@ class SummaryModel extends LaravelModel
                 sub_category.description AS description,
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.actualised_total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -335,9 +443,27 @@ class SummaryModel extends LaravelModel
                 sub_category.description AS description,
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.actualised_total) AS total,
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -378,9 +504,27 @@ class SummaryModel extends LaravelModel
         $collection = $this->selectRaw("
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.actualised_total) AS total,
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join('resource', 'item.resource_id', 'resource.id')
             ->join('currency', "{$this->sub_table}.currency_id", 'currency.id')
@@ -415,9 +559,27 @@ class SummaryModel extends LaravelModel
                 YEAR({$this->sub_table}.effective_date) as year, 
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.actualised_total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -456,9 +618,27 @@ class SummaryModel extends LaravelModel
                 YEAR({$this->sub_table}.effective_date) as year, 
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.actualised_total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")

--- a/app/ItemType/AllocatedExpense/SummaryTransformer.php
+++ b/app/ItemType/AllocatedExpense/SummaryTransformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\AllocatedExpense;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/AllocatedExpense/SummaryTransformerByCategory.php
+++ b/app/ItemType/AllocatedExpense/SummaryTransformerByCategory.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\AllocatedExpense;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/AllocatedExpense/SummaryTransformerByMonth.php
+++ b/app/ItemType/AllocatedExpense/SummaryTransformerByMonth.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\AllocatedExpense;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/AllocatedExpense/SummaryTransformerByResource.php
+++ b/app/ItemType/AllocatedExpense/SummaryTransformerByResource.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\AllocatedExpense;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/AllocatedExpense/SummaryTransformerBySubcategory.php
+++ b/app/ItemType/AllocatedExpense/SummaryTransformerBySubcategory.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\AllocatedExpense;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/AllocatedExpense/SummaryTransformerByYear.php
+++ b/app/ItemType/AllocatedExpense/SummaryTransformerByYear.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\AllocatedExpense;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/AllocatedExpense/Transformer.php
+++ b/app/ItemType/AllocatedExpense/Transformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\AllocatedExpense;
 
-use App\Models\Transformers\Transformer as BaseTransformer;
+use App\Transformers\Transformer as BaseTransformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/Game/Item.php
+++ b/app/ItemType/Game/Item.php
@@ -5,7 +5,7 @@ namespace App\ItemType\Game;
 
 use App\AllowedValue\Winner;
 use App\ItemType\ItemType;
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 use App\Request\Hash;
 use App\Request\Validate\Validator;
 use Illuminate\Database\Eloquent\Model;

--- a/app/ItemType/Game/Model.php
+++ b/app/ItemType/Game/Model.php
@@ -192,6 +192,25 @@ class Model extends LaravelModel
             ->offset($offset)
             ->limit($limit)
             ->select($select_fields)
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->table}`.`item_id` = `item`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->get()
             ->toArray();
     }

--- a/app/ItemType/Game/ResourceTypeModel.php
+++ b/app/ItemType/Game/ResourceTypeModel.php
@@ -123,6 +123,28 @@ class ResourceTypeModel extends LaravelModel
             ->offset($offset)
             ->limit($limit)
             ->select($select_fields)
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->item_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->item_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->item_table}`
+                    INNER JOIN 
+                        `item` ON 
+                            {$this->item_table}.`id` = `{$this->table}`.`id`
+                    INNER JOIN 
+                        `resource` ON 
+                            `item`.`resource_id` = `resource`.`id`
+                    WHERE
+                        `resource`.`resource_type_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_type_id
+                ]
+            )
             ->get()
             ->toArray();
     }

--- a/app/ItemType/Game/ResourceTypeModel.php
+++ b/app/ItemType/Game/ResourceTypeModel.php
@@ -63,8 +63,6 @@ class ResourceTypeModel extends LaravelModel
         array $sort_parameters = []
     ): array
     {
-
-
         $select_fields = [
             'resource.id AS resource_id',
             'resource.name AS resource_name',

--- a/app/ItemType/Game/ResourceTypeModel.php
+++ b/app/ItemType/Game/ResourceTypeModel.php
@@ -15,7 +15,9 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
  */
 class ResourceTypeModel extends LaravelModel
 {
-    protected $table = 'item_type_game';
+    protected $table = 'item';
+
+    protected $item_table = 'item_type_game';
 
     protected $guarded = ['id'];
 
@@ -27,24 +29,24 @@ class ResourceTypeModel extends LaravelModel
     ): int
     {
         $collection = $this
-            ->from('item')
-            ->join($this->table, 'item.id', $this->table . '.item_id')
+            ->from($this->table)
+            ->join($this->item_table, 'item.id', $this->item_table . '.item_id')
             ->join('resource', 'item.resource_id', 'resource.id')
             ->join('resource_type', 'resource.resource_type_id', 'resource_type.id')
             ->where('resource_type.id', '=', $resource_type_id);
 
         if (array_key_exists('complete', $parameters_collection) === true) {
-            $collection->where($this->table . '.complete', '=', 1);
+            $collection->where($this->item_table . '.complete', '=', 1);
         }
 
         $collection = Clause::applySearch(
             $collection,
-            $this->table,
+            $this->item_table,
             $search_parameters
         );
         $collection = Clause::applyFiltering(
             $collection,
-            $this->table,
+            $this->item_table,
             $filter_parameters
         );
 
@@ -68,38 +70,38 @@ class ResourceTypeModel extends LaravelModel
             'resource.name AS resource_name',
             'resource.description AS resource_description',
             'item.id AS item_id',
-            "{$this->table}.name AS item_name",
-            "{$this->table}.description AS item_description",
-            "{$this->table}.game AS item_game",
-            "{$this->table}.statistics AS item_statistics",
+            "{$this->item_table}.name AS item_name",
+            "{$this->item_table}.description AS item_description",
+            "{$this->item_table}.game AS item_game",
+            "{$this->item_table}.statistics AS item_statistics",
             "category.id AS item_winner_id",
             "category.name AS item_winner_name",
-            "{$this->table}.score AS item_score",
-            "{$this->table}.complete AS item_complete",
-            "{$this->table}.created_at AS item_created_at",
-            "{$this->table}.updated_at AS item_updated_at"
+            "{$this->item_table}.score AS item_score",
+            "{$this->item_table}.complete AS item_complete",
+            "{$this->item_table}.created_at AS item_created_at",
+            "{$this->item_table}.updated_at AS item_updated_at"
         ];
 
         $collection = $this
             ->from('item')
-            ->join($this->table, 'item.id', "{$this->table}.item_id")
+            ->join($this->item_table,  'item.id', "{$this->item_table}.item_id")
             ->join('resource', 'item.resource_id', 'resource.id')
             ->join('resource_type', 'resource.resource_type_id', 'resource_type.id')
-            ->leftJoin('category', $this->table . '.winner', 'category.id')
+            ->leftJoin('category', $this->item_table . '.winner', 'category.id')
             ->where('resource_type.id', '=', $resource_type_id);
 
         if (array_key_exists('complete', $parameters_collection) === true) {
-            $collection->where($this->table . '.complete', '=', 1);
+            $collection->where($this->item_table . '.complete', '=', 1);
         }
 
         $collection = Clause::applySearch(
             $collection,
-            $this->table,
+            $this->item_table,
             $search_parameters
         );
         $collection = Clause::applyFiltering(
             $collection,
-            $this->table,
+            $this->item_table,
             $filter_parameters
         );
 
@@ -107,16 +109,16 @@ class ResourceTypeModel extends LaravelModel
             foreach ($sort_parameters as $field => $direction) {
                 switch ($field) {
                     case 'created':
-                        $collection->orderBy('item.created_at', $direction);
+                        $collection->orderBy($this->item_table . '.created_at', $direction);
                         break;
 
                     default:
-                        $collection->orderBy('item.' . $field, $direction);
+                        $collection->orderBy($this->item_table . '.' . $field, $direction);
                         break;
                 }
             }
         } else {
-            $collection->orderBy('item.created_at', 'desc');
+            $collection->orderBy($this->item_table . '.created_at', 'desc');
         }
 
         return $collection
@@ -134,7 +136,7 @@ class ResourceTypeModel extends LaravelModel
                         `{$this->item_table}`
                     INNER JOIN 
                         `item` ON 
-                            {$this->item_table}.`id` = `{$this->table}`.`id`
+                            {$this->item_table}.`item_id` = `{$this->table}`.`id`
                     INNER JOIN 
                         `resource` ON 
                             `item`.`resource_id` = `resource`.`id`

--- a/app/ItemType/Game/ResourceTypeResponse.php
+++ b/app/ItemType/Game/ResourceTypeResponse.php
@@ -46,6 +46,11 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
                 $this->sort_fields
             );
 
+            $last_updated = null;
+            if (count($items) && array_key_exists('last_updated', $items[0])) {
+                $last_updated = $items[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($item) {
                     return (new Transformer($item))->asArray();
@@ -61,7 +66,8 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
                     $pagination_parameters,
                     count($items),
                     $total,
-                    $collection
+                    $collection,
+                    $last_updated
                 )
             );
             $this->cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/ItemType/Game/ResourceTypeTransformer.php
+++ b/app/ItemType/Game/ResourceTypeTransformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\Game;
 
-use App\Models\Transformers\Transformer as BaseTransformer;
+use App\Transformers\Transformer as BaseTransformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/Game/Response.php
+++ b/app/ItemType/Game/Response.php
@@ -48,6 +48,11 @@ class Response extends ItemTypeResponse
                 $this->sort_fields
             );
 
+            $last_updated = null;
+            if (count($items) && array_key_exists('last_updated', $items[0])) {
+                $last_updated = $items[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($item) {
                     return (new Transformer($item))->asArray();
@@ -63,7 +68,8 @@ class Response extends ItemTypeResponse
                     $pagination_parameters,
                     count($items),
                     $total,
-                    $collection
+                    $collection,
+                    $last_updated
                 )
             );
             $this->cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/ItemType/Game/SummaryModel.php
+++ b/app/ItemType/Game/SummaryModel.php
@@ -35,9 +35,27 @@ class SummaryModel extends LaravelModel
                 `item_subtype`.`id` AS resource_item_subtype_id,
                 `item_subtype`.`name` AS resource_item_subtype_name,
                 `item_subtype`.`description` AS resource_item_subtype_description,
-                COUNT({$this->sub_table}.item_id) AS count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -90,9 +108,27 @@ class SummaryModel extends LaravelModel
                 `item_subtype`.`id` AS resource_item_subtype_id,
                 `item_subtype`.`name` AS resource_item_subtype_name,
                 `item_subtype`.`description` AS resource_item_subtype_description,
-                COUNT({$this->sub_table}.item_id) AS count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")

--- a/app/ItemType/Game/SummaryResourceTypeModel.php
+++ b/app/ItemType/Game/SummaryResourceTypeModel.php
@@ -78,6 +78,28 @@ class SummaryResourceTypeModel extends LaravelModel
                 `item_subtype`.`description` AS resource_item_subtype_description,
                 COUNT(`{$this->sub_table}`.`item_id`) AS count"
             )
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    JOIN 
+                        `resource` ON 
+                            `{$this->table}`.`resource_id` = `resource`.`id`
+                    WHERE
+                        `resource`.`resource_type_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_type_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join('resource', 'item.resource_id', 'resource.id')
             ->join('resource_item_subtype', 'resource_item_subtype.resource_id', 'resource.id')

--- a/app/ItemType/Game/SummaryResourceTypeModel.php
+++ b/app/ItemType/Game/SummaryResourceTypeModel.php
@@ -28,9 +28,30 @@ class SummaryResourceTypeModel extends LaravelModel
                 `resource_type`.`id` AS resource_type_id, 
                 `resource_type`.`name` AS resource_type_name, 
                 `resource_type`.`description` AS resource_type_description, 
-                COUNT({$this->sub_table}.item_id) AS count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    JOIN 
+                        `resource` ON 
+                            `{$this->table}`.`resource_id` = `resource`.`id`
+                    WHERE
+                        `resource`.`resource_type_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_type_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join('resource', 'item.resource_id', 'resource.id')
             ->join('resource_type', 'resource.resource_type_id', 'resource_type.id')

--- a/app/ItemType/Game/SummaryResourceTypeModel.php
+++ b/app/ItemType/Game/SummaryResourceTypeModel.php
@@ -76,8 +76,7 @@ class SummaryResourceTypeModel extends LaravelModel
                 `item_subtype`.`id` AS resource_item_subtype_id,
                 `item_subtype`.`name` AS resource_item_subtype_name,
                 `item_subtype`.`description` AS resource_item_subtype_description,
-                COUNT(`{$this->sub_table}`.`item_id`) AS count, 
-                MAX(`{$this->sub_table}`.`created_at`) AS last_updated"
+                COUNT(`{$this->sub_table}`.`item_id`) AS count"
             )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join('resource', 'item.resource_id', 'resource.id')
@@ -105,9 +104,30 @@ class SummaryResourceTypeModel extends LaravelModel
     {
         $collection = $this
             ->selectRaw("
-                COUNT({$this->sub_table}.item_id) AS count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    JOIN 
+                        `resource` ON 
+                            `{$this->table}`.`resource_id` = `resource`.`id`
+                    WHERE
+                        `resource`.`resource_type_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_type_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")

--- a/app/ItemType/Game/SummaryResourceTypeResponse.php
+++ b/app/ItemType/Game/SummaryResourceTypeResponse.php
@@ -95,6 +95,8 @@ class SummaryResourceTypeResponse extends BaseSummaryResourceTypeResponse
                 $this->parameters
             );
 
+            print_r($summary); die;
+
             $collection = (new SummaryTransformerByResource($summary))->asArray();
 
             $this->assignToCache(

--- a/app/ItemType/Game/SummaryResourceTypeResponse.php
+++ b/app/ItemType/Game/SummaryResourceTypeResponse.php
@@ -95,8 +95,6 @@ class SummaryResourceTypeResponse extends BaseSummaryResourceTypeResponse
                 $this->parameters
             );
 
-            print_r($summary); die;
-
             $collection = (new SummaryTransformerByResource($summary))->asArray();
 
             $this->assignToCache(

--- a/app/ItemType/Game/SummaryTransformer.php
+++ b/app/ItemType/Game/SummaryTransformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\Game;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/Game/SummaryTransformerByResource.php
+++ b/app/ItemType/Game/SummaryTransformerByResource.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\Game;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/Game/Transformer.php
+++ b/app/ItemType/Game/Transformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\Game;
 
-use App\Models\Transformers\Transformer as BaseTransformer;
+use App\Transformers\Transformer as BaseTransformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/ItemType.php
+++ b/app/ItemType/ItemType.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 use App\Request\Parameter\Request;
 use App\Request\Validate\Validator;
 use Illuminate\Database\Eloquent\Model;

--- a/app/ItemType/ResourceTypeResponse.php
+++ b/app/ItemType/ResourceTypeResponse.php
@@ -49,7 +49,8 @@ abstract class ResourceTypeResponse
         array $pagination_parameters,
         int $count,
         int $total,
-        array $collection
+        array $collection,
+        string $last_updated = null
     ): array
     {
         $headers = new Headers();
@@ -61,6 +62,10 @@ abstract class ResourceTypeResponse
             ->addSort(Sort::xHeader())
             ->addParameters(Request::xHeader())
             ->addFilters(Filter::xHeader());
+
+        if ($last_updated !== null) {
+            $headers->addLastUpdated($last_updated);
+        }
 
         return $headers->headers();
     }

--- a/app/ItemType/Response.php
+++ b/app/ItemType/Response.php
@@ -55,7 +55,8 @@ abstract class Response
         array $pagination_parameters,
         int $count,
         int $total,
-        array $collection
+        array $collection,
+        string $last_updated = null
     ): array
     {
         $headers = new Headers();
@@ -67,6 +68,10 @@ abstract class Response
             ->addSort(Sort::xHeader())
             ->addParameters(Request::xHeader())
             ->addFilters(Filter::xHeader());
+
+        if ($last_updated !== null) {
+            $headers->addLastUpdated($last_updated);
+        }
 
         return $headers->headers();
     }

--- a/app/ItemType/SimpleExpense/Item.php
+++ b/app/ItemType/SimpleExpense/Item.php
@@ -5,7 +5,7 @@ namespace App\ItemType\SimpleExpense;
 
 use App\AllowedValue\Currency;
 use App\ItemType\ItemType;
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 use App\Request\Hash;
 use App\Request\Validate\Validator;
 use Illuminate\Database\Eloquent\Model;

--- a/app/ItemType/SimpleExpense/Model.php
+++ b/app/ItemType/SimpleExpense/Model.php
@@ -334,9 +334,29 @@ class Model extends LaravelModel
         $collection->offset($offset);
         $collection->limit($limit);
 
-        return $collection->select($select_fields)->
-            get()->
-            toArray();
+        return $collection
+            ->select($select_fields)
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->table}`.`item_id` = `item`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
+            ->get()
+            ->toArray();
     }
 
     public function hasCategoryAssignments(int $item_id): bool

--- a/app/ItemType/SimpleExpense/ResourceTypeModel.php
+++ b/app/ItemType/SimpleExpense/ResourceTypeModel.php
@@ -228,7 +228,7 @@ class ResourceTypeModel extends LaravelModel
                         `{$this->item_table}`
                     INNER JOIN 
                         `item` ON 
-                            {$this->item_table}.`id` = `{$this->table}`.`id`
+                            {$this->item_table}.`item_id` = `{$this->table}`.`id`
                     INNER JOIN 
                         `resource` ON 
                             `item`.`resource_id` = `resource`.`id`

--- a/app/ItemType/SimpleExpense/ResourceTypeModel.php
+++ b/app/ItemType/SimpleExpense/ResourceTypeModel.php
@@ -213,10 +213,33 @@ class ResourceTypeModel extends LaravelModel
             $collection->orderBy('item.created_at', 'desc');
         }
 
-        $collection->offset($offset);
-        $collection->limit($limit);
-        $collection->select($select_fields);
-
-        return $collection->get()->toArray();
+        return $collection
+            ->offset($offset)
+            ->limit($limit)
+            ->select($select_fields)
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->item_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->item_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->item_table}`
+                    INNER JOIN 
+                        `item` ON 
+                            {$this->item_table}.`id` = `{$this->table}`.`id`
+                    INNER JOIN 
+                        `resource` ON 
+                            `item`.`resource_id` = `resource`.`id`
+                    WHERE
+                        `resource`.`resource_type_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_type_id
+                ]
+            )
+            ->get()
+            ->toArray();
     }
 }

--- a/app/ItemType/SimpleExpense/ResourceTypeResponse.php
+++ b/app/ItemType/SimpleExpense/ResourceTypeResponse.php
@@ -46,6 +46,11 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
                 $this->sort_fields
             );
 
+            $last_updated = null;
+            if (count($items) && array_key_exists('last_updated', $items[0])) {
+                $last_updated = $items[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($item) {
                     return (new Transformer($item))->asArray();
@@ -61,7 +66,8 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
                     $pagination_parameters,
                     count($items),
                     $total,
-                    $collection
+                    $collection,
+                    $last_updated
                 )
             );
             $this->cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/ItemType/SimpleExpense/ResourceTypeTransformer.php
+++ b/app/ItemType/SimpleExpense/ResourceTypeTransformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\SimpleExpense;
 
-use App\Models\Transformers\Transformer as BaseTransformer;
+use App\Transformers\Transformer as BaseTransformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/SimpleExpense/Response.php
+++ b/app/ItemType/SimpleExpense/Response.php
@@ -48,6 +48,11 @@ class Response extends ItemTypeResponse
                 $this->sort_fields
             );
 
+            $last_updated = null;
+            if (count($items) && array_key_exists('last_updated', $items[0])) {
+                $last_updated = $items[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($item) {
                     return (new Transformer($item))->asArray();
@@ -63,7 +68,8 @@ class Response extends ItemTypeResponse
                     $pagination_parameters,
                     count($items),
                     $total,
-                    $collection
+                    $collection,
+                    $last_updated
                 )
             );
             $this->cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/ItemType/SimpleExpense/SummaryModel.php
+++ b/app/ItemType/SimpleExpense/SummaryModel.php
@@ -41,8 +41,27 @@ class SummaryModel extends LaravelModel
                 category.description AS description,
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated")
+                COUNT({$this->sub_table}.item_id) AS total_count"
+            )
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -84,9 +103,27 @@ class SummaryModel extends LaravelModel
                 category.description AS description, 
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count,
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -119,9 +156,27 @@ class SummaryModel extends LaravelModel
             ->selectRaw("
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count,
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -181,8 +236,27 @@ class SummaryModel extends LaravelModel
                 sub_category.description AS description,
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated")
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -228,9 +302,27 @@ class SummaryModel extends LaravelModel
                 sub_category.description AS description,
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count,
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join("resource", "resource.id", "item.resource_id")
             ->join("resource_type", "resource_type.id", "resource.resource_type_id")
@@ -269,9 +361,27 @@ class SummaryModel extends LaravelModel
         $collection = $this->selectRaw("
                 currency.code AS currency_code,
                 SUM({$this->sub_table}.total) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count,
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join('resource', 'item.resource_id', 'resource.id')
             ->join('currency', "{$this->sub_table}.currency_id", 'currency.id')

--- a/app/ItemType/SimpleExpense/SummaryResourceTypeModel.php
+++ b/app/ItemType/SimpleExpense/SummaryResourceTypeModel.php
@@ -35,9 +35,30 @@ class SummaryResourceTypeModel extends LaravelModel
             ->selectRaw("
                 sum({$this->sub_table}.total) AS total, 
                 currency.code AS currency_code,
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    JOIN 
+                        `resource` ON 
+                            `{$this->table}`.`resource_id` = `resource`.`id`
+                    WHERE
+                        `resource`.`resource_type_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_type_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join('resource', 'item.resource_id', 'resource.id')
             ->join('resource_type', 'resource.resource_type_id', 'resource_type.id')

--- a/app/ItemType/SimpleExpense/SummaryTransformer.php
+++ b/app/ItemType/SimpleExpense/SummaryTransformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\SimpleExpense;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/SimpleExpense/SummaryTransformerByCategory.php
+++ b/app/ItemType/SimpleExpense/SummaryTransformerByCategory.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\SimpleExpense;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/SimpleExpense/SummaryTransformerByResource.php
+++ b/app/ItemType/SimpleExpense/SummaryTransformerByResource.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\SimpleExpense;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/SimpleExpense/SummaryTransformerBySubcategory.php
+++ b/app/ItemType/SimpleExpense/SummaryTransformerBySubcategory.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\SimpleExpense;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/SimpleExpense/Transformer.php
+++ b/app/ItemType/SimpleExpense/Transformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\SimpleExpense;
 
-use App\Models\Transformers\Transformer as BaseTransformer;
+use App\Transformers\Transformer as BaseTransformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/SimpleItem/Item.php
+++ b/app/ItemType/SimpleItem/Item.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace App\ItemType\SimpleItem;
 
 use App\ItemType\ItemType;
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 use App\Request\Validate\Validator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Date;

--- a/app/ItemType/SimpleItem/ResourceTypeModel.php
+++ b/app/ItemType/SimpleItem/ResourceTypeModel.php
@@ -120,10 +120,33 @@ class ResourceTypeModel extends LaravelModel
             $collection->orderBy('item.created_at', 'desc');
         }
 
-        $collection->offset($offset);
-        $collection->limit($limit);
-        $collection->select($select_fields);
-
-        return $collection->get()->toArray();
+        $collection
+            ->offset($offset)
+            ->limit($limit)
+            ->select($select_fields)
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->item_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->item_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->item_table}`
+                    INNER JOIN 
+                        `item` ON 
+                            {$this->item_table}.`id` = `{$this->table}`.`id`
+                    INNER JOIN 
+                        `resource` ON 
+                            `item`.`resource_id` = `resource`.`id`
+                    WHERE
+                        `resource`.`resource_type_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_type_id
+                ]
+            )
+            ->get()
+            ->toArray();
     }
 }

--- a/app/ItemType/SimpleItem/ResourceTypeModel.php
+++ b/app/ItemType/SimpleItem/ResourceTypeModel.php
@@ -120,7 +120,7 @@ class ResourceTypeModel extends LaravelModel
             $collection->orderBy('item.created_at', 'desc');
         }
 
-        $collection
+        return $collection
             ->offset($offset)
             ->limit($limit)
             ->select($select_fields)
@@ -135,7 +135,7 @@ class ResourceTypeModel extends LaravelModel
                         `{$this->item_table}`
                     INNER JOIN 
                         `item` ON 
-                            {$this->item_table}.`id` = `{$this->table}`.`id`
+                            {$this->item_table}.`item_id` = `{$this->table}`.`id`
                     INNER JOIN 
                         `resource` ON 
                             `item`.`resource_id` = `resource`.`id`

--- a/app/ItemType/SimpleItem/ResourceTypeResponse.php
+++ b/app/ItemType/SimpleItem/ResourceTypeResponse.php
@@ -44,6 +44,11 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
                 $this->sort_fields
             );
 
+            $last_updated = null;
+            if (count($items) && array_key_exists('last_updated', $items[0])) {
+                $last_updated = $items[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($item) {
                     return (new Transformer($item))->asArray();
@@ -59,7 +64,8 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
                     $pagination_parameters,
                     count($items),
                     $total,
-                    $collection
+                    $collection,
+                    $last_updated
                 )
             );
             $this->cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/ItemType/SimpleItem/ResourceTypeTransformer.php
+++ b/app/ItemType/SimpleItem/ResourceTypeTransformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\SimpleItem;
 
-use App\Models\Transformers\Transformer as BaseTransformer;
+use App\Transformers\Transformer as BaseTransformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/SimpleItem/Response.php
+++ b/app/ItemType/SimpleItem/Response.php
@@ -47,6 +47,11 @@ class Response extends ItemTypeResponse
                 $this->sort_fields
             );
 
+            $last_updated = null;
+            if (count($items) && array_key_exists('last_updated', $items[0])) {
+                $last_updated = $items[0]['last_updated'];
+            }
+
             $collection = array_map(
                 static function ($item) {
                     return (new Transformer($item))->asArray();
@@ -62,7 +67,8 @@ class Response extends ItemTypeResponse
                     $pagination_parameters,
                     count($items),
                     $total,
-                    $collection
+                    $collection,
+                    $last_updated
                 )
             );
             $this->cache_control->putByKey(request()->getRequestUri(), $cache_collection->content());

--- a/app/ItemType/SimpleItem/SummaryModel.php
+++ b/app/ItemType/SimpleItem/SummaryModel.php
@@ -30,14 +30,32 @@ class SummaryModel extends LaravelModel
         $collection = $this->
             selectRaw("
                 SUM({$this->sub_table}.quantity) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count, 
-                MAX({$this->sub_table}.created_at) AS last_updated
-            ")->
-            join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")->
-            join("resource", "resource.id", "item.resource_id")->
-            join("resource_type", "resource_type.id", "resource.resource_type_id")->
-            where("resource_type.id", "=", $resource_type_id)->
-            where("resource.id", "=", $resource_id);
+                COUNT({$this->sub_table}.item_id) AS total_count
+            ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
+            ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
+            ->join("resource", "resource.id", "item.resource_id")
+            ->join("resource_type", "resource_type.id", "resource.resource_type_id")
+            ->where("resource_type.id", "=", $resource_type_id)
+            ->where("resource.id", "=", $resource_id);
 
         $collection = Clause::applySearch(
             $collection,
@@ -71,9 +89,27 @@ class SummaryModel extends LaravelModel
     {
         $collection = $this->selectRaw("
                 SUM({$this->sub_table}.quantity) AS total, 
-                COUNT({$this->sub_table}.item_id) AS total_count,
-                MAX({$this->sub_table}.created_at) AS last_updated
+                COUNT({$this->sub_table}.item_id) AS total_count
             ")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->sub_table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->sub_table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->sub_table}` 
+                    JOIN 
+                        `item` ON 
+                            `{$this->sub_table}`.`item_id` = `{$this->table}`.`id`
+                    WHERE
+                        `item`.`resource_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_id
+                ]
+            )
             ->join($this->sub_table, 'item.id', "{$this->sub_table}.item_id")
             ->join('resource', 'item.resource_id', 'resource.id')
             ->where('resource_id', '=', $resource_id)

--- a/app/ItemType/SimpleItem/SummaryTransformer.php
+++ b/app/ItemType/SimpleItem/SummaryTransformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\SimpleItem;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/SimpleItem/SummaryTransformerByResource.php
+++ b/app/ItemType/SimpleItem/SummaryTransformerByResource.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\SimpleItem;
 
-use App\Models\Transformers\Transformer;
+use App\Transformers\Transformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/ItemType/SimpleItem/Transformer.php
+++ b/app/ItemType/SimpleItem/Transformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace App\ItemType\SimpleItem;
 
-use App\Models\Transformers\Transformer as BaseTransformer;
+use App\Transformers\Transformer as BaseTransformer;
 
 /**
  * @author Dean Blackborough <dean@g3d-development.com>

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -89,6 +89,22 @@ class Category extends Model
                         `sub_category`.`category_id` = `category`.`id`
                 ) AS `category_subcategories`'
             )
+            ->selectRaw('
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(category.created_at), 
+                            IFNULL(MAX(category.updated_at), 0)
+                        )
+                    FROM 
+                        category
+                    WHERE 
+                        category.resource_type_id = ? 
+                ) AS last_updated',
+                [
+                    $resource_type_id
+                ]
+            )
             ->join("resource_type", "category.resource_type_id", "resource_type.id")
             ->where('category.resource_type_id', '=', $resource_type_id);
 

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -93,6 +93,22 @@ class Resource extends Model
                 'item_subtype.name AS resource_item_subtype_name',
                 'item_subtype.description AS resource_item_subtype_description'
             )
+            ->selectRaw('
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(resource.created_at), 
+                            IFNULL(MAX(resource.updated_at), 0)
+                        )
+                    FROM 
+                        resource
+                    WHERE
+                        `resource_type_id` = ? 
+                ) AS last_updated',
+                [
+                    $resource_type_id
+                ]
+            )
             ->join('resource_item_subtype', 'resource_item_subtype.resource_id', 'resource.id')
             ->join('item_subtype', 'resource_item_subtype.item_subtype_id', 'item_subtype.id')
             ->where('resource_type_id', '=', $resource_type_id);

--- a/app/Models/ResourceType.php
+++ b/app/Models/ResourceType.php
@@ -111,6 +111,17 @@ class ResourceType extends Model
                         resource.resource_type_id = resource_type.id
                 ) AS resource_type_resources'
             )
+            ->selectRaw('
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(resource_type.created_at), 
+                            IFNULL(MAX(resource_type.updated_at), 0)
+                        )
+                    FROM 
+                        resource_type 
+                ) AS last_updated'
+            )
             ->join('resource_type_item_type', 'resource_type.id', 'resource_type_item_type.resource_type_id')
             ->join('item_type', 'resource_type_item_type.item_type_id', 'item_type.id')
             ->leftJoin("resource", "resource_type.id", "resource.id");

--- a/app/Models/Summary/Category.php
+++ b/app/Models/Summary/Category.php
@@ -23,10 +23,26 @@ class Category extends Model
         int $resource_type_id,
         array $viewable_resource_types,
         array $search_parameters = []
-    ): int
+    ): array
     {
         $collection = $this
-            ->select('category.id')
+            ->selectRaw("COUNT(`{$this->table}`.`id`) AS total")
+            ->selectRaw("
+                (
+                    SELECT 
+                        GREATEST(
+                            MAX(`{$this->table}`.`created_at`), 
+                            IFNULL(MAX(`{$this->table}`.`updated_at`), 0)
+                        )
+                    FROM 
+                        `{$this->table}` 
+                    WHERE
+                        `{$this->table}`.`resource_type_id` = ? 
+                ) AS `last_updated`",
+                [
+                    $resource_type_id
+                ]
+            )
             ->join("resource_type", "category.resource_type_id", "resource_type.id")
             ->where('category.resource_type_id', '=', $resource_type_id);
 
@@ -37,6 +53,8 @@ class Category extends Model
 
         $collection = Clause::applySearch($collection, $this->table, $search_parameters);
 
-        return $collection->count();
+        return $collection
+            ->get()
+            ->toArray();
     }
 }

--- a/app/Models/Summary/ResourceType.php
+++ b/app/Models/Summary/ResourceType.php
@@ -31,8 +31,7 @@ class ResourceType extends Model
                     MAX(`{$this->table}`.`created_at`),
                     IFNULL(MAX(`{$this->table}`.`updated_at`), 0)
                 ) AS last_updated"
-            )
-            ->groupBy("{$this->table}.id");
+            );
 
         $collection = Clause::applyViewableResourceTypes(
             $collection,

--- a/app/Models/Summary/ResourceType.php
+++ b/app/Models/Summary/ResourceType.php
@@ -25,7 +25,7 @@ class ResourceType extends Model
     ): array
     {
         $collection = $this
-            ->selectRaw('SUM(resource_type.id) AS total')
+            ->selectRaw('COUNT(resource_type.id) AS total')
             ->selectRaw(
                 "GREATEST(
                     MAX(`{$this->table}`.`created_at`),

--- a/app/Transformers/Category.php
+++ b/app/Transformers/Category.php
@@ -1,7 +1,10 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Subcategory;
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/Currency.php
+++ b/app/Transformers/Currency.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/ItemCategory.php
+++ b/app/Transformers/ItemCategory.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/ItemPartialTransfer.php
+++ b/app/Transformers/ItemPartialTransfer.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/ItemSubcategory.php
+++ b/app/Transformers/ItemSubcategory.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/ItemSubtype.php
+++ b/app/Transformers/ItemSubtype.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/ItemTransfer.php
+++ b/app/Transformers/ItemTransfer.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/ItemType.php
+++ b/app/Transformers/ItemType.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/PermittedUser.php
+++ b/app/Transformers/PermittedUser.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display
@@ -10,14 +12,15 @@ namespace App\Models\Transformers;
  * @copyright Dean Blackborough 2018-2020
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class Queue extends Transformer
+class PermittedUser extends Transformer
 {
     public function format(array $to_transform): void
     {
         $this->transformed = [
-            'id' => $this->hash->queue()->encode($to_transform['jobs_id']),
-            'queue' => $to_transform['jobs_queue'],
-            'created' => $to_transform['jobs_created_at']
+            'id' => $this->hash->permittedUser()->encode($to_transform['permitted_user_id']),
+            'name' => $to_transform['permitted_user_name'],
+            'email' => $to_transform['permitted_user_email'],
+            'created' => $to_transform['permitted_user_created_at']
         ];
     }
 }

--- a/app/Transformers/Queue.php
+++ b/app/Transformers/Queue.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display
@@ -10,15 +12,14 @@ namespace App\Models\Transformers;
  * @copyright Dean Blackborough 2018-2020
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class PermittedUser extends Transformer
+class Queue extends Transformer
 {
     public function format(array $to_transform): void
     {
         $this->transformed = [
-            'id' => $this->hash->permittedUser()->encode($to_transform['permitted_user_id']),
-            'name' => $to_transform['permitted_user_name'],
-            'email' => $to_transform['permitted_user_email'],
-            'created' => $to_transform['permitted_user_created_at']
+            'id' => $this->hash->queue()->encode($to_transform['jobs_id']),
+            'queue' => $to_transform['jobs_queue'],
+            'created' => $to_transform['jobs_created_at']
         ];
     }
 }

--- a/app/Transformers/RequestErrorLog.php
+++ b/app/Transformers/RequestErrorLog.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/Resource.php
+++ b/app/Transformers/Resource.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/ResourceType.php
+++ b/app/Transformers/ResourceType.php
@@ -1,9 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
 
-use App\Models\Transformers\Resource as ResourceTransformer;
+use App\Transformers\Transformer;
+use App\Transformers\Resource as ResourceTransformer;
+use App\Transformers\Resource;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/ResourceTypeItem.php
+++ b/app/Transformers/ResourceTypeItem.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/Subcategory.php
+++ b/app/Transformers/Subcategory.php
@@ -1,7 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
+
+use App\Transformers\Transformer;
 
 /**
  * Transform the data from our queries into the format we want to display

--- a/app/Transformers/Transformer.php
+++ b/app/Transformers/Transformer.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Models\Transformers;
+namespace App\Transformers;
 
 use App\Request\Hash;
 

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": "^7.4",
         "ext-json": "*",
+        "lcobucci/jwt": "3.3.0",
         "doctrine/dbal": "^2.9",
         "fideloper/proxy": "^4.0",
         "guzzlehttp/guzzle": "^6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1dc7bf0bb3864317078e7a60190d47b6",
+    "content-hash": "d869d9f5a2533c7fd6db5a19a5d384ec",
     "packages": [
         {
             "name": "brick/math",
@@ -252,33 +252,32 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "2.10.3",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "03ca23afc2ee062f5d3e32426ad37c34a4770dcf"
+                "reference": "adce7a954a1c2f14f85e94aed90c8489af204086"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/03ca23afc2ee062f5d3e32426ad37c34a4770dcf",
-                "reference": "03ca23afc2ee062f5d3e32426ad37c34a4770dcf",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/adce7a954a1c2f14f85e94aed90c8489af204086",
+                "reference": "adce7a954a1c2f14f85e94aed90c8489af204086",
                 "shasum": ""
             },
             "require": {
                 "doctrine/cache": "^1.0",
                 "doctrine/event-manager": "^1.0",
                 "ext-pdo": "*",
-                "php": "^7.2"
+                "php": "^7.3 || ^8"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^8.1",
                 "jetbrains/phpstorm-stubs": "^2019.1",
-                "nikic/php-parser": "^4.4",
                 "phpstan/phpstan": "^0.12.40",
-                "phpunit/phpunit": "^8.5.5",
+                "phpunit/phpunit": "^9.4",
                 "psalm/plugin-phpunit": "^0.10.0",
                 "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-                "vimeo/psalm": "^3.14.2"
+                "vimeo/psalm": "^3.17.2"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -289,8 +288,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.10.x-dev",
-                    "dev-develop": "3.0.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -357,7 +355,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-02T01:35:42+00:00"
+            "time": "2020-11-14T20:26:58+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -618,23 +616,23 @@
         },
         {
             "name": "dragonmantank/cron-expression",
-            "version": "v2.3.0",
+            "version": "v2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dragonmantank/cron-expression.git",
-                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27"
+                "reference": "65b2d8ee1f10915efb3b55597da3404f096acba2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/72b6fbf76adb3cf5bc0db68559b33d41219aba27",
-                "reference": "72b6fbf76adb3cf5bc0db68559b33d41219aba27",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/65b2d8ee1f10915efb3b55597da3404f096acba2",
+                "reference": "65b2d8ee1f10915efb3b55597da3404f096acba2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.0|^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4|^7.0"
+                "phpunit/phpunit": "^6.4|^7.0|^8.0|^9.0"
             },
             "type": "library",
             "extra": {
@@ -668,20 +666,26 @@
                 "cron",
                 "schedule"
             ],
-            "time": "2019-03-31T00:38:28+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/dragonmantank",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-13T00:52:37+00:00"
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.20",
+            "version": "2.1.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "f46887bc48db66c7f38f668eb7d6ae54583617ff"
+                "reference": "ca90a3291eee1538cd48ff25163240695bd95448"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/f46887bc48db66c7f38f668eb7d6ae54583617ff",
-                "reference": "f46887bc48db66c7f38f668eb7d6ae54583617ff",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/ca90a3291eee1538cd48ff25163240695bd95448",
+                "reference": "ca90a3291eee1538cd48ff25163240695bd95448",
                 "shasum": ""
             },
             "require": {
@@ -726,28 +730,34 @@
                 "validation",
                 "validator"
             ],
-            "time": "2020-09-06T13:44:32+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/egulias",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-14T15:56:27+00:00"
         },
         {
             "name": "fideloper/proxy",
-            "version": "4.4.0",
+            "version": "4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fideloper/TrustedProxy.git",
-                "reference": "9beebf48a1c344ed67c1d36bb1b8709db7c3c1a8"
+                "reference": "c073b2bd04d1c90e04dc1b787662b558dd65ade0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fideloper/TrustedProxy/zipball/9beebf48a1c344ed67c1d36bb1b8709db7c3c1a8",
-                "reference": "9beebf48a1c344ed67c1d36bb1b8709db7c3c1a8",
+                "url": "https://api.github.com/repos/fideloper/TrustedProxy/zipball/c073b2bd04d1c90e04dc1b787662b558dd65ade0",
+                "reference": "c073b2bd04d1c90e04dc1b787662b558dd65ade0",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0",
+                "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0",
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "illuminate/http": "^5.0|^6.0|^7.0|^8.0",
+                "illuminate/http": "^5.0|^6.0|^7.0|^8.0|^9.0",
                 "mockery/mockery": "^1.0",
                 "phpunit/phpunit": "^6.0"
             },
@@ -780,7 +790,7 @@
                 "proxy",
                 "trusted proxy"
             ],
-            "time": "2020-06-23T01:36:47+00:00"
+            "time": "2020-10-22T13:48:01+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -901,23 +911,23 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "v1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+                "reference": "60d379c243457e073cff02bc323a2a86cb355631"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
-                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/60d379c243457e073cff02bc323a2a86cb355631",
+                "reference": "60d379c243457e073cff02bc323a2a86cb355631",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.0"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0"
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
             },
             "type": "library",
             "extra": {
@@ -948,20 +958,20 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-12-20T10:07:11+00:00"
+            "time": "2020-09-30T07:37:28+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
+                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
-                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/53330f47520498c0ae1f61f7e2c90f55690c06a3",
+                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3",
                 "shasum": ""
             },
             "require": {
@@ -974,15 +984,15 @@
             },
             "require-dev": {
                 "ext-zlib": "*",
-                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
             },
             "suggest": {
-                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6-dev"
+                    "dev-master": "1.7-dev"
                 }
             },
             "autoload": {
@@ -1019,7 +1029,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2019-07-01T23:21:34+00:00"
+            "time": "2020-09-30T07:37:11+00:00"
         },
         {
             "name": "hashids/hashids",
@@ -1089,31 +1099,31 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v7.28.1",
+            "version": "v7.29.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "f7493ab717ca2a9598b1db2d6a3bae8ac8c755e8"
+                "reference": "93f6d565a07045baa0e4b941ae1f733cd5984d65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/f7493ab717ca2a9598b1db2d6a3bae8ac8c755e8",
-                "reference": "f7493ab717ca2a9598b1db2d6a3bae8ac8c755e8",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/93f6d565a07045baa0e4b941ae1f733cd5984d65",
+                "reference": "93f6d565a07045baa0e4b941ae1f733cd5984d65",
                 "shasum": ""
             },
             "require": {
                 "doctrine/inflector": "^1.4|^2.0",
-                "dragonmantank/cron-expression": "^2.0",
+                "dragonmantank/cron-expression": "^2.3.1",
                 "egulias/email-validator": "^2.1.10",
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "ext-openssl": "*",
                 "league/commonmark": "^1.3",
-                "league/flysystem": "^1.0.34",
+                "league/flysystem": "^1.1",
                 "monolog/monolog": "^2.0",
-                "nesbot/carbon": "^2.17",
-                "opis/closure": "^3.1",
-                "php": "^7.2.5",
+                "nesbot/carbon": "^2.31",
+                "opis/closure": "^3.6",
+                "php": "^7.2.5|^8.0",
                 "psr/container": "^1.0",
                 "psr/simple-cache": "^1.0",
                 "ramsey/uuid": "^3.7|^4.0",
@@ -1172,14 +1182,14 @@
             "require-dev": {
                 "aws/aws-sdk-php": "^3.0",
                 "doctrine/dbal": "^2.6",
-                "filp/whoops": "^2.4",
-                "guzzlehttp/guzzle": "^6.3.1|^7.0",
+                "filp/whoops": "^2.8",
+                "guzzlehttp/guzzle": "^6.3.1|^7.0.1",
                 "league/flysystem-cached-adapter": "^1.0",
-                "mockery/mockery": "^1.3.1",
+                "mockery/mockery": "~1.3.3|^1.4.2",
                 "moontoast/math": "^1.1",
-                "orchestra/testbench-core": "^5.0",
+                "orchestra/testbench-core": "^5.8",
                 "pda/pheanstalk": "^4.0",
-                "phpunit/phpunit": "^8.4|^9.0",
+                "phpunit/phpunit": "^8.4|^9.3.3",
                 "predis/predis": "^1.1.1",
                 "symfony/cache": "^5.0"
             },
@@ -1192,18 +1202,18 @@
                 "ext-pcntl": "Required to use all features of the queue worker.",
                 "ext-posix": "Required to use all features of the queue worker.",
                 "ext-redis": "Required to use the Redis cache and queue drivers (^4.0|^5.0).",
-                "filp/whoops": "Required for friendly error pages in development (^2.4).",
-                "fzaninotto/faker": "Required to use the eloquent factory builder (^1.9.1).",
-                "guzzlehttp/guzzle": "Required to use the HTTP Client, Mailgun mail driver and the ping methods on schedules (^6.3.1|^7.0).",
+                "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
+                "filp/whoops": "Required for friendly error pages in development (^2.8).",
+                "guzzlehttp/guzzle": "Required to use the HTTP Client, Mailgun mail driver and the ping methods on schedules (^6.3.1|^7.0.1).",
                 "laravel/tinker": "Required to use the tinker console command (^2.0).",
                 "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",
                 "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
                 "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
-                "mockery/mockery": "Required to use mocking (^1.3.1).",
+                "mockery/mockery": "Required to use mocking (~1.3.3|^1.4.2).",
                 "moontoast/math": "Required to use ordered UUIDs (^1.1).",
                 "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
                 "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
-                "phpunit/phpunit": "Required to use assertions and run tests (^8.4|^9.0).",
+                "phpunit/phpunit": "Required to use assertions and run tests (^8.4|^9.3.3).",
                 "predis/predis": "Required to use the predis connector (^1.1.2).",
                 "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
                 "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
@@ -1243,25 +1253,25 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2020-09-09T15:02:46+00:00"
+            "time": "2020-11-03T14:12:58+00:00"
         },
         {
             "name": "laravel/helpers",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/helpers.git",
-                "reference": "b4b8d6e84a6306fc88870f61a244d8c537779f2d"
+                "reference": "cde8ea2427db4f37d67729846b70452499210a21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/helpers/zipball/b4b8d6e84a6306fc88870f61a244d8c537779f2d",
-                "reference": "b4b8d6e84a6306fc88870f61a244d8c537779f2d",
+                "url": "https://api.github.com/repos/laravel/helpers/zipball/cde8ea2427db4f37d67729846b70452499210a21",
+                "reference": "cde8ea2427db4f37d67729846b70452499210a21",
                 "shasum": ""
             },
             "require": {
                 "illuminate/support": "~5.8.0|^6.0|^7.0|^8.0",
-                "php": ">=7.1.3"
+                "php": "^7.1.3|^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.0|^8.0|^9.0"
@@ -1296,7 +1306,7 @@
                 "helpers",
                 "laravel"
             ],
-            "time": "2020-08-25T17:54:37+00:00"
+            "time": "2020-11-03T16:38:41+00:00"
         },
         {
             "name": "laravel/passport",
@@ -1371,29 +1381,29 @@
         },
         {
             "name": "laravel/tinker",
-            "version": "v2.4.2",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/tinker.git",
-                "reference": "58424c24e8aec31c3a3ac54eb3adb15e8a0a067b"
+                "reference": "45884b526e10a88a1b179fa1a1a24d5468c668c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/tinker/zipball/58424c24e8aec31c3a3ac54eb3adb15e8a0a067b",
-                "reference": "58424c24e8aec31c3a3ac54eb3adb15e8a0a067b",
+                "url": "https://api.github.com/repos/laravel/tinker/zipball/45884b526e10a88a1b179fa1a1a24d5468c668c2",
+                "reference": "45884b526e10a88a1b179fa1a1a24d5468c668c2",
                 "shasum": ""
             },
             "require": {
                 "illuminate/console": "^6.0|^7.0|^8.0",
                 "illuminate/contracts": "^6.0|^7.0|^8.0",
                 "illuminate/support": "^6.0|^7.0|^8.0",
-                "php": "^7.2",
-                "psy/psysh": "^0.10.3",
-                "symfony/var-dumper": "^4.3|^5.0"
+                "php": "^7.2.5|^8.0",
+                "psy/psysh": "^0.10.4",
+                "symfony/var-dumper": "^4.3.4|^5.0"
             },
             "require-dev": {
-                "mockery/mockery": "^1.3.1",
-                "phpunit/phpunit": "^8.4|^9.0"
+                "mockery/mockery": "~1.3.3|^1.4.2",
+                "phpunit/phpunit": "^8.5.8|^9.3.3"
             },
             "suggest": {
                 "illuminate/database": "The Illuminate Database package (^6.0|^7.0|^8.0)."
@@ -1431,20 +1441,20 @@
                 "laravel",
                 "psysh"
             ],
-            "time": "2020-08-11T19:28:08+00:00"
+            "time": "2020-10-29T13:07:12+00:00"
         },
         {
             "name": "lcobucci/jwt",
-            "version": "3.3.3",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "c1123697f6a2ec29162b82f170dd4a491f524773"
+                "reference": "8866a58fa866f6872f2a6ea0e04ad56480f0f440"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/c1123697f6a2ec29162b82f170dd4a491f524773",
-                "reference": "c1123697f6a2ec29162b82f170dd4a491f524773",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/8866a58fa866f6872f2a6ea0e04ad56480f0f440",
+                "reference": "8866a58fa866f6872f2a6ea0e04ad56480f0f440",
                 "shasum": ""
             },
             "require": {
@@ -1486,30 +1496,20 @@
                 "JWS",
                 "jwt"
             ],
-            "funding": [
-                {
-                    "url": "https://github.com/lcobucci",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/lcobucci",
-                    "type": "patreon"
-                }
-            ],
-            "time": "2020-08-20T13:22:28+00:00"
+            "time": "2019-05-22T09:44:23+00:00"
         },
         {
             "name": "league/commonmark",
-            "version": "1.5.4",
+            "version": "1.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "21819c989e69bab07e933866ad30c7e3f32984ba"
+                "reference": "11df9b36fd4f1d2b727a73bf14931d81373b9a54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/21819c989e69bab07e933866ad30c7e3f32984ba",
-                "reference": "21819c989e69bab07e933866ad30c7e3f32984ba",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/11df9b36fd4f1d2b727a73bf14931d81373b9a54",
+                "reference": "11df9b36fd4f1d2b727a73bf14931d81373b9a54",
                 "shasum": ""
             },
             "require": {
@@ -1521,7 +1521,7 @@
             },
             "require-dev": {
                 "cebe/markdown": "~1.0",
-                "commonmark/commonmark.js": "0.29.1",
+                "commonmark/commonmark.js": "0.29.2",
                 "erusev/parsedown": "~1.0",
                 "ext-json": "*",
                 "github/gfm": "0.29.0",
@@ -1591,7 +1591,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-18T01:19:12+00:00"
+            "time": "2020-10-31T13:49:32+00:00"
         },
         {
             "name": "league/event",
@@ -1736,16 +1736,16 @@
         },
         {
             "name": "league/mime-type-detection",
-            "version": "1.4.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/mime-type-detection.git",
-                "reference": "fda190b62b962d96a069fcc414d781db66d65b69"
+                "reference": "353f66d7555d8a90781f6f5e7091932f9a4250aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/fda190b62b962d96a069fcc414d781db66d65b69",
-                "reference": "fda190b62b962d96a069fcc414d781db66d65b69",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/353f66d7555d8a90781f6f5e7091932f9a4250aa",
+                "reference": "353f66d7555d8a90781f6f5e7091932f9a4250aa",
                 "shasum": ""
             },
             "require": {
@@ -1783,7 +1783,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-09T10:34:01+00:00"
+            "time": "2020-10-18T11:50:25+00:00"
         },
         {
             "name": "league/oauth2-server",
@@ -1955,16 +1955,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.39.2",
+            "version": "2.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "326efde1bc09077a26cb77f6e2e32e13f06c27f2"
+                "reference": "d0463779663437392fe42ff339ebc0213bd55498"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/326efde1bc09077a26cb77f6e2e32e13f06c27f2",
-                "reference": "326efde1bc09077a26cb77f6e2e32e13f06c27f2",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/d0463779663437392fe42ff339ebc0213bd55498",
+                "reference": "d0463779663437392fe42ff339ebc0213bd55498",
                 "shasum": ""
             },
             "require": {
@@ -1979,7 +1979,7 @@
                 "kylekatarnls/multi-tester": "^2.0",
                 "phpmd/phpmd": "^2.9",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.35",
+                "phpstan/phpstan": "^0.12.54",
                 "phpunit/phpunit": "^7.5 || ^8.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
@@ -2040,20 +2040,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-10T12:16:42+00:00"
+            "time": "2020-11-28T14:25:28+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.9.1",
+            "version": "v4.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "88e519766fc58bd46b8265561fb79b54e2e00b28"
+                "reference": "658f1be311a230e0907f5dfe0213742aff0596de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/88e519766fc58bd46b8265561fb79b54e2e00b28",
-                "reference": "88e519766fc58bd46b8265561fb79b54e2e00b28",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/658f1be311a230e0907f5dfe0213742aff0596de",
+                "reference": "658f1be311a230e0907f5dfe0213742aff0596de",
                 "shasum": ""
             },
             "require": {
@@ -2092,33 +2092,33 @@
                 "parser",
                 "php"
             ],
-            "time": "2020-08-30T16:15:20+00:00"
+            "time": "2020-09-26T10:30:38+00:00"
         },
         {
             "name": "opis/closure",
-            "version": "3.5.7",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opis/closure.git",
-                "reference": "4531e53afe2fc660403e76fb7644e95998bff7bf"
+                "reference": "943b5d70cc5ae7483f6aff6ff43d7e34592ca0f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opis/closure/zipball/4531e53afe2fc660403e76fb7644e95998bff7bf",
-                "reference": "4531e53afe2fc660403e76fb7644e95998bff7bf",
+                "url": "https://api.github.com/repos/opis/closure/zipball/943b5d70cc5ae7483f6aff6ff43d7e34592ca0f5",
+                "reference": "943b5d70cc5ae7483f6aff6ff43d7e34592ca0f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.4 || ^7.0"
+                "php": "^5.4 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "jeremeamia/superclosure": "^2.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.5.x-dev"
+                    "dev-master": "3.6.x-dev"
                 }
             },
             "autoload": {
@@ -2153,24 +2153,24 @@
                 "serialization",
                 "serialize"
             ],
-            "time": "2020-09-06T17:02:15+00:00"
+            "time": "2020-11-07T02:01:34+00:00"
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v9.99.99",
+            "version": "v9.99.100",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7"
+                "php": ">= 7"
             },
             "require-dev": {
                 "phpunit/phpunit": "4.*|5.*",
@@ -2198,7 +2198,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2018-07-02T15:55:56+00:00"
+            "time": "2020-10-15T08:29:30+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -2994,16 +2994,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "186f395b256065ba9b890c0a4e48a91d598fa2cf"
+                "reference": "e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/186f395b256065ba9b890c0a4e48a91d598fa2cf",
-                "reference": "186f395b256065ba9b890c0a4e48a91d598fa2cf",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e",
+                "reference": "e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e",
                 "shasum": ""
             },
             "require": {
@@ -3040,11 +3040,6 @@
                 "symfony/process": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
@@ -3083,31 +3078,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-02T07:07:40+00:00"
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "e544e24472d4c97b2d11ade7caacd446727c6bf9"
+                "reference": "6cbebda22ffc0d4bb8fea0c1311c2ca54c4c8fa0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/e544e24472d4c97b2d11ade7caacd446727c6bf9",
-                "reference": "e544e24472d4c97b2d11ade7caacd446727c6bf9",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/6cbebda22ffc0d4bb8fea0c1311c2ca54c4c8fa0",
+                "reference": "6cbebda22ffc0d4bb8fea0c1311c2ca54c4c8fa0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\CssSelector\\": ""
@@ -3150,7 +3140,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-20T17:43:50+00:00"
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3218,16 +3208,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "525636d4b84e06c6ca72d96b6856b5b169416e6a"
+                "reference": "a154f2b12fd1ec708559ba73ed58bd1304e55718"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/525636d4b84e06c6ca72d96b6856b5b169416e6a",
-                "reference": "525636d4b84e06c6ca72d96b6856b5b169416e6a",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/a154f2b12fd1ec708559ba73ed58bd1304e55718",
+                "reference": "a154f2b12fd1ec708559ba73ed58bd1304e55718",
                 "shasum": ""
             },
             "require": {
@@ -3242,11 +3232,6 @@
                 "symfony/serializer": "^4.4|^5.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\ErrorHandler\\": ""
@@ -3285,20 +3270,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-17T10:01:29+00:00"
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "94871fc0a69c3c5da57764187724cdce0755899c"
+                "reference": "26f4edae48c913fc183a3da0553fe63bdfbd361a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/94871fc0a69c3c5da57764187724cdce0755899c",
-                "reference": "94871fc0a69c3c5da57764187724cdce0755899c",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/26f4edae48c913fc183a3da0553fe63bdfbd361a",
+                "reference": "26f4edae48c913fc183a3da0553fe63bdfbd361a",
                 "shasum": ""
             },
             "require": {
@@ -3318,6 +3303,7 @@
                 "psr/log": "~1.0",
                 "symfony/config": "^4.4|^5.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0",
                 "symfony/expression-language": "^4.4|^5.0",
                 "symfony/http-foundation": "^4.4|^5.0",
                 "symfony/service-contracts": "^1.1|^2",
@@ -3328,11 +3314,6 @@
                 "symfony/http-kernel": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\EventDispatcher\\": ""
@@ -3371,7 +3352,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-13T14:19:42+00:00"
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -3451,27 +3432,22 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "2b765f0cf6612b3636e738c0689b29aa63088d5d"
+                "reference": "e70eb5a69c2ff61ea135a13d2266e8914a67b3a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/2b765f0cf6612b3636e738c0689b29aa63088d5d",
-                "reference": "2b765f0cf6612b3636e738c0689b29aa63088d5d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e70eb5a69c2ff61ea135a13d2266e8914a67b3a0",
+                "reference": "e70eb5a69c2ff61ea135a13d2266e8914a67b3a0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
@@ -3510,20 +3486,96 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-17T10:01:29+00:00"
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
-            "name": "symfony/http-foundation",
-            "version": "v5.1.5",
+            "name": "symfony/http-client-contracts",
+            "version": "v2.3.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "41a4647f12870e9d41d9a7d72ff0614a27208558"
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "41db680a15018f9c1d4b23516059633ce280ca33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/41a4647f12870e9d41d9a7d72ff0614a27208558",
-                "reference": "41a4647f12870e9d41d9a7d72ff0614a27208558",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/41db680a15018f9c1d4b23516059633ce280ca33",
+                "reference": "41db680a15018f9c1d4b23516059633ce280ca33",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5"
+            },
+            "suggest": {
+                "symfony/http-client-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-version": "2.3",
+                "branch-alias": {
+                    "dev-main": "2.3-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-14T17:08:19+00:00"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v5.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "a2860ec970404b0233ab1e59e0568d3277d32b6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/a2860ec970404b0233ab1e59e0568d3277d32b6f",
+                "reference": "a2860ec970404b0233ab1e59e0568d3277d32b6f",
                 "shasum": ""
             },
             "require": {
@@ -3542,11 +3594,6 @@
                 "symfony/mime": "To use the file extension guesser"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\HttpFoundation\\": ""
@@ -3585,20 +3632,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-17T07:48:54+00:00"
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "3e32676e6cb5d2081c91a56783471ff8a7f7110b"
+                "reference": "a13b3c4d994a4fd051f4c6800c5e33c9508091dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/3e32676e6cb5d2081c91a56783471ff8a7f7110b",
-                "reference": "3e32676e6cb5d2081c91a56783471ff8a7f7110b",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/a13b3c4d994a4fd051f4c6800c5e33c9508091dd",
+                "reference": "a13b3c4d994a4fd051f4c6800c5e33c9508091dd",
                 "shasum": ""
             },
             "require": {
@@ -3607,6 +3654,7 @@
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/error-handler": "^4.4|^5.0",
                 "symfony/event-dispatcher": "^5.0",
+                "symfony/http-client-contracts": "^1.1|^2",
                 "symfony/http-foundation": "^4.4|^5.0",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-php73": "^1.9",
@@ -3655,11 +3703,6 @@
                 "symfony/dependency-injection": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\HttpKernel\\": ""
@@ -3698,20 +3741,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-02T08:15:18+00:00"
+            "time": "2020-10-28T05:55:23+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "89a2c9b4cb7b5aa516cf55f5194c384f444c81dc"
+                "reference": "f5485a92c24d4bcfc2f3fc648744fb398482ff1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/89a2c9b4cb7b5aa516cf55f5194c384f444c81dc",
-                "reference": "89a2c9b4cb7b5aa516cf55f5194c384f444c81dc",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/f5485a92c24d4bcfc2f3fc648744fb398482ff1b",
+                "reference": "f5485a92c24d4bcfc2f3fc648744fb398482ff1b",
                 "shasum": ""
             },
             "require": {
@@ -3728,11 +3771,6 @@
                 "symfony/dependency-injection": "^4.4|^5.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Mime\\": ""
@@ -3775,24 +3813,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-17T10:01:29+00:00"
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -3800,7 +3838,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3851,24 +3889,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "6c2f78eb8f5ab8eaea98f6d414a5915f2e0fce36"
+                "reference": "c536646fdb4f29104dd26effc2fdcb9a5b085024"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/6c2f78eb8f5ab8eaea98f6d414a5915f2e0fce36",
-                "reference": "6c2f78eb8f5ab8eaea98f6d414a5915f2e0fce36",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/c536646fdb4f29104dd26effc2fdcb9a5b085024",
+                "reference": "c536646fdb4f29104dd26effc2fdcb9a5b085024",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-iconv": "For best performance"
@@ -3876,7 +3914,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3928,24 +3966,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "b740103edbdcc39602239ee8860f0f45a8eb9aa5"
+                "reference": "c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b740103edbdcc39602239ee8860f0f45a8eb9aa5",
-                "reference": "b740103edbdcc39602239ee8860f0f45a8eb9aa5",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c",
+                "reference": "c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -3953,7 +3991,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4006,26 +4044,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "5dcab1bc7146cf8c1beaa4502a3d9be344334251"
+                "reference": "3b75acd829741c768bc8b1f84eb33265e7cc5117"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/5dcab1bc7146cf8c1beaa4502a3d9be344334251",
-                "reference": "5dcab1bc7146cf8c1beaa4502a3d9be344334251",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/3b75acd829741c768bc8b1f84eb33265e7cc5117",
+                "reference": "3b75acd829741c768bc8b1f84eb33265e7cc5117",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": ">=7.1",
                 "symfony/polyfill-intl-normalizer": "^1.10",
-                "symfony/polyfill-php70": "^1.10",
                 "symfony/polyfill-php72": "^1.10"
             },
             "suggest": {
@@ -4034,7 +4071,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4091,24 +4128,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-04T06:02:08+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e"
+                "reference": "727d1096295d807c309fb01a851577302394c897"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e",
-                "reference": "37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/727d1096295d807c309fb01a851577302394c897",
+                "reference": "727d1096295d807c309fb01a851577302394c897",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -4116,7 +4153,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4172,24 +4209,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a"
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/a6977d63bf9a0ad4c65cd352709e230876f9904a",
-                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -4197,7 +4234,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4249,106 +4286,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php70",
-            "version": "v1.18.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "0dd93f2c578bdc9c72697eaa5f1dd25644e618d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/0dd93f2c578bdc9c72697eaa5f1dd25644e618d3",
-                "reference": "0dd93f2c578bdc9c72697eaa5f1dd25644e618d3",
-                "shasum": ""
-            },
-            "require": {
-                "paragonie/random_compat": "~1.0|~2.0|~9.99",
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.18-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php70\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "639447d008615574653fb3bc60d1986d7172eaae"
+                "reference": "cede45fcdfabdd6043b3592e83678e42ec69e930"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/639447d008615574653fb3bc60d1986d7172eaae",
-                "reference": "639447d008615574653fb3bc60d1986d7172eaae",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cede45fcdfabdd6043b3592e83678e42ec69e930",
+                "reference": "cede45fcdfabdd6043b3592e83678e42ec69e930",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4399,29 +4359,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "fffa1a52a023e782cdcc221d781fe1ec8f87fcca"
+                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fffa1a52a023e782cdcc221d781fe1ec8f87fcca",
-                "reference": "fffa1a52a023e782cdcc221d781fe1ec8f87fcca",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/8ff431c517be11c78c48a39a66d37431e26a6bed",
+                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4475,29 +4435,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981"
+                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/d87d5766cbf48d72388a9f6b85f280c8ad51f981",
-                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
+                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.8"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4555,20 +4515,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "1864216226af21eb76d9477f691e7cbf198e0402"
+                "reference": "f00872c3f6804150d6a0f73b4151daab96248101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/1864216226af21eb76d9477f691e7cbf198e0402",
-                "reference": "1864216226af21eb76d9477f691e7cbf198e0402",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f00872c3f6804150d6a0f73b4151daab96248101",
+                "reference": "f00872c3f6804150d6a0f73b4151daab96248101",
                 "shasum": ""
             },
             "require": {
@@ -4576,11 +4536,6 @@
                 "symfony/polyfill-php80": "^1.15"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Process\\": ""
@@ -4619,7 +4574,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-23T08:36:24+00:00"
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -4688,16 +4643,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "47b0218344cb6af25c93ca8ee1137fafbee5005d"
+                "reference": "d6ceee2a37b61b41079005207bf37746d1bfe71f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/47b0218344cb6af25c93ca8ee1137fafbee5005d",
-                "reference": "47b0218344cb6af25c93ca8ee1137fafbee5005d",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/d6ceee2a37b61b41079005207bf37746d1bfe71f",
+                "reference": "d6ceee2a37b61b41079005207bf37746d1bfe71f",
                 "shasum": ""
             },
             "require": {
@@ -4727,11 +4682,6 @@
                 "symfony/yaml": "For using the YAML loader"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Routing\\": ""
@@ -4776,7 +4726,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-10T08:03:57+00:00"
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4856,16 +4806,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "0de4cc1e18bb596226c06a82e2e7e9bc6001a63a"
+                "reference": "a97573e960303db71be0dd8fda9be3bca5e0feea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/0de4cc1e18bb596226c06a82e2e7e9bc6001a63a",
-                "reference": "0de4cc1e18bb596226c06a82e2e7e9bc6001a63a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/a97573e960303db71be0dd8fda9be3bca5e0feea",
+                "reference": "a97573e960303db71be0dd8fda9be3bca5e0feea",
                 "shasum": ""
             },
             "require": {
@@ -4883,11 +4833,6 @@
                 "symfony/var-exporter": "^4.4|^5.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\String\\": ""
@@ -4937,20 +4882,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-17T07:48:54+00:00"
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "917b02cdc5f33e0309b8e9d33ee1480b20687413"
+                "reference": "27980838fd261e04379fa91e94e81e662fe5a1b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/917b02cdc5f33e0309b8e9d33ee1480b20687413",
-                "reference": "917b02cdc5f33e0309b8e9d33ee1480b20687413",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/27980838fd261e04379fa91e94e81e662fe5a1b6",
+                "reference": "27980838fd261e04379fa91e94e81e662fe5a1b6",
                 "shasum": ""
             },
             "require": {
@@ -4986,11 +4931,6 @@
                 "symfony/yaml": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Translation\\": ""
@@ -5029,20 +4969,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-17T10:01:29+00:00"
+            "time": "2020-10-24T12:01:57+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v2.2.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "77ce1c3627c9f39643acd9af086631f842c50c4d"
+                "reference": "e2eaa60b558f26a4b0354e1bbb25636efaaad105"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/77ce1c3627c9f39643acd9af086631f842c50c4d",
-                "reference": "77ce1c3627c9f39643acd9af086631f842c50c4d",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/e2eaa60b558f26a4b0354e1bbb25636efaaad105",
+                "reference": "e2eaa60b558f26a4b0354e1bbb25636efaaad105",
                 "shasum": ""
             },
             "require": {
@@ -5054,7 +4994,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -5104,20 +5044,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2020-09-28T13:05:58+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v5.1.5",
+            "version": "v5.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "b43a3905262bcf97b2510f0621f859ca4f5287be"
+                "reference": "4e13f3fcefb1fcaaa5efb5403581406f4e840b9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b43a3905262bcf97b2510f0621f859ca4f5287be",
-                "reference": "b43a3905262bcf97b2510f0621f859ca4f5287be",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/4e13f3fcefb1fcaaa5efb5403581406f4e840b9a",
+                "reference": "4e13f3fcefb1fcaaa5efb5403581406f4e840b9a",
                 "shasum": ""
             },
             "require": {
@@ -5144,11 +5084,6 @@
                 "Resources/bin/var-dump-server"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "Resources/functions/dump.php"
@@ -5194,7 +5129,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-17T07:42:30+00:00"
+            "time": "2020-10-27T10:11:13+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -5321,23 +5256,23 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "1.5.3",
+            "version": "1.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "25bcbf01678930251fd572891447d9e318a6e2b8"
+                "reference": "80953678b19901e5165c56752d087fc11526017c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/25bcbf01678930251fd572891447d9e318a6e2b8",
-                "reference": "25bcbf01678930251fd572891447d9e318a6e2b8",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/80953678b19901e5165c56752d087fc11526017c",
+                "reference": "80953678b19901e5165c56752d087fc11526017c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.0.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0"
+                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
             },
             "suggest": {
                 "ext-intl": "Use Intl for transliterator_transliterate() support"
@@ -5387,7 +5322,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-22T23:32:04+00:00"
+            "time": "2020-11-12T00:07:28+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -5461,36 +5396,31 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -5504,7 +5434,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -5527,29 +5457,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-29T17:27:14+00:00"
+            "time": "2020-11-10T18:47:58+00:00"
         },
         {
             "name": "facade/ignition-contracts",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facade/ignition-contracts.git",
-                "reference": "aeab1ce8b68b188a43e81758e750151ad7da796b"
+                "reference": "3c921a1cdba35b68a7f0ccffc6dffc1995b18267"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facade/ignition-contracts/zipball/aeab1ce8b68b188a43e81758e750151ad7da796b",
-                "reference": "aeab1ce8b68b188a43e81758e750151ad7da796b",
+                "url": "https://api.github.com/repos/facade/ignition-contracts/zipball/3c921a1cdba35b68a7f0ccffc6dffc1995b18267",
+                "reference": "3c921a1cdba35b68a7f0ccffc6dffc1995b18267",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3|^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.14",
-                "phpunit/phpunit": "^7.5|^8.0",
-                "vimeo/psalm": "^3.12"
+                "friendsofphp/php-cs-fixer": "^v2.15.8",
+                "phpunit/phpunit": "^9.3.11",
+                "vimeo/psalm": "^3.17.1"
             },
             "type": "library",
             "autoload": {
@@ -5576,29 +5506,29 @@
                 "flare",
                 "ignition"
             ],
-            "time": "2020-07-14T10:10:28+00:00"
+            "time": "2020-10-16T08:27:54+00:00"
         },
         {
             "name": "filp/whoops",
-            "version": "2.7.3",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "5d5fe9bb3d656b514d455645b3addc5f7ba7714d"
+                "reference": "307fb34a5ab697461ec4c9db865b20ff2fd40771"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/5d5fe9bb3d656b514d455645b3addc5f7ba7714d",
-                "reference": "5d5fe9bb3d656b514d455645b3addc5f7ba7714d",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/307fb34a5ab697461ec4c9db865b20ff2fd40771",
+                "reference": "307fb34a5ab697461ec4c9db865b20ff2fd40771",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9 || ^7.0",
+                "php": "^5.5.9 || ^7.0 || ^8.0",
                 "psr/log": "^1.0.1"
             },
             "require-dev": {
                 "mockery/mockery": "^0.9 || ^1.0",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.3",
                 "symfony/var-dumper": "^2.6 || ^3.0 || ^4.0 || ^5.0"
             },
             "suggest": {
@@ -5608,7 +5538,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
@@ -5637,7 +5567,7 @@
                 "throwable",
                 "whoops"
             ],
-            "time": "2020-06-14T09:00:00+00:00"
+            "time": "2020-11-01T12:00:00+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -5687,6 +5617,7 @@
                 "faker",
                 "fixtures"
             ],
+            "abandoned": true,
             "time": "2019-12-12T13:22:17+00:00"
         },
         {
@@ -5806,16 +5737,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
                 "shasum": ""
             },
             "require": {
@@ -5856,26 +5787,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-29T13:22:24+00:00"
+            "time": "2020-11-13T09:40:50+00:00"
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v4.2.0",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "d50490417eded97be300a92cd7df7badc37a9018"
+                "reference": "7c125dc2463f3e144ddc7e05e63077109508c94e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/d50490417eded97be300a92cd7df7badc37a9018",
-                "reference": "d50490417eded97be300a92cd7df7badc37a9018",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/7c125dc2463f3e144ddc7e05e63077109508c94e",
+                "reference": "7c125dc2463f3e144ddc7e05e63077109508c94e",
                 "shasum": ""
             },
             "require": {
                 "facade/ignition-contracts": "^1.0",
                 "filp/whoops": "^2.4",
-                "php": "^7.2.5",
+                "php": "^7.2.5 || ^8.0",
                 "symfony/console": "^5.0"
             },
             "require-dev": {
@@ -5885,7 +5816,7 @@
                 "fruitcake/laravel-cors": "^1.0",
                 "laravel/framework": "^7.0",
                 "laravel/tinker": "^2.0",
-                "nunomaduro/larastan": "^0.5",
+                "nunomaduro/larastan": "^0.6",
                 "orchestra/testbench": "^5.0",
                 "phpstan/phpstan": "^0.12.3",
                 "phpunit/phpunit": "^8.5.1 || ^9.0"
@@ -5926,7 +5857,21 @@
                 "php",
                 "symfony"
             ],
-            "time": "2020-04-04T19:56:08+00:00"
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-10-29T15:12:23+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -6081,16 +6026,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.1",
+            "version": "5.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44"
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d870572532cd70bc3fab58f2e23ad423c8404c44",
-                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
                 "shasum": ""
             },
             "require": {
@@ -6129,20 +6074,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2020-08-15T11:14:08+00:00"
+            "time": "2020-09-03T19:13:55+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651"
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e878a14a65245fbe78f8080eba03b47c3b705651",
-                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
                 "shasum": ""
             },
             "require": {
@@ -6174,32 +6119,32 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2020-06-27T10:12:23+00:00"
+            "time": "2020-09-17T18:55:26+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.11.1",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "b20034be5efcdab4fb60ca3a29cba2949aead160"
+                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b20034be5efcdab4fb60ca3a29cba2949aead160",
-                "reference": "b20034be5efcdab4fb60ca3a29cba2949aead160",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2",
-                "phpdocumentor/reflection-docblock": "^5.0",
+                "php": "^7.2 || ~8.0, <8.1",
+                "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0",
-                "phpunit/phpunit": "^8.0"
+                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
             },
             "type": "library",
             "extra": {
@@ -6237,20 +6182,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-07-08T12:44:21+00:00"
+            "time": "2020-09-29T09:10:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "7.0.10",
+            "version": "7.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf"
+                "reference": "52f55786aa2e52c26cd9e2db20aff2981e0f7399"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f1884187926fbb755a9aaf0b3836ad3165b478bf",
-                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/52f55786aa2e52c26cd9e2db20aff2981e0f7399",
+                "reference": "52f55786aa2e52c26cd9e2db20aff2981e0f7399",
                 "shasum": ""
             },
             "require": {
@@ -6300,7 +6245,13 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-11-20T13:55:58+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-27T06:08:35+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -6494,39 +6445,39 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.8",
+            "version": "8.5.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "34c18baa6a44f1d1fbf0338907139e9dce95b997"
+                "reference": "3123601e3b29339b20129acc3f989cfec3274566"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/34c18baa6a44f1d1fbf0338907139e9dce95b997",
-                "reference": "34c18baa6a44f1d1fbf0338907139e9dce95b997",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3123601e3b29339b20129acc3f989cfec3274566",
+                "reference": "3123601e3b29339b20129acc3f989cfec3274566",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.2.0",
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.9.1",
+                "myclabs/deep-copy": "^1.10.0",
                 "phar-io/manifest": "^1.0.3",
                 "phar-io/version": "^2.0.1",
                 "php": "^7.2",
-                "phpspec/prophecy": "^1.8.1",
-                "phpunit/php-code-coverage": "^7.0.7",
+                "phpspec/prophecy": "^1.10.3",
+                "phpunit/php-code-coverage": "^7.0.12",
                 "phpunit/php-file-iterator": "^2.0.2",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^2.1.2",
                 "sebastian/comparator": "^3.0.2",
                 "sebastian/diff": "^3.0.2",
-                "sebastian/environment": "^4.2.2",
-                "sebastian/exporter": "^3.1.1",
+                "sebastian/environment": "^4.2.3",
+                "sebastian/exporter": "^3.1.2",
                 "sebastian/global-state": "^3.0.0",
                 "sebastian/object-enumerator": "^3.0.3",
                 "sebastian/resource-operations": "^2.0.1",
@@ -6583,7 +6534,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-06-22T07:06:58+00:00"
+            "time": "2020-11-27T12:46:45+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/config/api/app/version.php
+++ b/config/api/app/version.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 return [
-    'version'=> 'v2.17.0',
+    'version'=> 'v2.17.1',
     'prefix' => 'v2',
-    'release_date' => '2020-11-22',
+    'release_date' => '2020-11-28',
     'changelog' => [
         'api' => '/v2/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -225,25 +225,16 @@
                     <h3>Added</h3>
 
                     <ul>
-                        <li>We have added a `complete` parameter for the `game` item-type; when the parameter is included and set to true, only complete games will be returned in collections and summaries.</li>
-                    </ul>
-
-                    <h3>Changed</h3>
-
-                    <ul>
-                        <li>We have added item-type based response classes for all item collections and summaries. Item and resource type items are unique; there are no shared dependencies. The shared dependencies were a result of the first two item-types being similar, with the addition of the game item-type, we have learnt our lesson.</li>
-                        <li>We have tweaked the TTL for permitted, and viewable resource types. The TTL for public viewable resource types is higher than for private users.</li>
-                        <li>With the addition of more item-type classes, we have tweaked our collection TTLs for public and private users.</li>
-                        <li>We have moved our 'Method' classes; it doesn't make sense for them to sit inside the 'Option' namespace.</li>
-                        <li>We have moved our 'AllowedValue' classes; it doesn't make sense for them to sit inside the 'Option' namespace.</li>
-                        <li>We have reorganised all the item-type classes; we are keeping all the classes for each item-type together.</li>
-                        <li>We have tweaked our response classes; we will do slightly less work when reading from the cache.</li>
+                        <li>We have added the `X-Last-Updated` header to the `resource-types`, `resources`, `categories`, `subcategories`, `items` and `resource items` collection routes.</li>
+                        <li>We have added the `X-Last-Updated` header to additional summary routes; the header was missing, and we are going to use it.</li>
+                        <li>We have increased the coverage of our request test suite.</li>
+                        <li>We have relocated our `Transformer` classes; we have moved them out of the `Models` namespace.</li>
                     </ul>
 
                     <h3>Fixed</h3>
 
                     <ul>
-                        <li>We have removed all our interfaces; the interfaces were not useful, and we are going a slightly different way with the item-type classes, interfaces will return.</li>
+                        <li>We have updated the way we calculated the value for `X-Last-Updated`. We are using the max of the `created at` and `updated at`, not just looking at the `created at` time.</li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
### Changed
- We have added the `X-Last-Updated` header to the `resource-types`, `resources`, `categories`, `subcategories`, `items` and `resource items` collection routes.
- We have added the `X-Last-Updated` header to additional summary routes; the header was missing, and we are going to use it.
- We have increased the coverage of our request test suite.
- We have relocated our `Transformer` classes; we have moved them out of the `Models` namespace.

### Fixed
- We have updated the way we calculated the value for `X-Last-Updated`. We are using the max of the `created at` and `updated at`, not just looking at the `created at` time.