### PR TITLE
Delete budget pro resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 The complete changelog for the Costs to Expect REST API, our changelog follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v3.11.1] - 2023-06-13
+### Fixed
+- The account deleting jobs are now all aware of the 'budget-pro' item type.
+- Added missing "not supported" responses for the 'budget-pro' item type.
+
 ## [v3.11.0] - 2023-05-26
 ### Added
 - Added support for the 'budget-pro' item type. For now the 'budget-pro' item type is a duplicate of the 'budget' item type but that will change in the future.

--- a/app/Http/Controllers/View/ItemDataController.php
+++ b/app/Http/Controllers/View/ItemDataController.php
@@ -35,7 +35,7 @@ class ItemDataController extends Controller
         $item_type = Select::itemType((int) $resource_type_id);
 
         return match ($item_type) {
-            'allocated-expense', 'budget' => Response::notSupported(),
+            'allocated-expense', 'budget', 'budget-pro' => Response::notSupported(),
             'game' => $this->gameCollection((int) $resource_type_id, (int) $resource_id, (int) $item_id),
             default => throw new \OutOfRangeException('No item type definition for ' . $item_type, 500),
         };
@@ -55,7 +55,7 @@ class ItemDataController extends Controller
         $item_type = Select::itemType((int) $resource_type_id);
 
         return match ($item_type) {
-            'allocated-expense', 'budget' => Response::notSupported(),
+            'allocated-expense', 'budget', 'budget-pro' => Response::notSupported(),
             'game' => $this->gameOptionsIndex((int) $resource_type_id, (int) $resource_id, (int) $item_id),
             default => throw new \OutOfRangeException('No item type definition for ' . $item_type, 500),
         };
@@ -76,7 +76,7 @@ class ItemDataController extends Controller
         $item_type = Select::itemType((int) $resource_type_id);
 
         return match ($item_type) {
-            'allocated-expense', 'budget' => Response::notSupported(),
+            'allocated-expense', 'budget', 'budget-pro' => Response::notSupported(),
             'game' => $this->gameOptionsShow((int) $resource_type_id, (int) $resource_id, (int) $item_id, $key),
             default => throw new \OutOfRangeException('No item type definition for ' . $item_type, 500),
         };
@@ -95,7 +95,7 @@ class ItemDataController extends Controller
         $item_type = Select::itemType((int) $resource_type_id);
 
         return match ($item_type) {
-            'allocated-expense', 'budget' => Response::notSupported(),
+            'allocated-expense', 'budget', 'budget-pro' => Response::notSupported(),
             'game' => $this->gameShow((int) $resource_type_id, (int) $resource_id, (int) $item_id, $key),
             default => throw new \OutOfRangeException('No item type definition for ' . $item_type, 500),
         };

--- a/app/Http/Controllers/View/ItemLogController.php
+++ b/app/Http/Controllers/View/ItemLogController.php
@@ -37,7 +37,7 @@ class ItemLogController extends Controller
         $item_type = Select::itemType((int)$resource_type_id);
 
         return match ($item_type) {
-            'allocated-expense', 'budget' => Response::notSupported(),
+            'allocated-expense', 'budget', 'budget-pro' => Response::notSupported(),
             'game' => $this->gameCollection((int) $resource_type_id, (int) $resource_id, (int) $item_id),
             default => throw new OutOfRangeException('No item type definition for ' . $item_type, 500),
         };
@@ -97,7 +97,7 @@ class ItemLogController extends Controller
         $item_type = Select::itemType((int)$resource_type_id);
 
         return match ($item_type) {
-            'allocated-expense', 'budget' => Response::notSupported(),
+            'allocated-expense', 'budget', 'budget-pro' => Response::notSupported(),
             'game' => $this->gameOptionsIndex((int) $resource_type_id, (int) $resource_id, (int) $item_id),
             default => throw new OutOfRangeException('No item type definition for ' . $item_type, 500),
         };
@@ -180,7 +180,7 @@ class ItemLogController extends Controller
         $item_type = Select::itemType((int)$resource_type_id);
 
         return match ($item_type) {
-            'allocated-expense', 'budget' => Response::notSupported(),
+            'allocated-expense', 'budget', 'budget-pro' => Response::notSupported(),
             'game' => $this->gameShow((int) $resource_type_id, (int) $resource_id, (int) $item_id, (int) $item_log_id),
             default => throw new OutOfRangeException('No item type definition for ' . $item_type, 500),
         };

