### PR TITLE
v2.19.1

### DIFF
--- a/.docker/api/Dockerfile
+++ b/.docker/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.0-apache
 
 COPY . /var/www/html
 COPY .docker/api/vhost.conf /etc/apache2/sites-available/000-default.conf

--- a/.docker/mysql/Dockerfile
+++ b/.docker/mysql/Dockerfile
@@ -1,1 +1,1 @@
-FROM  mysql:5.7
+FROM  mysql:8

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ APP_NAME=cte-api
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
+APP_CACHE=true
 APP_URL=http://localhost:8080
 APP_URI_LOCAL=http://api
 APP_REGISTRATIONS=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 The complete changelog for the Costs to Expect REST API, our changelog follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v2.19.1] - 2021-02-12
+### Added
+- We have added additional `resource-type` tests.
+- We have started work on `resource` tests.
+
+### Changed
+- The cache setting for the API can now be set in `.env`.
+- We have updated phpunit.xml; the local cache will be disabled for tests.
+- We have updated our Docker setup; we have switched from MySQL 5.7 to 8.0 and PHP 7.4 to PHP 8.0.
+- We have moved our Cache classes into `App\Cache`.
+- We have updated our `ConvertRouteParameters` middleware; our middleware now returns a 404 for invalid route parameters.
+
+### Fixed
+- We have updated some of our responses; the response no longer call `exit()` and are therefore testable.
+- We have fixed our `ResourceTypeName` validator; our validator will no longer allow duplicate names.
+
 ## [v2.19.0] - 2021-02-08
 ### Added
 - We have started transferring our Postman response tests to local feature tests.

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ our local test suite is as complete as the Postman request tests.
 
 | Controller | Progress |
 | :--- | :--- |
-| Authentication | Complete (34) |
+| Authentication | Complete (34 Tests/62 Assertions) |
 | CategoryManage  | Not started |
 | ItemCategoryManage  | Not started |
 | ItemManage  | Not started |
@@ -252,7 +252,7 @@ our local test suite is as complete as the Postman request tests.
 | ItemSubcategoryManage  | Not started |
 | ItemTransferManage  | Not started |
 | RequestManage  | Not started |
-| ResourceManage  | Not started |
-| ResourceTypeManage  | In progress (11) |
+| ResourceManage  | In Progress (0 Tests/0 Assertions) |
+| ResourceTypeManage  | Complete (12 Tests/27 Assertions) |
 | SubcategoryManage  | Not started |
 | ToolManage  | Not started |

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ our local test suite is as complete as the Postman request tests.
 | ItemSubcategoryManage  | Not started |
 | ItemTransferManage  | Not started |
 | RequestManage  | Not started |
-| ResourceManage  | In Progress (0 Tests/0 Assertions) |
+| ResourceManage  | In Progress (1 Tests/2 Assertions) |
 | ResourceTypeManage  | Complete (12 Tests/27 Assertions) |
 | SubcategoryManage  | Not started |
 | ToolManage  | Not started |

--- a/README.md
+++ b/README.md
@@ -253,6 +253,6 @@ our local test suite is as complete as the Postman request tests.
 | ItemTransferManage  | Not started |
 | RequestManage  | Not started |
 | ResourceManage  | Not started |
-| ResourceTypeManage  | In progress (2) |
+| ResourceTypeManage  | In progress (11) |
 | SubcategoryManage  | Not started |
 | ToolManage  | Not started |

--- a/app/Cache/Collection.php
+++ b/app/Cache/Collection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Response\Cache;
+namespace App\Cache;
 
 /**
  * Cache helper, container for the cached data, gives us a simple
@@ -12,11 +12,13 @@ namespace App\Response\Cache;
  * @copyright Dean Blackborough 2018-2021
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class Summary
+class Collection
 {
     private bool $cached;
     private array $collection;
     private array $headers;
+    private array $pagination;
+    private int $total;
 
     /**
      * Create a cache response object
@@ -44,22 +46,30 @@ class Summary
     public function content(): array
     {
         return [
+            'total' => $this->total,
             'collection' => $this->collection,
-            'headers' => $this->headers
+            'headers' => $this->headers,
+            'pagination' => $this->pagination
         ];
     }
 
     /**
      * Create the cache data object
      *
+     * @param int $total
      * @param array $collection
+     * @param array $pagination
      * @param array $headers
      */
     public function create(
+        int $total,
         array $collection,
+        array $pagination,
         array $headers
     ): void {
+        $this->setTotal($total);
         $this->setCollection($collection);
+        $this->setPagination($pagination);
         $this->setHeaders($headers);
     }
 
@@ -87,14 +97,16 @@ class Summary
      * Pass in the content from the cache table, the content will include
      * four indexes, total, collection, headers and pagination
      *
-     * @param array $content
+     * @param array|null $content
      */
     public function setFromCache(array $content = null): void
     {
         if ($content !== null) {
             $this->cached = true;
+            $this->total = $content['total'];
             $this->collection = $content['collection'];
             $this->headers = $content['headers'];
+            $this->pagination = $content['pagination'];
         }
     }
 
@@ -106,6 +118,26 @@ class Summary
     private function setHeaders(array $headers): void
     {
         $this->headers = $headers;
+    }
+
+    /**
+     * Set the pagination data for the collection
+     *
+     * @param array $pagination
+     */
+    private function setPagination(array $pagination): void
+    {
+        $this->pagination = $pagination;
+    }
+
+    /**
+     * Set the total count for the collection
+     *
+     * @param int $total
+     */
+    private function setTotal(int $total): void
+    {
+        $this->total = $total;
     }
 
     /**

--- a/app/Cache/Control.php
+++ b/app/Cache/Control.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Response\Cache;
+namespace App\Cache;
 
 use App\Models\Cache;
 use Illuminate\Support\Facades\Cache as LaravelCache;

--- a/app/Cache/Job.php
+++ b/app/Cache/Job.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Response\Cache;
+namespace App\Cache;
 
 /**
  * Decode the payload for a job

--- a/app/Cache/JobPayload.php
+++ b/app/Cache/JobPayload.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Response\Cache;
+namespace App\Cache;
 
 /**
  * Generate the data we need the ClearResourceTypeIdCache job. The job

--- a/app/Cache/Key.php
+++ b/app/Cache/Key.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Response\Cache;
+namespace App\Cache;
 
 use App\Request\Hash;
 

--- a/app/Cache/KeyGroup.php
+++ b/app/Cache/KeyGroup.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace App\Response\Cache;
+namespace App\Cache;
 
 class KeyGroup
 {

--- a/app/Cache/Summary.php
+++ b/app/Cache/Summary.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Response\Cache;
+namespace App\Cache;
 
 /**
  * Cache helper, container for the cached data, gives us a simple
@@ -12,13 +12,11 @@ namespace App\Response\Cache;
  * @copyright Dean Blackborough 2018-2021
  * @license https://github.com/costs-to-expect/api/blob/master/LICENSE
  */
