### PR TITLE
v3.05.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The complete changelog for the Costs to Expect REST API, our changelog follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v3.05.1] - 2022-10-06
+### Fixed
+- Config file referencing the incorrect language file.
+- `target_account` is not a required field for the "budget" item type.
+- `amount` and `name` should be sorting options for the "budget" item type collection.
+- `description` and `end_date` are nullable fields for the "budget" item type.
+- `name` should be a sortable field for the "budget" item type.
+
 ## [v3.05.0] - 2022-09-11
 ### Added
 - Added full support for the `budget` item type, all endpoints.

--- a/app/ItemType/Budget/Models/Item.php
+++ b/app/ItemType/Budget/Models/Item.php
@@ -206,11 +206,11 @@ class Item extends LaravelModel
             foreach ($sort_parameters as $field => $direction) {
                 switch ($field) {
                     case 'created':
-                        $collection->orderBy('item.created_at', $direction);
+                        $collection->orderBy($this->table . '.created_at', $direction);
                         break;
 
                     default:
-                        $collection->orderBy('item.' . $field, $direction);
+                        $collection->orderBy($this->table . '.' . $field, $direction);
                         break;
                 }
             }

--- a/config/api/app/version.php
+++ b/config/api/app/version.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 return [
-    'version'=> 'v3.05.0',
+    'version'=> 'v3.05.1',
     'prefix' => 'v3',
-    'release_date' => '2022-09-11',
+    'release_date' => '2022-10-06',
     'changelog' => [
         'api' => '/v3/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'

--- a/config/api/item-type-budget/fields-post.php
+++ b/config/api/item-type-budget/fields-post.php
@@ -31,7 +31,7 @@ return [
         'validation' => [
             'max-length' => 255
         ],
-        'required' => true
+        'required' => false
     ],
     'description' => [
         'field' => 'description',

--- a/config/api/item-type-budget/searchable.php
+++ b/config/api/item-type-budget/searchable.php
@@ -2,4 +2,8 @@
 
 declare(strict_types=1);
 
-return [];
+return [
+    'name' => [
+        'type' => 'string'
+    ],
+];

--- a/config/api/item-type-budget/sortable.php
+++ b/config/api/item-type-budget/sortable.php
@@ -3,5 +3,7 @@
 declare(strict_types=1);
 
 return [
-    'created'
+    'created',
+    'amount',
+    'name'
 ];

--- a/config/api/item-type-budget/validation-post.php
+++ b/config/api/item-type-budget/validation-post.php
@@ -19,11 +19,13 @@ return [
         'target_account' => [
             'sometimes',
             'string',
-            'max:255'
+            'max:255',
+            'nullable'
         ],
         'description' => [
             'sometimes',
-            'string'
+            'string',
+            'nullable'
         ],
         'amount' => [
             'required',
@@ -46,7 +48,8 @@ return [
         ],
         'end_date' => [
             'sometimes',
-            'date_format:Y-m-d'
+            'date_format:Y-m-d',
+            'nullable'
         ],
         'disabled' => [
             'sometimes',

--- a/config/api/resource-type/parameters-show.php
+++ b/config/api/resource-type/parameters-show.php
@@ -6,14 +6,14 @@ return [
     'include-resources' => [
         'field' => 'include-resources',
         'title' => 'resource-type/parameters-show.title-include-resources',
-        'description' => 'resource-type/parameters.description-include-resources',
+        'description' => 'resource-type/parameters-show.description-include-resources',
         'type' => 'boolean',
         'required' => false
     ],
     'include-permitted-users' => [
         'field' => 'include-permitted-users',
         'title' => 'resource-type/parameters-show.title-include-permitted-users',
-        'description' => 'resource-type/parameters.description-include-permitted-users',
+        'description' => 'resource-type/parameters-show.description-include-permitted-users',
         'type' => 'boolean',
         'required' => false
     ]


### PR DESCRIPTION
### Fixed
- Config file referencing the incorrect language file.
- `target_account` is not a required field for the "budget" item type.
- `amount` and `name` should be sorting options for the "budget" item type collection.
- `description` and `end_date` are nullable fields for the "budget" item type.
- `name` should be a sortable field for the "budget" item type.