--- a/app/Jobs/DeleteAccount.php
+++ b/app/Jobs/DeleteAccount.php
@@ -137,6 +137,18 @@ class DeleteAccount implements ShouldQueue
         ', [$resource_id]);
     }
 
+    protected function deleteBudgetProItems(int $resource_id): int
+    {
+        return DB::delete('
+            DELETE FROM
+                `item_type_budget_pro`
+            WHERE
+                `item_type_budget_pro`.`item_id` IN (
+                SELECT `item`.`id` FROM `item` WHERE `item`.`resource_id` = ?
+            )
+        ', [$resource_id]);
+    }
+
     protected function deleteCategories(int $resource_type_id): int
     {
         return DB::delete('
@@ -228,6 +240,7 @@ class DeleteAccount implements ShouldQueue
         return match ($item_type) {
             'allocated-expense' => $this->deleteAllocatedExpenseItems($resource_id),
             'budget' => $this->deleteBudgetItems($resource_id),
+            'budget-pro' => $this->deleteBudgetProItems($resource_id),
             'game' => $this->deleteGameItems($resource_id),
             default => throw new \OutOfRangeException('No item type definition for ' . $item_type, 500),
         };

--- a/app/Jobs/DeleteResource.php
+++ b/app/Jobs/DeleteResource.php
@@ -129,6 +129,18 @@ class DeleteResource implements ShouldQueue
         ', [$resource_id]);
     }
 
+    protected function deleteBudgetProItems(int $resource_id): int
+    {
+        return DB::delete('
+            DELETE FROM
+                `item_type_budget_pro`
+            WHERE
+                `item_type_budget_pro`.`item_id` IN (
+                SELECT `item`.`id` FROM `item` WHERE `item`.`resource_id` = ?
+            )
+        ', [$resource_id]);
+    }
+
     protected function deleteGameItems(int $resource_id): int
     {
         return DB::delete('
@@ -210,6 +222,7 @@ class DeleteResource implements ShouldQueue
         return match ($item_type) {
             'allocated-expense' => $this->deleteAllocatedExpenseItems($resource_id),
             'budget' => $this->deleteBudgetItems($resource_id),
+            'budget-pro' => $this->deleteBudgetProItems($resource_id),
             'game' => $this->deleteGameItems($resource_id),
             default => throw new \OutOfRangeException('No item type definition for ' . $item_type, 500),
         };

--- a/app/Jobs/DeleteResourceType.php
+++ b/app/Jobs/DeleteResourceType.php
@@ -129,6 +129,18 @@ class DeleteResourceType implements ShouldQueue
         ', [$resource_id]);
     }
 
+    protected function deleteBudgetProItems(int $resource_id): int
+    {
+        return DB::delete('
+            DELETE FROM
+                `item_type_budget_pro`
+            WHERE
+                `item_type_budget_pro`.`item_id` IN (
+                SELECT `item`.`id` FROM `item` WHERE `item`.`resource_id` = ?
+            )
+        ', [$resource_id]);
+    }
+
     protected function deleteCategories(int $resource_type_id): int
     {
         return DB::delete('
@@ -220,6 +232,7 @@ class DeleteResourceType implements ShouldQueue
         return match ($item_type) {
             'allocated-expense' => $this->deleteAllocatedExpenseItems($resource_id),
             'budget' => $this->deleteBudgetItems($resource_id),
+            'budget-pro' => $this->deleteBudgetProItems($resource_id),
             'game' => $this->deleteGameItems($resource_id),
             default => throw new \OutOfRangeException('No item type definition for ' . $item_type, 500),
         };

--- a/config/api/app/version.php
+++ b/config/api/app/version.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 return [
-    'version'=> 'v3.11.0',
+    'version'=> 'v3.11.1',
     'prefix' => 'v3',
-    'release_date' => '2023-05-29',
+    'release_date' => '2023-06-13',
     'changelog' => [
         'api' => '/v3/changelog',
         'markdown' => 'https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md'


### PR DESCRIPTION
### Fixed
- The account deleting jobs are now all aware of the 'budget-pro' item type.
- Added missing "not supported" responses for the 'budget-pro' item type.