-class Collection
+class Summary
 {
     private bool $cached;
     private array $collection;
     private array $headers;
-    private array $pagination;
-    private int $total;
 
     /**
      * Create a cache response object
@@ -46,30 +44,22 @@ class Collection
     public function content(): array
     {
         return [
-            'total' => $this->total,
             'collection' => $this->collection,
-            'headers' => $this->headers,
-            'pagination' => $this->pagination
+            'headers' => $this->headers
         ];
     }
 
     /**
      * Create the cache data object
      *
-     * @param int $total
      * @param array $collection
-     * @param array $pagination
      * @param array $headers
      */
     public function create(
-        int $total,
         array $collection,
-        array $pagination,
         array $headers
     ): void {
-        $this->setTotal($total);
         $this->setCollection($collection);
-        $this->setPagination($pagination);
         $this->setHeaders($headers);
     }
 
@@ -97,16 +87,14 @@ class Collection
      * Pass in the content from the cache table, the content will include
      * four indexes, total, collection, headers and pagination
      *
-     * @param array|null $content
+     * @param array $content
      */
     public function setFromCache(array $content = null): void
     {
         if ($content !== null) {
             $this->cached = true;
-            $this->total = $content['total'];
             $this->collection = $content['collection'];
             $this->headers = $content['headers'];
-            $this->pagination = $content['pagination'];
         }
     }
 
@@ -118,26 +106,6 @@ class Collection
     private function setHeaders(array $headers): void
     {
         $this->headers = $headers;
-    }
-
-    /**
-     * Set the pagination data for the collection
-     *
-     * @param array $pagination
-     */
-    private function setPagination(array $pagination): void
-    {
-        $this->pagination = $pagination;
-    }
-
-    /**
-     * Set the total count for the collection
-     *
-     * @param int $total
-     */
-    private function setTotal(int $total): void
-    {
-        $this->total = $total;
     }
 
     /**

--- a/app/Cache/Trash.php
+++ b/app/Cache/Trash.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Response\Cache;
+namespace App\Cache;
 
 class Trash
 {

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -52,7 +52,7 @@ class Handler extends ExceptionHandler
     public function render($request, \Throwable $exception)
     {
         if ($exception instanceof AuthenticationException) {
-            \App\Response\Responses::authenticationRequired();
+            return \App\Response\Responses::authenticationRequired();
         }
 
         $status_code = 500;

--- a/app/Http/Controllers/CategoryManage.php
+++ b/app/Http/Controllers/CategoryManage.php
@@ -148,12 +148,16 @@ class CategoryManage extends Controller
             return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
-        BodyValidation::checkForInvalidFields(
+        $invalid_fields = BodyValidation::checkForInvalidFields(
             array_merge(
                 (new Category())->patchableFields(),
                 (new CategoryValidator)->dynamicDefinedFields()
             )
         );
+
+        if (count($invalid_fields) > 0) {
+            return Responses::invalidFieldsInRequest($invalid_fields);
+        }
 
         foreach (request()->all() as $key => $value) {
             $category->$key = $value;

--- a/app/Http/Controllers/CategoryManage.php
+++ b/app/Http/Controllers/CategoryManage.php
@@ -131,7 +131,9 @@ class CategoryManage extends Controller
             return Responses::failedToSelectModelForUpdateOrDelete();
         }
 
-        BodyValidation::checkForEmptyPatch();
+        if (count(request()->all()) === 0) {
+            return \App\Response\Responses::nothingToPatch();
+        }
 
         $validator = (new CategoryValidator)->update([
             'resource_type_id' => (int) $category->resource_type_id,

--- a/app/Http/Controllers/CategoryManage.php
+++ b/app/Http/Controllers/CategoryManage.php
@@ -3,12 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Jobs\ClearCache;
-use App\Request\BodyValidation;
-Use App\Response\Cache;
 use App\Models\Category;
-use App\Transformers\Category as CategoryTransformer;
+use App\Request\BodyValidation;
 use App\Request\Validate\Category as CategoryValidator;
 use App\Response\Responses;
+use App\Transformers\Category as CategoryTransformer;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -40,8 +39,8 @@ class CategoryManage extends Controller
             return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::CATEGORY_CREATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::CATEGORY_CREATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id
             ])
@@ -85,8 +84,8 @@ class CategoryManage extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.item-category'));
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::CATEGORY_DELETE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::CATEGORY_DELETE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id
             ])
@@ -163,8 +162,8 @@ class CategoryManage extends Controller
             $category->$key = $value;
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::CATEGORY_UPDATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::CATEGORY_UPDATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id
             ])

--- a/app/Http/Controllers/CategoryView.php
+++ b/app/Http/Controllers/CategoryView.php
@@ -2,15 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Category;
 use App\Models\Subcategory;
 use App\Option\CategoryCollection;
 use App\Option\CategoryItem;
-Use App\Response\Cache;
-use App\Response\Header\Header;
 use App\Request\Parameter;
+use App\Response\Header\Header;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
-use App\Models\Category;
 use App\Transformers\Category as CategoryTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
@@ -37,13 +36,13 @@ class CategoryView extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.resource-type'));
         }
 
-        $cache_control = new Cache\Control(
+        $cache_control = new \App\Cache\Control(
             $this->writeAccessToResourceType((int) $resource_type_id),
             $this->user_id
         );
         $cache_control->setTtlOneMonth();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -50,7 +50,10 @@ class Controller extends BaseController
 
     protected function setPermittedResourceTypes(): void
     {
-        if (auth('api')->user() !== null && auth()->guard('api')->check() === true) {
+        if (
+            auth('api')->user() !== null &&
+            auth()->guard('api')->check() === true
+        ) {
             $this->user_id = auth('api')->user()->id; // Safe as check above ensures not null
 
             $cache_control = new Control(true, $this->user_id);

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\ResourceType;
+use App\Cache\Collection;
+use App\Cache\Control;
 use App\Models\ResourceAccess;
+use App\Models\ResourceType;
 use App\Request\Hash;
 use App\Request\Validate\Boolean;
-use App\Response\Cache\Collection;
-use App\Response\Cache\Control;
 use Illuminate\Routing\Controller as BaseController;
 
 class Controller extends BaseController

--- a/app/Http/Controllers/CurrencyView.php
+++ b/app/Http/Controllers/CurrencyView.php
@@ -5,9 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Currency;
 use App\Option\CurrencyCollection;
 use App\Option\CurrencyItem;
-use App\Response\Cache;
-use App\Response\Header\Headers;
 use App\Request\Parameter;
+use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
 use App\Transformers\Currency as CurrencyTransformer;
 use Illuminate\Http\JsonResponse;
@@ -29,10 +28,10 @@ class CurrencyView extends Controller
      */
     public function index(): JsonResponse
     {
-        $cache_control = new Cache\Control();
+        $cache_control = new \App\Cache\Control();
         $cache_control->setTtlOneYear();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/ItemCategoryManage.php
+++ b/app/Http/Controllers/ItemCategoryManage.php
@@ -54,7 +54,7 @@ class ItemCategoryManage extends Controller
         $validator = (new ItemCategoryValidator)->create();
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors(
+            return \App\Request\BodyValidation::returnValidationErrors(
                 $validator,
                 (new \App\AllowedValue\Category())->allowedValues($resource_type_id)
             );

--- a/app/Http/Controllers/ItemCategoryManage.php
+++ b/app/Http/Controllers/ItemCategoryManage.php
@@ -5,9 +5,8 @@ namespace App\Http\Controllers;
 use App\ItemType\Entity;
 use App\Jobs\ClearCache;
 use App\Models\ItemCategory;
-use App\Transformers\ItemCategory as ItemCategoryTransformer;
 use App\Request\Validate\ItemCategory as ItemCategoryValidator;
-use App\Response\Cache;
+use App\Transformers\ItemCategory as ItemCategoryTransformer;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -60,8 +59,8 @@ class ItemCategoryManage extends Controller
             );
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::ITEM_CATEGORY_CREATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::ITEM_CATEGORY_CREATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id,
                 'resource_id' => $resource_id
@@ -126,8 +125,8 @@ class ItemCategoryManage extends Controller
             return \App\Response\Responses::notFound(trans('entities.item-category'));
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::ITEM_CATEGORY_DELETE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::ITEM_CATEGORY_DELETE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id,
                 'resource_id' => $resource_id

--- a/app/Http/Controllers/ItemCategoryView.php
+++ b/app/Http/Controllers/ItemCategoryView.php
@@ -4,11 +4,10 @@ namespace App\Http\Controllers;
 
 use App\ItemType\Entity;
 use App\Models\ItemCategory;
-use App\Transformers\ItemCategory as ItemCategoryTransformer;
 use App\Option\ItemCategoryCollection;
 use App\Option\ItemCategoryItem;
-use App\Response\Cache;
 use App\Response\Header\Header;
+use App\Transformers\ItemCategory as ItemCategoryTransformer;
 use Illuminate\Http\JsonResponse;
 
 /**
@@ -26,13 +25,13 @@ class ItemCategoryView extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.item'));
         }
 
-        $cache_control = new Cache\Control(
+        $cache_control = new \App\Cache\Control(
             $this->writeAccessToResourceType((int) $resource_type_id),
             $this->user_id
         );
         $cache_control->setTtlOneWeek();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/ItemManage.php
+++ b/app/Http/Controllers/ItemManage.php
@@ -39,7 +39,7 @@ class ItemManage extends Controller
         $validator = $validation->create();
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors($validator);
+            return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
         $model = $entity->model();
@@ -104,7 +104,7 @@ class ItemManage extends Controller
         $validator = $validation->update();
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors($validator);
+            return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
         $cache_job_payload = (new Cache\JobPayload())

--- a/app/Http/Controllers/ItemManage.php
+++ b/app/Http/Controllers/ItemManage.php
@@ -6,7 +6,6 @@ use App\ItemType\Entity;
 use App\Jobs\ClearCache;
 use App\Models\Item;
 use App\Models\ItemTransfer;
-use App\Response\Cache;
 use App\Response\Responses;
 use Exception;
 use Illuminate\Database\QueryException;
@@ -44,8 +43,8 @@ class ItemManage extends Controller
 
         $model = $entity->model();
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::ITEM_CREATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::ITEM_CREATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id,
                 'resource_id' => $resource_id
@@ -107,8 +106,8 @@ class ItemManage extends Controller
             return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::ITEM_DELETE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::ITEM_DELETE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id,
                 'resource_id' => $resource_id
@@ -153,8 +152,8 @@ class ItemManage extends Controller
 
         $entity = Entity::item($resource_type_id);
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::ITEM_DELETE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::ITEM_DELETE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id,
                 'resource_id' => $resource_id

--- a/app/Http/Controllers/ItemManage.php
+++ b/app/Http/Controllers/ItemManage.php
@@ -7,6 +7,7 @@ use App\Jobs\ClearCache;
 use App\Models\Item;
 use App\Models\ItemTransfer;
 use App\Response\Cache;
+use App\Response\Responses;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -93,7 +94,11 @@ class ItemManage extends Controller
             return \App\Response\Responses::nothingToPatch();
         }
 
-        \App\Request\BodyValidation::checkForInvalidFields(array_keys($entity->patchValidation()));
+        $invalid_fields = \App\Request\BodyValidation::checkForInvalidFields(array_keys($entity->patchValidation()));
+
+        if (count($invalid_fields) > 0) {
+            return Responses::invalidFieldsInRequest($invalid_fields);
+        }
 
         $validation = $entity->validator();
         $validator = $validation->update();

--- a/app/Http/Controllers/ItemManage.php
+++ b/app/Http/Controllers/ItemManage.php
@@ -89,7 +89,9 @@ class ItemManage extends Controller
 
         $entity = Entity::item($resource_type_id);
 
-        \App\Request\BodyValidation::checkForEmptyPatch();
+        if (count(request()->all()) === 0) {
+            return \App\Response\Responses::nothingToPatch();
+        }
 
         \App\Request\BodyValidation::checkForInvalidFields(array_keys($entity->patchValidation()));
 

--- a/app/Http/Controllers/ItemPartialTransferManage.php
+++ b/app/Http/Controllers/ItemPartialTransferManage.php
@@ -83,7 +83,7 @@ class ItemPartialTransferManage extends Controller
         );
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors($validator);
+            return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
         $new_resource_id = $this->hash->decode('resource', request()->input('resource_id'));

--- a/app/Http/Controllers/ItemPartialTransferManage.php
+++ b/app/Http/Controllers/ItemPartialTransferManage.php
@@ -4,10 +4,9 @@ namespace App\Http\Controllers;
 
 use App\Jobs\ClearCache;
 use App\Models\ItemPartialTransfer;
-use App\Transformers\ItemPartialTransfer as ItemPartialTransferTransformer;
-use App\Response\Cache;
 use App\Request\Validate\ItemPartialTransfer as ItemPartialTransferValidator;
 use App\Response\Responses;
+use App\Transformers\ItemPartialTransfer as ItemPartialTransferTransformer;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -38,8 +37,8 @@ class ItemPartialTransferManage extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.item-partial-transfer'));
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::ITEM_PARTIAL_TRANSFER_DELETE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::ITEM_PARTIAL_TRANSFER_DELETE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id
             ])
@@ -92,8 +91,8 @@ class ItemPartialTransferManage extends Controller
             return Responses::unableToDecode();
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::ITEM_PARTIAL_TRANSFER_CREATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::ITEM_PARTIAL_TRANSFER_CREATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id
             ])

--- a/app/Http/Controllers/ItemPartialTransferView.php
+++ b/app/Http/Controllers/ItemPartialTransferView.php
@@ -4,14 +4,13 @@ namespace App\Http\Controllers;
 
 use App\ItemType\Entity;
 use App\Models\ItemPartialTransfer;
-use App\Transformers\ItemPartialTransfer as ItemPartialTransferTransformer;
 use App\Option\ItemPartialTransferCollection;
 use App\Option\ItemPartialTransferItem;
 use App\Option\ItemPartialTransferTransfer;
 use App\Request\Parameter;
-use App\Response\Cache;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
+use App\Transformers\ItemPartialTransfer as ItemPartialTransferTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 
@@ -37,7 +36,7 @@ class ItemPartialTransferView extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.resource-type'));
         }
 
-        $cache_control = new Cache\Control(
+        $cache_control = new \App\Cache\Control(
             $this->writeAccessToResourceType((int) $resource_type_id),
             $this->user_id
         );
@@ -48,7 +47,7 @@ class ItemPartialTransferView extends Controller
             return \App\Response\Responses::notSupported();
         }
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/ItemSubcategoryManage.php
+++ b/app/Http/Controllers/ItemSubcategoryManage.php
@@ -6,9 +6,8 @@ use App\ItemType\Entity;
 use App\Jobs\ClearCache;
 use App\Models\ItemCategory;
 use App\Models\ItemSubcategory;
-use App\Transformers\ItemSubcategory as ItemSubcategoryTransformer;
 use App\Request\Validate\ItemSubcategory as ItemSubcategoryValidator;
-use App\Response\Cache;
+use App\Transformers\ItemSubcategory as ItemSubcategoryTransformer;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -72,8 +71,8 @@ class ItemSubcategoryManage extends Controller
             );
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::ITEM_SUBCATEGORY_CREATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::ITEM_SUBCATEGORY_CREATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id,
                 'resource_id' => $resource_id
@@ -145,8 +144,8 @@ class ItemSubcategoryManage extends Controller
             return \App\Response\Responses::notFound(trans('entities.item-subcategory'));
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::ITEM_SUBCATEGORY_DELETE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::ITEM_SUBCATEGORY_DELETE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id,
                 'resource_id' => $resource_id

--- a/app/Http/Controllers/ItemSubcategoryManage.php
+++ b/app/Http/Controllers/ItemSubcategoryManage.php
@@ -66,7 +66,7 @@ class ItemSubcategoryManage extends Controller
         $validator = (new ItemSubcategoryValidator)->create(['category_id' => $item_category->category_id]);
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors(
+            return \App\Request\BodyValidation::returnValidationErrors(
                 $validator,
                 (new \App\AllowedValue\Subcategory())->allowedValues($item_category->category_id)
             );

--- a/app/Http/Controllers/ItemSubcategoryView.php
+++ b/app/Http/Controllers/ItemSubcategoryView.php
@@ -5,11 +5,10 @@ namespace App\Http\Controllers;
 use App\ItemType\Entity;
 use App\Models\ItemCategory;
 use App\Models\ItemSubcategory;
-use App\Transformers\ItemSubcategory as ItemSubcategoryTransformer;
 use App\Option\ItemSubcategoryCollection;
 use App\Option\ItemSubcategoryItem;
-use App\Response\Cache;
 use App\Response\Header\Header;
+use App\Transformers\ItemSubcategory as ItemSubcategoryTransformer;
 use Illuminate\Http\JsonResponse;
 
 /**
@@ -42,13 +41,13 @@ class ItemSubcategoryView extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.item-category'));
         }
 
-        $cache_control = new Cache\Control(
+        $cache_control = new \App\Cache\Control(
             $this->writeAccessToResourceType((int) $resource_type_id),
             $this->user_id
         );
         $cache_control->setTtlOneWeek();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/ItemSubtypeView.php
+++ b/app/Http/Controllers/ItemSubtypeView.php
@@ -5,14 +5,13 @@ namespace App\Http\Controllers;
 use App\Models\ItemSubtype;
 use App\Option\ItemSubtypeCollection;
 use App\Option\ItemSubtypeItem;
-use App\Response\Cache;
-use App\Response\Header\Header;
 use App\Request\Parameter;
 use App\Request\Route;
+use App\Response\Header\Header;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
-use App\Transformers\ItemSubtype as ItemSubtypeTransformer;
 use App\Response\Responses;
+use App\Transformers\ItemSubtype as ItemSubtypeTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 
@@ -31,10 +30,10 @@ class ItemSubtypeView extends Controller
             Responses::notFound(trans('entities.item-subtype'));
         }
 
-        $cache_control = new Cache\Control();
+        $cache_control = new \App\Cache\Control();
         $cache_control->setTtlOneYear();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/ItemTransferManage.php
+++ b/app/Http/Controllers/ItemTransferManage.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Jobs\ClearCache;
 use App\Models\Item;
 use App\Models\ItemTransfer;
-use App\Response\Cache;
 use App\Request\Validate\ItemTransfer as ItemTransferValidator;
 use Exception;
 use Illuminate\Database\QueryException;
@@ -44,8 +43,8 @@ class ItemTransferManage extends Controller
             return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::ITEM_TRANSFER_CREATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::ITEM_TRANSFER_CREATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id
             ])

--- a/app/Http/Controllers/ItemTransferManage.php
+++ b/app/Http/Controllers/ItemTransferManage.php
@@ -41,7 +41,7 @@ class ItemTransferManage extends Controller
         );
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors($validator);
+            return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
         $cache_job_payload = (new Cache\JobPayload())

--- a/app/Http/Controllers/ItemTransferView.php
+++ b/app/Http/Controllers/ItemTransferView.php
@@ -3,14 +3,13 @@
 namespace App\Http\Controllers;
 
 use App\Models\ItemTransfer;
-use App\Transformers\ItemTransfer as ItemTransferTransformer;
 use App\Option\ItemTransferCollection;
 use App\Option\ItemTransferItem;
 use App\Option\ItemTransferTransfer;
-use App\Response\Cache;
-use App\Response\Header\Headers;
 use App\Request\Parameter;
+use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
+use App\Transformers\ItemTransfer as ItemTransferTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 
@@ -36,13 +35,13 @@ class ItemTransferView extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.item-transfer'));
         }
 
-        $cache_control = new Cache\Control(
+        $cache_control = new \App\Cache\Control(
             $this->writeAccessToResourceType((int) $resource_type_id),
             $this->user_id
         );
         $cache_control->setTtlOneWeek();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/ItemTypeView.php
+++ b/app/Http/Controllers/ItemTypeView.php
@@ -5,13 +5,12 @@ namespace App\Http\Controllers;
 use App\Models\ItemType;
 use App\Option\ItemTypeCollection;
 use App\Option\ItemTypeItem;
-use App\Response\Cache;
-use App\Response\Header\Headers;
 use App\Request\Parameter;
 use App\Request\Route;
+use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
-use App\Transformers\ItemType as ItemTypeTransformer;
 use App\Response\Responses;
+use App\Transformers\ItemType as ItemTypeTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 
@@ -33,10 +32,10 @@ class ItemTypeView extends Controller
      */
     public function index(): JsonResponse
     {
-        $cache_control = new Cache\Control();
+        $cache_control = new \App\Cache\Control();
         $cache_control->setTtlOneYear();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/PermittedUserView.php
+++ b/app/Http/Controllers/PermittedUserView.php
@@ -3,12 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Models\PermittedUser;
-use App\Transformers\PermittedUser as PermittedUserTransformer;
 use App\Option\PermittedUserCollection;
-use App\Response\Cache;
 use App\Request\Parameter;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
+use App\Transformers\PermittedUser as PermittedUserTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
 
@@ -29,13 +28,13 @@ class PermittedUserView extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.resource-type'));
         }
 
-        $cache_control = new Cache\Control(
+        $cache_control = new \App\Cache\Control(
             $this->writeAccessToResourceType((int) $resource_type_id),
             $this->user_id
         );
         $cache_control->setTtlOneMonth();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/QueueView.php
+++ b/app/Http/Controllers/QueueView.php
@@ -5,10 +5,9 @@ namespace App\Http\Controllers;
 use App\Models\Queue;
 use App\Option\QueueCollection;
 use App\Option\QueueItem;
-use App\Response\Cache;
-use App\Response\Header\Headers;
 use App\Request\Parameter;
 use App\Request\Route;
+use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
 use App\Transformers\Queue as QueueTransformer;
 use Illuminate\Http\JsonResponse;
@@ -27,10 +26,10 @@ class QueueView extends Controller
      */
     public function index(): JsonResponse
     {
-        $cache_control = new Cache\Control();
+        $cache_control = new \App\Cache\Control();
         $cache_control->setTtlFivesMinutes();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/RequestManage.php
+++ b/app/Http/Controllers/RequestManage.php
@@ -28,7 +28,7 @@ class RequestManage extends Controller
         $validator = (new RequestErrorLogValidator())->create();
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors($validator);
+            return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
         try {

--- a/app/Http/Controllers/ResourceManage.php
+++ b/app/Http/Controllers/ResourceManage.php
@@ -50,7 +50,7 @@ class ResourceManage extends Controller
         ]);
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors($validator);
+            return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
         $cache_job_payload = (new Cache\JobPayload())
@@ -180,7 +180,7 @@ class ResourceManage extends Controller
         ]);
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors($validator);
+            return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
         $invalid_fields = \App\Request\BodyValidation::checkForInvalidFields(

--- a/app/Http/Controllers/ResourceManage.php
+++ b/app/Http/Controllers/ResourceManage.php
@@ -3,13 +3,12 @@
 namespace App\Http\Controllers;
 
 use App\Jobs\ClearCache;
+use App\Models\Resource;
 use App\Models\ResourceItemSubtype;
 use App\Models\ResourceType;
-use App\Response\Cache;
-use App\Models\Resource;
-use App\Transformers\Resource as ResourceTransformer;
 use App\Request\Validate\Resource as ResourceValidator;
 use App\Response\Responses;
+use App\Transformers\Resource as ResourceTransformer;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -53,8 +52,8 @@ class ResourceManage extends Controller
             return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::RESOURCE_CREATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::RESOURCE_CREATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id
             ])
@@ -122,8 +121,8 @@ class ResourceManage extends Controller
             return Responses::failedToSelectModelForUpdateOrDelete();
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::RESOURCE_DELETE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::RESOURCE_DELETE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id,
                 'resource_id' => $resource_id
@@ -198,8 +197,8 @@ class ResourceManage extends Controller
             $resource->$key = $value;
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::RESOURCE_UPDATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::RESOURCE_UPDATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id
             ])

--- a/app/Http/Controllers/ResourceManage.php
+++ b/app/Http/Controllers/ResourceManage.php
@@ -170,7 +170,9 @@ class ResourceManage extends Controller
             return Responses::failedToSelectModelForUpdateOrDelete();
         }
 
-        \App\Request\BodyValidation::checkForEmptyPatch();
+        if (count(request()->all()) === 0) {
+            return \App\Response\Responses::nothingToPatch();
+        }
 
         $validator = (new ResourceValidator())->update([
             'resource_type_id' => (int)$resource_type_id,

--- a/app/Http/Controllers/ResourceManage.php
+++ b/app/Http/Controllers/ResourceManage.php
@@ -183,12 +183,16 @@ class ResourceManage extends Controller
             \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
-        \App\Request\BodyValidation::checkForInvalidFields(
+        $invalid_fields = \App\Request\BodyValidation::checkForInvalidFields(
             array_merge(
                 (new Resource())->patchableFields(),
                 (new ResourceValidator())->dynamicDefinedFields()
             )
         );
+
+        if (count($invalid_fields) > 0) {
+            return Responses::invalidFieldsInRequest($invalid_fields);
+        }
 
         foreach (request()->all() as $key => $value) {
             $resource->$key = $value;

--- a/app/Http/Controllers/ResourceTypeManage.php
+++ b/app/Http/Controllers/ResourceTypeManage.php
@@ -9,6 +9,7 @@ use App\Models\Resource;
 use App\Models\ResourceTypeItemType;
 use App\Response\Cache;
 use App\Models\ResourceType;
+use App\Response\Responses;
 use App\Transformers\ResourceType as ResourceTypeTransformer;
 use App\Request\Validate\ResourceType as ResourceTypeValidator;
 use Exception;
@@ -189,12 +190,16 @@ class ResourceTypeManage extends Controller
             \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
-        \App\Request\BodyValidation::checkForInvalidFields(
+        $invalid_fields = \App\Request\BodyValidation::checkForInvalidFields(
             array_merge(
                 (new ResourceType())->patchableFields(),
                 (new ResourceTypeValidator())->dynamicDefinedFields()
             )
         );
+
+        if (count($invalid_fields) > 0) {
+            return Responses::invalidFieldsInRequest($invalid_fields);
+        }
 
         foreach (request()->all() as $key => $value) {
             $resource_type->$key = $value;

--- a/app/Http/Controllers/ResourceTypeManage.php
+++ b/app/Http/Controllers/ResourceTypeManage.php
@@ -6,12 +6,11 @@ use App\Jobs\ClearCache;
 use App\Models\Category;
 use App\Models\PermittedUser;
 use App\Models\Resource;
-use App\Models\ResourceTypeItemType;
-use App\Response\Cache;
 use App\Models\ResourceType;
+use App\Models\ResourceTypeItemType;
+use App\Request\Validate\ResourceType as ResourceTypeValidator;
 use App\Response\Responses;
 use App\Transformers\ResourceType as ResourceTypeTransformer;
-use App\Request\Validate\ResourceType as ResourceTypeValidator;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -43,8 +42,8 @@ class ResourceTypeManage extends Controller
             return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::RESOURCE_TYPE_CREATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::RESOURCE_TYPE_CREATE)
             ->setRouteParameters([])
             ->setPermittedUser(true)
             ->setUserId($this->user_id);
@@ -121,8 +120,8 @@ class ResourceTypeManage extends Controller
             $this->viewable_resource_types
         );
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::RESOURCE_TYPE_DELETE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::RESOURCE_TYPE_DELETE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id
             ])
@@ -205,8 +204,8 @@ class ResourceTypeManage extends Controller
             $resource_type->$key = $value;
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::RESOURCE_TYPE_UPDATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::RESOURCE_TYPE_UPDATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id
             ])

--- a/app/Http/Controllers/ResourceTypeManage.php
+++ b/app/Http/Controllers/ResourceTypeManage.php
@@ -176,7 +176,9 @@ class ResourceTypeManage extends Controller
             return \App\Response\Responses::failedToSelectModelForUpdateOrDelete();
         }
 
-        \App\Request\BodyValidation::checkForEmptyPatch();
+        if (count(request()->all()) === 0) {
+            return \App\Response\Responses::nothingToPatch();
+        }
 
         $validator = (new ResourceTypeValidator())->update([
             'resource_type_id' => (int) ($resource_type_id),

--- a/app/Http/Controllers/ResourceTypeManage.php
+++ b/app/Http/Controllers/ResourceTypeManage.php
@@ -182,12 +182,12 @@ class ResourceTypeManage extends Controller
         }
 
         $validator = (new ResourceTypeValidator())->update([
-            'resource_type_id' => (int) ($resource_type_id),
+            'resource_type_id' => (int) $resource_type_id,
             'user_id' => $this->user_id
         ]);
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors($validator);
+            return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
         $invalid_fields = \App\Request\BodyValidation::checkForInvalidFields(

--- a/app/Http/Controllers/ResourceTypeView.php
+++ b/app/Http/Controllers/ResourceTypeView.php
@@ -2,15 +2,14 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Resource;
 use App\AllowedValue\ItemType;
+use App\Models\Resource;
+use App\Models\ResourceType;
 use App\Option\ResourceTypeCollection;
 use App\Option\ResourceTypeItem;
-use App\Response\Cache;
-use App\Response\Header\Headers;
 use App\Request\Parameter;
+use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
-use App\Models\ResourceType;
 use App\Transformers\ResourceType as ResourceTypeTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
@@ -28,10 +27,10 @@ class ResourceTypeView extends Controller
 
     public function index(): JsonResponse
     {
-        $cache_control = new Cache\Control( true, $this->user_id);
+        $cache_control = new \App\Cache\Control( true, $this->user_id);
         $cache_control->setTtlOneWeek();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/ResourceView.php
+++ b/app/Http/Controllers/ResourceView.php
@@ -2,16 +2,15 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\ResourceType;
 use App\AllowedValue\ItemSubtype;
+use App\Models\Resource;
+use App\Models\ResourceType;
 use App\Option\ResourceCollection;
 use App\Option\ResourceItem;
-use App\Response\Cache;
-use App\Response\Header\Header;
 use App\Request\Parameter;
+use App\Response\Header\Header;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
-use App\Models\Resource;
 use App\Transformers\Resource as ResourceTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
@@ -40,13 +39,13 @@ class ResourceView extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.resource-type'));
         }
 
-        $cache_control = new Cache\Control(
+        $cache_control = new \App\Cache\Control(
             $this->writeAccessToResourceType((int) $resource_type_id),
             $this->user_id
         );
         $cache_control->setTtlOneWeek();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/SubcategoryManage.php
+++ b/app/Http/Controllers/SubcategoryManage.php
@@ -160,12 +160,16 @@ class SubcategoryManage extends Controller
             \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
-        \App\Request\BodyValidation::checkForInvalidFields(
+        $invalid_fields = \App\Request\BodyValidation::checkForInvalidFields(
             array_merge(
                 (new Subcategory())->patchableFields(),
                 (new SubcategoryValidator)->dynamicDefinedFields()
             )
         );
+
+        if (count($invalid_fields) > 0) {
+            return Responses::invalidFieldsInRequest($invalid_fields);
+        }
 
         foreach (request()->all() as $key => $value) {
             $subcategory->$key = $value;

--- a/app/Http/Controllers/SubcategoryManage.php
+++ b/app/Http/Controllers/SubcategoryManage.php
@@ -147,7 +147,9 @@ class SubcategoryManage extends Controller
             return Responses::failedToSelectModelForUpdateOrDelete();
         }
 
-        \App\Request\BodyValidation::checkForEmptyPatch();
+        if (count(request()->all()) === 0) {
+            return \App\Response\Responses::nothingToPatch();
+        }
 
         $validator = (new SubcategoryValidator())->update([
             'category_id' => (int)$category_id,

--- a/app/Http/Controllers/SubcategoryManage.php
+++ b/app/Http/Controllers/SubcategoryManage.php
@@ -40,7 +40,7 @@ class SubcategoryManage extends Controller
         $validator = (new SubcategoryValidator)->create(['category_id' => $category_id]);
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors($validator);
+            return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
         $cache_job_payload = (new Cache\JobPayload())
@@ -157,7 +157,7 @@ class SubcategoryManage extends Controller
         ]);
 
         if ($validator->fails()) {
-            \App\Request\BodyValidation::returnValidationErrors($validator);
+            return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
         $invalid_fields = \App\Request\BodyValidation::checkForInvalidFields(

--- a/app/Http/Controllers/SubcategoryManage.php
+++ b/app/Http/Controllers/SubcategoryManage.php
@@ -3,11 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Jobs\ClearCache;
-use App\Response\Cache;
 use App\Models\Subcategory;
-use App\Transformers\Subcategory as SubcategoryTransformer;
 use App\Request\Validate\Subcategory as SubcategoryValidator;
 use App\Response\Responses;
+use App\Transformers\Subcategory as SubcategoryTransformer;
 use Exception;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -43,8 +42,8 @@ class SubcategoryManage extends Controller
             return \App\Request\BodyValidation::returnValidationErrors($validator);
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::SUBCATEGORY_CREATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::SUBCATEGORY_CREATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id,
                 'category_id' => $category_id
@@ -100,8 +99,8 @@ class SubcategoryManage extends Controller
             return Responses::notFound(trans('entities.subcategory'));
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::SUBCATEGORY_DELETE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::SUBCATEGORY_DELETE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id,
                 'category_id' => $category_id
@@ -175,8 +174,8 @@ class SubcategoryManage extends Controller
             $subcategory->$key = $value;
         }
 
-        $cache_job_payload = (new Cache\JobPayload())
-            ->setGroupKey(Cache\KeyGroup::SUBCATEGORY_UPDATE)
+        $cache_job_payload = (new \App\Cache\JobPayload())
+            ->setGroupKey(\App\Cache\KeyGroup::SUBCATEGORY_UPDATE)
             ->setRouteParameters([
                 'resource_type_id' => $resource_type_id,
                 'category_id' => $category_id

--- a/app/Http/Controllers/SubcategoryView.php
+++ b/app/Http/Controllers/SubcategoryView.php
@@ -2,14 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Subcategory;
 use App\Option\SubcategoryCollection;
 use App\Option\SubcategoryItem;
-use App\Response\Cache;
-use App\Response\Header\Header;
 use App\Request\Parameter;
+use App\Response\Header\Header;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
-use App\Models\Subcategory;
 use App\Transformers\Subcategory as SubcategoryTransformer;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
@@ -31,13 +30,13 @@ class SubcategoryView extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.category'));
         }
 
-        $cache_control = new Cache\Control(
+        $cache_control = new \App\Cache\Control(
             $this->writeAccessToResourceType((int) $resource_type_id),
             $this->user_id
         );
         $cache_control->setTtlOneMonth();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_collection->valid() === false) {

--- a/app/Http/Controllers/Summary/CategoryView.php
+++ b/app/Http/Controllers/Summary/CategoryView.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Summary;
 use App\Http\Controllers\Controller;
 use App\Models\Summary\Category;
 use App\Option\SummaryCategoryCollection;
-use App\Response\Cache;
 use App\Request\Parameter;
 use App\Response\Header\Headers;
 use Illuminate\Http\JsonResponse;
@@ -33,13 +32,13 @@ class CategoryView extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.resource-type'));
         }
 
-        $cache_control = new Cache\Control(
+        $cache_control = new \App\Cache\Control(
             $this->writeAccessToResourceType((int) $resource_type_id),
             $this->user_id
         );
         $cache_control->setTtlOneMonth();
 
-        $cache_summary = new Cache\Summary();
+        $cache_summary = new \App\Cache\Summary();
         $cache_summary->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_summary->valid() === false) {

--- a/app/Http/Controllers/Summary/ResourceTypeView.php
+++ b/app/Http/Controllers/Summary/ResourceTypeView.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Summary;
 use App\Http\Controllers\Controller;
 use App\Models\Summary\ResourceType;
 use App\Option\SummaryResourceTypeCollection;
-use App\Response\Cache;
 use App\Request\Parameter;
 use App\Response\Header\Headers;
 use Illuminate\Http\JsonResponse;
@@ -27,10 +26,10 @@ class ResourceTypeView extends Controller
      */
     public function index(): JsonResponse
     {
-        $cache_control = new Cache\Control(true, $this->user_id);
+        $cache_control = new \App\Cache\Control(true, $this->user_id);
         $cache_control->setTtlOneWeek();
 
-        $cache_summary = new Cache\Summary();
+        $cache_summary = new \App\Cache\Summary();
         $cache_summary->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_summary->valid() === false) {

--- a/app/Http/Controllers/Summary/ResourceView.php
+++ b/app/Http/Controllers/Summary/ResourceView.php
@@ -3,10 +3,9 @@
 namespace App\Http\Controllers\Summary;
 
 use App\Http\Controllers\Controller;
-use App\Option\SummaryResourceCollection;
-use App\Response\Cache;
-use App\Request\Parameter;
 use App\Models\Summary\Resource;
+use App\Option\SummaryResourceCollection;
+use App\Request\Parameter;
 use App\Response\Header\Headers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Config;
@@ -33,13 +32,13 @@ class ResourceView extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.resource-type'));
         }
 
-        $cache_control = new Cache\Control(
+        $cache_control = new \App\Cache\Control(
             $this->writeAccessToResourceType((int) $resource_type_id),
             $this->user_id
         );
         $cache_control->setTtlOneWeek();
 
-        $cache_summary = new Cache\Summary();
+        $cache_summary = new \App\Cache\Summary();
         $cache_summary->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_summary->valid() === false) {

--- a/app/Http/Controllers/Summary/SubcategoryView.php
+++ b/app/Http/Controllers/Summary/SubcategoryView.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Summary;
 use App\Http\Controllers\Controller;
 use App\Models\Summary\Subcategory;
 use App\Option\SummarySubcategoryCollection;
-use App\Response\Cache;
 use App\Request\Parameter;
 use App\Response\Header\Headers;
 use Illuminate\Http\JsonResponse;
@@ -34,13 +33,13 @@ class SubcategoryView extends Controller
             \App\Response\Responses::notFoundOrNotAccessible(trans('entities.category'));
         }
 
-        $cache_control = new Cache\Control(
+        $cache_control = new \App\Cache\Control(
             $this->writeAccessToResourceType((int) $resource_type_id),
             $this->user_id
         );
         $cache_control->setTtlOneMonth();
 
-        $cache_summary = new Cache\Summary();
+        $cache_summary = new \App\Cache\Summary();
         $cache_summary->setFromCache($cache_control->getByKey(request()->getRequestUri()));
 
         if ($cache_control->isRequestCacheable() === false || $cache_summary->valid() === false) {

--- a/app/Http/Controllers/ToolManage.php
+++ b/app/Http/Controllers/ToolManage.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Response\Cache;
 use App\Response\Responses;
 use Illuminate\Http\JsonResponse;
 
@@ -15,7 +14,7 @@ class ToolManage extends Controller
 {
     public function cache(): JsonResponse
     {
-        $cache_control = new Cache\Control(true, $this->user_id);
+        $cache_control = new \App\Cache\Control(true, $this->user_id);
 
         $keys = $cache_control->fetchMatchingCacheKeys('', true);
 
@@ -29,7 +28,7 @@ class ToolManage extends Controller
 
     public function deleteCache(): JsonResponse
     {
-        $cache_control = new Cache\Control(true, $this->user_id);
+        $cache_control = new \App\Cache\Control(true, $this->user_id);
 
         $keys = $cache_control->fetchMatchingCacheKeys('', true);
 

--- a/app/Http/Middleware/ConvertRouteParameters.php
+++ b/app/Http/Middleware/ConvertRouteParameters.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use App\Request\Hash;
+use App\Response\Responses;
 use Closure;
 
 /**
@@ -47,7 +48,7 @@ class ConvertRouteParameters
             $param_value = $request->route($param);
             if ($param_value !== null) {
                 $id = $hash->decode($route_params[$param], $param_value);
-                is_int($id) ? $value = $id : $value = null;
+                is_int($id) ? $value = $id : Responses::notFoundOrNotAccessible($route_params[$param]);
                 $request->route()->setParameter($param, $value);
             }
         }

--- a/app/ItemType/AllocatedExpense/ResourceTypeResponse.php
+++ b/app/ItemType/AllocatedExpense/ResourceTypeResponse.php
@@ -3,9 +3,8 @@ declare(strict_types=1);
 
 namespace App\ItemType\AllocatedExpense;
 
-use App\ItemType\ResourceTypeResponse as BaseResourceTypeResponse;
 use App\ItemType\AllocatedExpense\ResourceTypeTransformer as Transformer;
-use App\Response\Cache;
+use App\ItemType\ResourceTypeResponse as BaseResourceTypeResponse;
 use Illuminate\Http\JsonResponse;
 
 class ResourceTypeResponse extends BaseResourceTypeResponse
@@ -18,7 +17,7 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
             $this->cache_control->setTtlOneDay();
         }
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
 
         if (

--- a/app/ItemType/AllocatedExpense/Response.php
+++ b/app/ItemType/AllocatedExpense/Response.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace App\ItemType\AllocatedExpense;
 
 use App\ItemType\Response as ItemTypeResponse;
-use App\Response\Cache;
 use App\Response\Responses;
 use Illuminate\Http\JsonResponse;
 
@@ -18,7 +17,7 @@ class Response extends ItemTypeResponse
             $this->cache_control->setTtlOneDay();
         }
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
 
         if (

--- a/app/ItemType/AllocatedExpense/SummaryResourceTypeResponse.php
+++ b/app/ItemType/AllocatedExpense/SummaryResourceTypeResponse.php
@@ -4,7 +4,6 @@ namespace App\ItemType\AllocatedExpense;
 
 use App\ItemType\SummaryResourceTypeResponse as BaseSummaryResourceTypeResponse;
 use App\Request\Validate\Boolean;
-use App\Response\Cache;
 use Illuminate\Http\JsonResponse;
 
 class SummaryResourceTypeResponse extends BaseSummaryResourceTypeResponse
@@ -468,7 +467,7 @@ class SummaryResourceTypeResponse extends BaseSummaryResourceTypeResponse
     // Overridden here, because we want a different TTL
     protected function setUpCache(): void
     {
-        $this->cache_control = new Cache\Control(
+        $this->cache_control = new \App\Cache\Control(
             $this->permitted_user,
             $this->user_id
         );
@@ -479,7 +478,7 @@ class SummaryResourceTypeResponse extends BaseSummaryResourceTypeResponse
             $this->cache_control->setTtlOneDay();
         }
 
-        $this->cache_summary = new Cache\Summary();
+        $this->cache_summary = new \App\Cache\Summary();
         $this->cache_summary->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
     }
 }

--- a/app/ItemType/AllocatedExpense/SummaryResponse.php
+++ b/app/ItemType/AllocatedExpense/SummaryResponse.php
@@ -4,7 +4,6 @@ namespace App\ItemType\AllocatedExpense;
 
 use App\ItemType\SummaryResponse as BaseSummaryResponse;
 use App\Request\Validate\Boolean;
-use App\Response\Cache;
 use Illuminate\Http\JsonResponse;
 
 class SummaryResponse extends BaseSummaryResponse
@@ -447,7 +446,7 @@ class SummaryResponse extends BaseSummaryResponse
     // Overridden here, because we want a different TTL
     protected function setUpCache(): void
     {
-        $this->cache_control = new Cache\Control(
+        $this->cache_control = new \App\Cache\Control(
             $this->permitted_user,
             $this->user_id
         );
@@ -458,7 +457,7 @@ class SummaryResponse extends BaseSummaryResponse
             $this->cache_control->setTtlOneDay();
         }
 
-        $this->cache_summary = new Cache\Summary();
+        $this->cache_summary = new \App\Cache\Summary();
         $this->cache_summary->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
     }
 }

--- a/app/ItemType/Game/ResourceTypeResponse.php
+++ b/app/ItemType/Game/ResourceTypeResponse.php
@@ -3,9 +3,8 @@ declare(strict_types=1);
 
 namespace App\ItemType\Game;
 
-use App\ItemType\ResourceTypeResponse as BaseResourceTypeResponse;
 use App\ItemType\Game\ResourceTypeTransformer as Transformer;
-use App\Response\Cache;
+use App\ItemType\ResourceTypeResponse as BaseResourceTypeResponse;
 use Illuminate\Http\JsonResponse;
 
 class ResourceTypeResponse extends BaseResourceTypeResponse
@@ -14,7 +13,7 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
     {
         $this->cache_control->setTtlOneWeek();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
 
         if (

--- a/app/ItemType/Game/Response.php
+++ b/app/ItemType/Game/Response.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace App\ItemType\Game;
 
 use App\ItemType\Response as ItemTypeResponse;
-use App\Response\Cache;
 use App\Response\Responses;
 use Illuminate\Http\JsonResponse;
 
@@ -14,7 +13,7 @@ class Response extends ItemTypeResponse
     {
         $this->cache_control->setTtlOneWeek();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
 
         if (

--- a/app/ItemType/ResourceTypeResponse.php
+++ b/app/ItemType/ResourceTypeResponse.php
@@ -7,7 +7,6 @@ use App\Request\Parameter\Filter;
 use App\Request\Parameter\Request;
 use App\Request\Parameter\Search;
 use App\Request\Parameter\Sort;
-use App\Response\Cache;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
 use Illuminate\Http\JsonResponse;
@@ -20,7 +19,7 @@ abstract class ResourceTypeResponse
 
     protected ?int $user_id;
 
-    protected Cache\Control $cache_control;
+    protected \App\Cache\Control $cache_control;
 
     protected array $request_parameters;
     protected array $search_parameters;
@@ -37,7 +36,7 @@ abstract class ResourceTypeResponse
         $this->permitted_user = $permitted_user;
         $this->user_id = $user_id;
 
-        $this->cache_control = new Cache\Control(
+        $this->cache_control = new \App\Cache\Control(
             $this->permitted_user,
             $this->user_id
         );

--- a/app/ItemType/Response.php
+++ b/app/ItemType/Response.php
@@ -7,7 +7,6 @@ use App\Request\Parameter\Filter;
 use App\Request\Parameter\Request;
 use App\Request\Parameter\Search;
 use App\Request\Parameter\Sort;
-use App\Response\Cache;
 use App\Response\Header\Header;
 use App\Response\Header\Headers;
 use App\Response\Pagination as UtilityPagination;
@@ -23,7 +22,7 @@ abstract class Response
 
     protected ?int $user_id;
 
-    protected Cache\Control $cache_control;
+    protected \App\Cache\Control $cache_control;
 
     protected array $request_parameters;
     protected array $search_parameters;
@@ -42,7 +41,7 @@ abstract class Response
         $this->permitted_user = $permitted_user;
         $this->user_id = $user_id;
 
-        $this->cache_control = new Cache\Control(
+        $this->cache_control = new \App\Cache\Control(
             $this->permitted_user,
             $this->user_id
         );

--- a/app/ItemType/SimpleExpense/ResourceTypeResponse.php
+++ b/app/ItemType/SimpleExpense/ResourceTypeResponse.php
@@ -5,7 +5,6 @@ namespace App\ItemType\SimpleExpense;
 
 use App\ItemType\ResourceTypeResponse as BaseResourceTypeResponse;
 use App\ItemType\SimpleExpense\ResourceTypeTransformer as Transformer;
-use App\Response\Cache;
 use Illuminate\Http\JsonResponse;
 
 class ResourceTypeResponse extends BaseResourceTypeResponse
@@ -14,7 +13,7 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
     {
         $this->cache_control->setTtlOneMonth();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
 
         if (

--- a/app/ItemType/SimpleExpense/Response.php
+++ b/app/ItemType/SimpleExpense/Response.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace App\ItemType\SimpleExpense;
 
 use App\ItemType\Response as ItemTypeResponse;
-use App\Response\Cache;
 use App\Response\Responses;
 use Illuminate\Http\JsonResponse;
 
@@ -14,7 +13,7 @@ class Response extends ItemTypeResponse
     {
         $this->cache_control->setTtlOneMonth();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
 
         if (

--- a/app/ItemType/SimpleItem/ResourceTypeResponse.php
+++ b/app/ItemType/SimpleItem/ResourceTypeResponse.php
@@ -5,7 +5,6 @@ namespace App\ItemType\SimpleItem;
 
 use App\ItemType\ResourceTypeResponse as BaseResourceTypeResponse;
 use App\ItemType\SimpleItem\ResourceTypeTransformer as Transformer;
-use App\Response\Cache;
 use Illuminate\Http\JsonResponse;
 
 class ResourceTypeResponse extends BaseResourceTypeResponse
@@ -14,7 +13,7 @@ class ResourceTypeResponse extends BaseResourceTypeResponse
     {
         $this->cache_control->setTtlOneMonth();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
 
         if (

--- a/app/ItemType/SimpleItem/Response.php
+++ b/app/ItemType/SimpleItem/Response.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace App\ItemType\SimpleItem;
 
 use App\ItemType\Response as ItemTypeResponse;
-use App\Response\Cache;
 use App\Response\Responses;
 use Illuminate\Http\JsonResponse;
 
@@ -14,7 +13,7 @@ class Response extends ItemTypeResponse
     {
         $this->cache_control->setTtlOneMonth();
 
-        $cache_collection = new Cache\Collection();
+        $cache_collection = new \App\Cache\Collection();
         $cache_collection->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
 
         if (

--- a/app/ItemType/SummaryResourceTypeResponse.php
+++ b/app/ItemType/SummaryResourceTypeResponse.php
@@ -3,7 +3,6 @@
 namespace App\ItemType;
 
 use App\Request\Parameter;
-use App\Response\Cache;
 use App\Response\Header\Headers;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
@@ -26,9 +25,9 @@ abstract class SummaryResourceTypeResponse
 
     protected Model $model;
 
-    protected Cache\Control $cache_control;
+    protected \App\Cache\Control $cache_control;
 
-    protected Cache\Summary $cache_summary;
+    protected \App\Cache\Summary $cache_summary;
 
     public function __construct(
         int $resource_type_id,
@@ -47,9 +46,9 @@ abstract class SummaryResourceTypeResponse
     protected function assignToCache(
         array $summary,
         array $collection,
-        Cache\Control $cache_control,
-        Cache\Summary $cache_summary
-    ): Cache\Summary
+        \App\Cache\Control $cache_control,
+        \App\Cache\Summary $cache_summary
+    ): \App\Cache\Summary
     {
         $headers = new Headers();
 
@@ -95,13 +94,13 @@ abstract class SummaryResourceTypeResponse
 
     protected function setUpCache(): void
     {
-        $this->cache_control = new Cache\Control(
+        $this->cache_control = new \App\Cache\Control(
             $this->permitted_user,
             $this->user_id
         );
         $this->cache_control->setTtlOneWeek();
 
-        $this->cache_summary = new Cache\Summary();
+        $this->cache_summary = new \App\Cache\Summary();
         $this->cache_summary->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
     }
 }

--- a/app/ItemType/SummaryResponse.php
+++ b/app/ItemType/SummaryResponse.php
@@ -3,7 +3,6 @@
 namespace App\ItemType;
 
 use App\Request\Parameter;
-use App\Response\Cache;
 use App\Response\Header\Headers;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
@@ -28,9 +27,9 @@ abstract class SummaryResponse
 
     protected Model $model;
 
-    protected Cache\Control $cache_control;
+    protected \App\Cache\Control $cache_control;
 
-    protected Cache\Summary $cache_summary;
+    protected \App\Cache\Summary $cache_summary;
 
     public function __construct(
         int $resource_type_id,
@@ -51,9 +50,9 @@ abstract class SummaryResponse
     protected function assignToCache(
         array $summary,
         array $collection,
-        Cache\Control $cache_control,
-        Cache\Summary $cache_summary
-    ): Cache\Summary
+        \App\Cache\Control $cache_control,
+        \App\Cache\Summary $cache_summary
+    ): \App\Cache\Summary
     {
         $headers = new Headers();
 
@@ -100,13 +99,13 @@ abstract class SummaryResponse
 
     protected function setUpCache(): void
     {
-        $this->cache_control = new Cache\Control(
+        $this->cache_control = new \App\Cache\Control(
             $this->permitted_user,
             $this->user_id
         );
         $this->cache_control->setTtlOneWeek();
 
-        $this->cache_summary = new Cache\Summary();
+        $this->cache_summary = new \App\Cache\Summary();
         $this->cache_summary->setFromCache($this->cache_control->getByKey(request()->getRequestUri()));
     }
 }

--- a/app/Jobs/ClearCache.php
+++ b/app/Jobs/ClearCache.php
@@ -2,12 +2,12 @@
 
 namespace App\Jobs;
 
-use App\Models\ResourceType;
+use App\Cache\Control;
+use App\Cache\Job;
+use App\Cache\KeyGroup;
+use App\Cache\Trash;
 use App\Models\ResourceAccess;
-use App\Response\Cache\Control;
-use App\Response\Cache\Job;
-use App\Response\Cache\KeyGroup;
-use App\Response\Cache\Trash;
+use App\Models\ResourceType;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;

--- a/app/Request/BodyValidation.php
+++ b/app/Request/BodyValidation.php
@@ -28,7 +28,7 @@ class BodyValidation
      *
      * @return JsonResponse|null
      */
-    public static function checkForInvalidFields(array $patchable_fields): ?JsonResponse
+    public static function checkForInvalidFields(array $patchable_fields): array
     {
         $invalid_fields = [];
         foreach (request()->all() as $key => $value) {
@@ -37,11 +37,12 @@ class BodyValidation
             }
         }
 
-        if (count($invalid_fields) !== 0) {
-            return \App\Response\Responses::invalidFieldsInRequest($invalid_fields);
-        }
+        return $invalid_fields;
+    }
 
-        return null;
+    public static function returnInvalidFieldsInRequest(array $invalid_fields)
+    {
+        return \App\Response\Responses::invalidFieldsInRequest($invalid_fields);
     }
 
     public static function returnValidationErrors( // Rename this

--- a/app/Request/BodyValidation.php
+++ b/app/Request/BodyValidation.php
@@ -44,21 +44,6 @@ class BodyValidation
         return null;
     }
 
-    /**
-     * Check the request to see if there are any fields in the request, if not
-     * we simply throw an error
-     *
-     * @return JsonResponse|null
-     */
-    public static function checkForEmptyPatch(): ?JsonResponse
-    {
-        if (count(request()->all()) === 0) {
-            return \App\Response\Responses::nothingToPatch();
-        }
-
-        return null;
-    }
-
     public static function returnValidationErrors( // Rename this
         Validator $validator,
         array $allowed_values = []

--- a/app/Response/Responses.php
+++ b/app/Response/Responses.php
@@ -373,11 +373,10 @@ class Responses
             $response = self::addException($response, $e);
         }
 
-        response()->json(
+        return response()->json(
             $response,
             400
-        )->send();
-        exit();
+        );
     }
 
     /**

--- a/app/Response/Responses.php
+++ b/app/Response/Responses.php
@@ -184,11 +184,10 @@ class Responses
             $response = self::addException($response, $e);
         }
 
-        response()->json(
+        return response()->json(
             $response,
             403
-        )->send();
-        exit();
+        );
     }
 
     public static function categoryAssignmentLimit(int $limit, ?Exception $e = null): JsonResponse
@@ -349,11 +348,10 @@ class Responses
             $response = self::addException($response, $e);
         }
 
-        response()->json(
+        return response()->json(
             $response,
             400
-        )->send();
-        exit();
+        );
     }
 
     /**

--- a/app/Response/Responses.php
+++ b/app/Response/Responses.php
@@ -290,8 +290,7 @@ class Responses
             $response = self::addException($response, $e);
         }
 
-        response()->json($response,204)->send();
-        exit;
+        return response()->json($response,204);
     }
 
     public static function subcategoryAssignmentLimit(int $limit, ?Exception $e = null): JsonResponse

--- a/app/Rules/ResourceTypeName.php
+++ b/app/Rules/ResourceTypeName.php
@@ -46,12 +46,12 @@ class ResourceTypeName implements Rule
             ];
         }
 
-        $exists = DB::table('resource_type')->
-            join('permitted_user', 'resource_type.id', '=', 'permitted_user.resource_type_id')->
-            where($where_clauses)->
-            get();
+        $count = DB::table('resource_type')
+            ->join('permitted_user', 'resource_type.id', '=', 'permitted_user.resource_type_id')
+            ->where($where_clauses)
+            ->count();
 
-        return count($exists) === 0;
+        return $count === 0;
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -2,10 +2,14 @@
 
 namespace App;
 
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Laravel\Sanctum\HasApiTokens;
 
+/**
+ * @mixin QueryBuilder
+ */
 class User extends Authenticatable
 {
     use HasApiTokens, Notifiable;

--- a/config/api/app/cache.php
+++ b/config/api/app/cache.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 return [
-    'enable' => true,
+    'enable' => env('APP_CACHE', true),
     'ttl' => 31536000,
     'public_key_prefix' => '-p-'
 ];

--- a/config/api/app/version.php
+++ b/config/api/app/version.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 return [
-    'version'=> 'v2.19.0',
+    'version'=> 'v2.19.1',
     'prefix' => 'v2',
-    'release_date' => '2021-02-08',
+    'release_date' => '2021-02-12',
     'changelog' => [
         'api' => '/v2/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </coverage>
     <php>
         <server name="APP_ENV" value="testing"/>
+        <server name="APP_CACHE" value="false"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
         <server name="DB_CONNECTION" value="mysql"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,7 @@
     <php>
         <server name="APP_ENV" value="testing"/>
         <server name="APP_CACHE" value="false"/>
+        <server name="APP_DEBUG" value="true"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
         <server name="DB_CONNECTION" value="mysql"/>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -225,17 +225,25 @@
                     <h3>Added</h3>
 
                     <ul>
-                        <li>We have opened up registration on the API; you can register, login, and use all the expected authentication features.</li>
-                        <li>We have added notification emails for registration and forgot password requests.</li>
+                        <li>We have added additional `resource-type` tests.</li>
+                        <li>We have started work on `resource` tests.</li>
                     </ul>
 
                     <h3>Changed</h3>
 
                     <ul>
-                        <li>We have switched to Laravel Sanctum and removed all references to Laravel Passport, Sanctum makes more sense for our API.</li>
-                        <li>We have updated to Laravel version 8.</li>
-                        <li>We have tweaked our Docker setup and removed composer and phpunit.</li>
-                        <li>Content updates.</li>
+                        <li>The cache setting for the API can now be set in `.env`.</li>
+                        <li>We have updated phpunit.xml; the local cache will be disabled for tests.</li>
+                        <li>We have updated our Docker setup; we have switched from MySQL 5.7 to 8.0 and PHP 7.4 to PHP 8.0.</li>
+                        <li>We have moved our Cache classes into `App\Cache`.</li>
+                        <li>We have updated our `ConvertRouteParameters` middleware; our middleware now returns a 404 for invalid route parameters.</li>
+                    </ul>
+
+                    <h3>Fixed</h3>
+
+                    <ul>
+                        <li>We have updated some of our responses; the response no longer call `exit()` and are therefore testable.</li>
+                        <li>We have fixed our `ResourceTypeName` validator; our validator will no longer allow duplicate names.</li>
                     </ul>
                 </div>
             </div>

--- a/routes/api/private-routes.php
+++ b/routes/api/private-routes.php
@@ -35,7 +35,7 @@ Route::group(
         Route::post(
             'resource-types/{resource_type_id}/resources',
             'ResourceManage@create'
-        );
+        )->name('resource.create');
 
         Route::post(
             'resource-types/{resource_type_id}/resources/{resource_id}/items',

--- a/routes/api/private-routes.php
+++ b/routes/api/private-routes.php
@@ -105,7 +105,7 @@ Route::group(
         Route::patch(
             'resource-types/{resource_type_id}',
             'ResourceTypeManage@update'
-        );
+        )->name('resource-type.update');
 
         Route::patch(
             'resource-types/{resource_type_id}/categories/{category_id}',

--- a/routes/api/private-routes.php
+++ b/routes/api/private-routes.php
@@ -65,7 +65,7 @@ Route::group(
         Route::delete(
             'resource-types/{resource_type_id}',
             'ResourceTypeManage@delete'
-        );
+        )->name('resource-type.delete');
 
         Route::delete(
             'resource-types/{resource_type_id}/categories/{category_id}',

--- a/routes/api/public-routes.php
+++ b/routes/api/public-routes.php
@@ -121,7 +121,7 @@ Route::group(
         Route::options(
             'resource-types',
             'ResourceTypeView@optionsIndex'
-        );
+        )->name('resource-type.list');
 
         Route::get(
             'resource-types/{resource_type_id}',

--- a/tests/Feature/Http/Controllers/ResourceManageTest.php
+++ b/tests/Feature/Http/Controllers/ResourceManageTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\User;
+use Tests\TestCase;
+
+class ResourceManageTest extends TestCase
+{
+    /** @test */
+    public function create_resource_success(): void
+    {
+        $this->actingAs(User::find(1));
+
+        $response = $this->postResourceType(
+            [
+                'name' => $this->faker->text(255),
+                'description' => $this->faker->text,
+                'item_type_id' => 'OqZwKX16bW',
+                'public' => false
+            ]
+        );
+
+        $response->assertStatus(201);
+        $id = $response->json('id');
+
+        $response = $this->postResource(
+            $id,
+            [
+                'name' => $this->faker->text(200),
+                'description' => $this->faker->text(200),
+                'effective_date' => '2002-01-01',
+                'item_subtype_id' => 'a56kbWV82n'
+            ]
+        );
+
+        $response->assertStatus(201);
+    }
+}

--- a/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
+++ b/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
@@ -70,6 +70,40 @@ class ResourceTypeManageTest extends TestCase
     }
 
     /** @test */
+    public function create_resource_type_fails_non_unique_name(): void
+    {
+        $this->actingAs(User::find(1));
+
+        $name = $this->faker->text(10);
+
+        $response = $this->post(
+            route('resource-type.create'),
+            [
+                'name' => $name,
+                'description' => $this->faker->text,
+                'item_type_id' => 'OqZwKX16bW',
+                'public' => false
+            ]
+        );
+
+        $response->assertStatus(201);
+        $this->assertJsonIsResourceType($response->content());
+
+        // Create the second with the same name
+        $response = $this->post(
+            route('resource-type.create'),
+            [
+                'name' => $name,
+                'description' => $this->faker->text,
+                'item_type_id' => 'OqZwKX16bW',
+                'public' => false
+            ]
+        );
+
+        $response->assertStatus(422);
+    }
+
+    /** @test */
     public function create_resource_type_fails_not_signed_in(): void
     {
         $response = $this->post(
@@ -156,5 +190,83 @@ class ResourceTypeManageTest extends TestCase
         );
 
         $response->assertStatus(400);
+    }
+
+    /** @test */
+    public function update_resource_type_fails_non_unique_name(): void
+    {
+        $this->actingAs(User::find(1));
+
+        $name = $this->faker->text(15);
+
+        // Create the first resource type
+        $response = $this->post(
+            route('resource-type.create'),
+            [
+                'name' => $name,
+                'description' => $this->faker->text(255),
+                'item_type_id' => 'OqZwKX16bW',
+                'public' => false
+            ]
+        );
+
+        $response->assertStatus(201);
+        $this->assertJsonIsResourceType($response->content());
+
+        // Create the second resource type
+        $response = $this->post(
+            route('resource-type.create'),
+            [
+                'name' => $this->faker->text(15),
+                'description' => $this->faker->text(255),
+                'item_type_id' => 'OqZwKX16bW',
+                'public' => false
+            ]
+        );
+
+        $response->assertStatus(201);
+        $this->assertJsonIsResourceType($response->content());
+
+        $id = $response->json('id');
+
+        // Update with same name as the first
+        $response = $this->patch(
+            route('resource-type.update', ['resource_type_id' => $id]),
+            [
+                'name' => $name
+            ]
+        );
+
+        $response->assertStatus(422);
+    }
+
+    /** @test */
+    public function update_resource_type_success(): void
+    {
+        $this->actingAs(User::find(1));
+
+        $response = $this->post(
+            route('resource-type.create'),
+            [
+                'name' => $this->faker->text(255),
+                'description' => $this->faker->text,
+                'item_type_id' => 'OqZwKX16bW',
+                'public' => false
+            ]
+        );
+
+        $response->assertStatus(201);
+        $this->assertJsonIsResourceType($response->content());
+
+        $id = $response->json('id');
+
+        $response = $this->patch(
+            route('resource-type.update', ['resource_type_id' => $id]),
+            [
+                'name' => $this->faker->text(100)
+            ]
+        );
+
+        $response->assertStatus(204);
     }
 }

--- a/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
+++ b/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
@@ -8,6 +8,55 @@ use Tests\TestCase;
 class ResourceTypeManageTest extends TestCase
 {
     /** @test */
+    public function create_resource_type_fails_item_type_invalid(): void
+    {
+        $this->actingAs(User::find(1));
+
+        $response = $this->post(
+            route('resource-type.create'),
+            [
+                'name' => $this->faker->text(200),
+                'description' => $this->faker->text(200),
+                'item_type_id' => 'OqZwKX16bg'
+            ]
+        );
+
+        $response->assertStatus(422);
+    }
+
+    /** @test */
+    public function create_resource_type_fails_no_description_in_payload(): void
+    {
+        $this->actingAs(User::find(1));
+
+        $response = $this->post(
+            route('resource-type.create'),
+            [
+                'name' => $this->faker->text(200),
+                'item_type_id' => 'OqZwKX16bW'
+            ]
+        );
+
+        $response->assertStatus(422);
+    }
+
+    /** @test */
+    public function create_resource_type_fails_no_name_in_payload(): void
+    {
+        $this->actingAs(User::find(1));
+
+        $response = $this->post(
+            route('resource-type.create'),
+            [
+                'description' => $this->faker->text(200),
+                'item_type_id' => 'OqZwKX16bW'
+            ]
+        );
+
+        $response->assertStatus(422);
+    }
+
+    /** @test */
     public function create_resource_type_fails_no_payload(): void
     {
         $this->actingAs(User::find(1));
@@ -48,5 +97,34 @@ class ResourceTypeManageTest extends TestCase
 
         $response->assertStatus(201);
         $this->assertJsonIsResourceType($response->content());
+    }
+
+    /** @test */
+    public function update_resource_type_fails_no_payload(): void
+    {
+        $this->actingAs(User::find(1));
+
+        $response = $this->post(
+            route('resource-type.create'),
+            [
+                'name' => $this->faker->text(255),
+                'description' => $this->faker->text,
+                'item_type_id' => 'OqZwKX16bW',
+                'public' => false
+            ]
+        );
+
+        $response->assertStatus(201);
+        $this->assertJsonIsResourceType($response->content());
+
+        $id = $response->json('id');
+
+        $response = $this->patch(
+            route('resource-type.update', ['resource_type_id' => $id]),
+            [
+            ]
+        );
+
+        $response->assertStatus(400);
     }
 }

--- a/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
+++ b/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
@@ -134,6 +134,34 @@ class ResourceTypeManageTest extends TestCase
     }
 
     /** @test */
+    public function delete_resource_type_success(): void
+    {
+        $this->actingAs(User::find(1));
+
+        $response = $this->post(
+            route('resource-type.create'),
+            [
+                'name' => $this->faker->text(255),
+                'description' => $this->faker->text,
+                'item_type_id' => 'OqZwKX16bW',
+                'public' => false
+            ]
+        );
+
+        $response->assertStatus(201);
+        $this->assertJsonIsResourceType($response->content());
+
+        $id = $response->json('id');
+
+        $response = $this->delete(
+            route('resource-type.delete', ['resource_type_id' => $id]),
+            []
+        );
+
+        $response->assertStatus(204);
+    }
+
+    /** @test */
     public function update_resource_type_fails_extra_fields_in_payload(): void
     {
         $this->actingAs(User::find(1));

--- a/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
+++ b/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
@@ -12,8 +12,7 @@ class ResourceTypeManageTest extends TestCase
     {
         $this->actingAs(User::find(1));
 
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'name' => $this->faker->text(200),
                 'description' => $this->faker->text(200),
@@ -29,8 +28,7 @@ class ResourceTypeManageTest extends TestCase
     {
         $this->actingAs(User::find(1));
 
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'name' => $this->faker->text(200),
                 'item_type_id' => 'OqZwKX16bW'
@@ -45,8 +43,7 @@ class ResourceTypeManageTest extends TestCase
     {
         $this->actingAs(User::find(1));
 
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'description' => $this->faker->text(200),
                 'item_type_id' => 'OqZwKX16bW'
@@ -61,8 +58,7 @@ class ResourceTypeManageTest extends TestCase
     {
         $this->actingAs(User::find(1));
 
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             []
         );
 
@@ -76,8 +72,7 @@ class ResourceTypeManageTest extends TestCase
 
         $name = $this->faker->text(10);
 
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'name' => $name,
                 'description' => $this->faker->text,
@@ -90,8 +85,7 @@ class ResourceTypeManageTest extends TestCase
         $this->assertJsonIsResourceType($response->content());
 
         // Create the second with the same name
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'name' => $name,
                 'description' => $this->faker->text,
@@ -106,8 +100,7 @@ class ResourceTypeManageTest extends TestCase
     /** @test */
     public function create_resource_type_fails_not_signed_in(): void
     {
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             []
         );
 
@@ -119,8 +112,7 @@ class ResourceTypeManageTest extends TestCase
     {
         $this->actingAs(User::find(1));
 
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'name' => $this->faker->text(255),
                 'description' => $this->faker->text,
@@ -138,8 +130,7 @@ class ResourceTypeManageTest extends TestCase
     {
         $this->actingAs(User::find(1));
 
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'name' => $this->faker->text(255),
                 'description' => $this->faker->text,
@@ -153,10 +144,7 @@ class ResourceTypeManageTest extends TestCase
 
         $id = $response->json('id');
 
-        $response = $this->delete(
-            route('resource-type.delete', ['resource_type_id' => $id]),
-            []
-        );
+        $response = $this->deleteResourceType($id);
 
         $response->assertStatus(204);
     }
@@ -166,8 +154,7 @@ class ResourceTypeManageTest extends TestCase
     {
         $this->actingAs(User::find(1));
 
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'name' => $this->faker->text(255),
                 'description' => $this->faker->text,
@@ -181,8 +168,8 @@ class ResourceTypeManageTest extends TestCase
 
         $id = $response->json('id');
 
-        $response = $this->patch(
-            route('resource-type.update', ['resource_type_id' => $id]),
+        $response = $this->patchResourceType(
+            $id,
             [
                 'extra' => $this->faker->text(100)
             ]
@@ -196,8 +183,7 @@ class ResourceTypeManageTest extends TestCase
     {
         $this->actingAs(User::find(1));
 
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'name' => $this->faker->text(255),
                 'description' => $this->faker->text,
@@ -211,10 +197,9 @@ class ResourceTypeManageTest extends TestCase
 
         $id = $response->json('id');
 
-        $response = $this->patch(
-            route('resource-type.update', ['resource_type_id' => $id]),
-            [
-            ]
+        $response = $this->patchResourceType(
+            $id,
+            []
         );
 
         $response->assertStatus(400);
@@ -228,8 +213,7 @@ class ResourceTypeManageTest extends TestCase
         $name = $this->faker->text(15);
 
         // Create the first resource type
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'name' => $name,
                 'description' => $this->faker->text(255),
@@ -242,8 +226,7 @@ class ResourceTypeManageTest extends TestCase
         $this->assertJsonIsResourceType($response->content());
 
         // Create the second resource type
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'name' => $this->faker->text(15),
                 'description' => $this->faker->text(255),
@@ -258,8 +241,8 @@ class ResourceTypeManageTest extends TestCase
         $id = $response->json('id');
 
         // Update with same name as the first
-        $response = $this->patch(
-            route('resource-type.update', ['resource_type_id' => $id]),
+        $response = $this->patchResourceType(
+            $id,
             [
                 'name' => $name
             ]
@@ -273,8 +256,7 @@ class ResourceTypeManageTest extends TestCase
     {
         $this->actingAs(User::find(1));
 
-        $response = $this->post(
-            route('resource-type.create'),
+        $response = $this->postResourceType(
             [
                 'name' => $this->faker->text(255),
                 'description' => $this->faker->text,
@@ -288,8 +270,8 @@ class ResourceTypeManageTest extends TestCase
 
         $id = $response->json('id');
 
-        $response = $this->patch(
-            route('resource-type.update', ['resource_type_id' => $id]),
+        $response = $this->patchResourceType(
+            $id,
             [
                 'name' => $this->faker->text(100)
             ]

--- a/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
+++ b/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
@@ -100,6 +100,36 @@ class ResourceTypeManageTest extends TestCase
     }
 
     /** @test */
+    public function update_resource_type_fails_extra_fields_in_payload(): void
+    {
+        $this->actingAs(User::find(1));
+
+        $response = $this->post(
+            route('resource-type.create'),
+            [
+                'name' => $this->faker->text(255),
+                'description' => $this->faker->text,
+                'item_type_id' => 'OqZwKX16bW',
+                'public' => false
+            ]
+        );
+
+        $response->assertStatus(201);
+        $this->assertJsonIsResourceType($response->content());
+
+        $id = $response->json('id');
+
+        $response = $this->patch(
+            route('resource-type.update', ['resource_type_id' => $id]),
+            [
+                'extra' => $this->faker->text(100)
+            ]
+        );
+
+        $response->assertStatus(400);
+    }
+
+    /** @test */
     public function update_resource_type_fails_no_payload(): void
     {
         $this->actingAs(User::find(1));

--- a/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
+++ b/tests/Feature/Http/Controllers/ResourceTypeManageTest.php
@@ -21,6 +21,17 @@ class ResourceTypeManageTest extends TestCase
     }
 
     /** @test */
+    public function create_resource_type_fails_not_signed_in(): void
+    {
+        $response = $this->post(
+            route('resource-type.create'),
+            []
+        );
+
+        $response->assertStatus(403);
+    }
+
+    /** @test */
     public function create_resource_type_success(): void
     {
         $this->actingAs(User::find(1));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Testing\TestResponse;
 use Opis\JsonSchema\Schema;
 use Opis\JsonSchema\Validator;
 
@@ -46,5 +47,25 @@ abstract class TestCase extends BaseTestCase
 
         $result = $validator->schemaValidation(json_decode($content), $schema);
         self::assertTrue($result->isValid());
+    }
+
+    protected function deleteResourceType(string $resource_type_id): TestResponse
+    {
+        return $this->delete(
+            route('resource-type.update', ['resource_type_id' => $resource_type_id]), []
+        );
+    }
+
+    protected function patchResourceType(string $resource_type_id, array $payload): TestResponse
+    {
+        return $this->patch(
+            route('resource-type.update', ['resource_type_id' => $resource_type_id]),
+            $payload
+        );
+    }
+
+    protected function postResourceType(array $payload): TestResponse
+    {
+        return $this->post(route('resource-type.create'), $payload);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -64,6 +64,14 @@ abstract class TestCase extends BaseTestCase
         );
     }
 
+    protected function postResource(string $resource_type_id, array $payload): TestResponse
+    {
+        return $this->post(
+            route('resource.create', ['resource_type_id' => $resource_type_id]),
+            $payload
+        );
+    }
+
     protected function postResourceType(array $payload): TestResponse
     {
         return $this->post(route('resource-type.create'), $payload);


### PR DESCRIPTION
### Added
- We have added additional `resource-type` tests.
- We have started work on `resource` tests.

### Changed
- The cache setting for the API can now be set in `.env`.
- We have updated phpunit.xml; the local cache will be disabled for tests.
- We have updated our Docker setup; we have switched from MySQL 5.7 to 8.0 and PHP 7.4 to PHP 8.0.
- We have moved our Cache classes into `App\Cache`.
- We have updated our `ConvertRouteParameters` middleware; our middleware now returns a 404 for invalid route parameters.

### Fixed
- We have updated some of our responses; the response no longer call `exit()` and are therefore testable.
- We have fixed our `ResourceTypeName` validator; our validator will no longer allow duplicate names.